### PR TITLE
MYST-181 Use proposals endpoint instead of create-session

### DIFF
--- a/bytescount_client/middleware.go
+++ b/bytescount_client/middleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/mysterium/node/openvpn"
 	"github.com/mysterium/node/server"
 	"github.com/mysterium/node/server/dto"
+	"github.com/mysterium/node/session"
 	"net"
 	"regexp"
 	"strconv"
@@ -14,12 +15,12 @@ import (
 type middleware struct {
 	mysteriumClient server.Client
 	interval        time.Duration
-	sessionId       string
+	sessionId       session.SessionId
 
 	connection net.Conn
 }
 
-func NewMiddleware(mysteriumClient server.Client, sessionId string, interval time.Duration) openvpn.ManagementMiddleware {
+func NewMiddleware(mysteriumClient server.Client, sessionId session.SessionId, interval time.Duration) openvpn.ManagementMiddleware {
 	return &middleware{
 		mysteriumClient: mysteriumClient,
 		interval:        interval,
@@ -65,8 +66,8 @@ func (middleware *middleware) ConsumeLine(line string) (consumed bool, err error
 		return
 	}
 
-	err = middleware.mysteriumClient.SessionSendStats(middleware.sessionId, dto.SessionStats{
-		Id:            middleware.sessionId,
+	err = middleware.mysteriumClient.SessionSendStats(string(middleware.sessionId), dto.SessionStats{
+		Id:            string(middleware.sessionId),
 		BytesSent:     bytesOut,
 		BytesReceived: bytesIn,
 	})

--- a/client_connection/interface.go
+++ b/client_connection/interface.go
@@ -2,6 +2,7 @@ package client_connection
 
 import (
 	"github.com/mysterium/node/identity"
+	"github.com/mysterium/node/session"
 )
 
 type State string
@@ -14,7 +15,7 @@ const (
 
 type ConnectionStatus struct {
 	State     State
-	SessionId string
+	SessionId session.SessionId
 	LastError error
 }
 

--- a/client_connection/manager.go
+++ b/client_connection/manager.go
@@ -42,7 +42,7 @@ func NewManager(mysteriumClient server.Client, dialogEstablisherFactory DialogEs
 func (manager *connectionManager) Connect(identity identity.Identity, nodeKey string) error {
 	manager.status = statusConnecting()
 
-	proposals, err := manager.mysteriumClient.Proposals(nodeKey)
+	proposals, err := manager.mysteriumClient.FindProposals(nodeKey)
 	if err != nil {
 		manager.status = statusError(err)
 		return err

--- a/client_connection/manager_test.go
+++ b/client_connection/manager_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mysterium/node/openvpn/service_discovery"
 	"github.com/mysterium/node/openvpn/session"
 	"github.com/mysterium/node/server"
-	mysterium_api_client "github.com/mysterium/node/server/dto"
 	"github.com/mysterium/node/service_discovery/dto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -35,7 +34,7 @@ func (tc *test_context) SetupTest() {
 	}
 
 	tc.fakeOpenVpn = &fake_openvpn_client{make(chan int, 1), nil}
-	fakeVpnClientFactory := func(vpnSession session.VpnSession, session mysterium_api_client.Session) (openvpn.Client, error) {
+	var fakeVpnClientFactory VpnClientFactory = func(vpnSession session.VpnSession) (openvpn.Client, error) {
 		return tc.fakeOpenVpn, nil
 	}
 
@@ -68,7 +67,7 @@ func (tc *test_context) TestWhenManagerMadeConnectionStatusReturnsConnectedState
 	err := tc.connManager.Connect(identity.FromAddress("identity-1"), "vpn-node-1")
 
 	assert.NoError(tc.T(), err)
-	assert.Equal(tc.T(), ConnectionStatus{Connected, "vpn-node-1-session", nil}, tc.connManager.Status())
+	assert.Equal(tc.T(), ConnectionStatus{Connected, "vpn-session-id", nil}, tc.connManager.Status())
 }
 
 func (tc *test_context) TestStatusReportsConnectingWhenConnectionIsInProgress() {

--- a/client_connection/manager_test.go
+++ b/client_connection/manager_test.go
@@ -46,6 +46,13 @@ func (tc *test_context) TestWhenNoConnectionIsMadeStatusIsNotConnected() {
 	assert.Equal(tc.T(), ConnectionStatus{NotConnected, "", nil}, tc.connManager.Status())
 }
 
+func (tc *test_context) TestWithUnknownNodeKey() {
+	noProposalsError := errors.New("node has no service proposals")
+
+	assert.Error(tc.T(), tc.connManager.Connect(identity.FromAddress("identity-1"), "unknown-node"))
+	assert.Equal(tc.T(), ConnectionStatus{NotConnected, "", noProposalsError}, tc.connManager.Status())
+}
+
 func (tc *test_context) TestOnConnectErrorStatusIsNotConnectedAndLastErrorIsSet() {
 	fatalVpnError := errors.New("fatal connection error")
 	tc.fakeOpenVpn.onConnectReturnError = fatalVpnError

--- a/cmd/mysterium_server/command_run/command.go
+++ b/cmd/mysterium_server/command_run/command.go
@@ -3,7 +3,7 @@ package command_run
 import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/mysterium/node/communication"
-    "github.com/mysterium/node/identity"
+	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/ipify"
 	"github.com/mysterium/node/nat"
 	"github.com/mysterium/node/openvpn"

--- a/cmd/mysterium_server/command_run/factory.go
+++ b/cmd/mysterium_server/command_run/factory.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mysterium/node/communication"
 	"github.com/mysterium/node/communication/nats_dialog"
 	"github.com/mysterium/node/communication/nats_discovery"
+	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/ipify"
 	"github.com/mysterium/node/nat"
 	"github.com/mysterium/node/openvpn"
@@ -11,7 +12,6 @@ import (
 	dto_discovery "github.com/mysterium/node/service_discovery/dto"
 	"github.com/mysterium/node/session"
 	"os"
-    "github.com/mysterium/node/identity"
 )
 
 func NewCommand(vpnMiddlewares ...openvpn.ManagementMiddleware) *CommandRun {

--- a/communication/nats_dialog/dialog_establisher_test.go
+++ b/communication/nats_dialog/dialog_establisher_test.go
@@ -4,10 +4,10 @@ import (
 	"github.com/mysterium/node/communication"
 	"github.com/mysterium/node/communication/nats"
 	"github.com/mysterium/node/communication/nats_discovery"
+	"github.com/mysterium/node/identity"
 	dto_discovery "github.com/mysterium/node/service_discovery/dto"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"github.com/mysterium/node/identity"
 )
 
 func TestDialogEstablisher_Interface(t *testing.T) {

--- a/communication/nats_dialog/dialog_waiter_test.go
+++ b/communication/nats_dialog/dialog_waiter_test.go
@@ -4,9 +4,9 @@ import (
 	"github.com/mysterium/node/communication"
 	"github.com/mysterium/node/communication/nats"
 	"github.com/mysterium/node/communication/nats_discovery"
+	"github.com/mysterium/node/identity"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"github.com/mysterium/node/identity"
 )
 
 func TestDialogWaiter_Interface(t *testing.T) {

--- a/communication/nats_dialog/dto_request_test.go
+++ b/communication/nats_dialog/dto_request_test.go
@@ -2,9 +2,9 @@ package nats_dialog
 
 import (
 	"encoding/json"
+	"github.com/mysterium/node/identity"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"github.com/mysterium/node/identity"
 )
 
 func TestRequestSerialize(t *testing.T) {

--- a/communication/nats_discovery/address.go
+++ b/communication/nats_discovery/address.go
@@ -3,8 +3,8 @@ package nats_discovery
 import (
 	"fmt"
 	"github.com/mysterium/node/communication/nats"
-	dto_discovery "github.com/mysterium/node/service_discovery/dto"
 	"github.com/mysterium/node/identity"
+	dto_discovery "github.com/mysterium/node/service_discovery/dto"
 	nats_lib "github.com/nats-io/go-nats"
 )
 

--- a/communication/nats_discovery/address_test.go
+++ b/communication/nats_discovery/address_test.go
@@ -1,11 +1,11 @@
 package nats_discovery
 
 import (
+	"github.com/mysterium/node/identity"
 	dto_discovery "github.com/mysterium/node/service_discovery/dto"
 	"github.com/nats-io/go-nats"
 	"github.com/stretchr/testify/assert"
 	"testing"
-    "github.com/mysterium/node/identity"
 )
 
 func TestNewAddress(t *testing.T) {

--- a/identity/cache.go
+++ b/identity/cache.go
@@ -1,8 +1,8 @@
 package identity
 
 import (
-	"io/ioutil"
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -34,7 +34,7 @@ func (ic *identityCache) GetIdentity() (identity Identity, err error) {
 	return
 }
 
-func (ic *identityCache) StoreIdentity(identity Identity) (error) {
+func (ic *identityCache) StoreIdentity(identity Identity) error {
 	cache := cacheData{
 		Identity: identity,
 	}

--- a/identity/cache_test.go
+++ b/identity/cache_test.go
@@ -1,9 +1,9 @@
 package identity
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"testing"
 )
 
 var file = "/tmp/cache.json"

--- a/identity/keystore_fake.go
+++ b/identity/keystore_fake.go
@@ -11,7 +11,7 @@ type keyStoreFake struct {
 }
 
 func NewKeystoreFake() *keyStoreFake {
-    return &keyStoreFake{}
+	return &keyStoreFake{}
 }
 
 func (self *keyStoreFake) Accounts() []accounts.Account {

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -6,8 +6,8 @@ package identity
 import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"strings"
 	"github.com/pkg/errors"
+	"strings"
 )
 
 type identityManager struct {

--- a/ipify/client_rest.go
+++ b/ipify/client_rest.go
@@ -84,7 +84,7 @@ func parseResponseJson(response *http.Response, dto interface{}) error {
 
 func parseResponseError(response *http.Response) error {
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return errors.New(fmt.Sprintf("Server response invalid: %s", response.Status))
+		return errors.New(fmt.Sprintf("Server response invalid: %s (%s)", response.Status, response.Request.URL))
 	}
 
 	return nil

--- a/openvpn/service_discovery/factory_test.go
+++ b/openvpn/service_discovery/factory_test.go
@@ -1,13 +1,13 @@
 package service_discovery
 
 import (
+	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/money"
 	"github.com/mysterium/node/openvpn/service_discovery/dto"
 	dto_discovery "github.com/mysterium/node/service_discovery/dto"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-    "github.com/mysterium/node/identity"
 )
 
 var (

--- a/server/client_fake.go
+++ b/server/client_fake.go
@@ -3,7 +3,6 @@ package server
 import (
 	"github.com/mysterium/node/server/dto"
 
-	"fmt"
 	log "github.com/cihub/seelog"
 	"github.com/mysterium/node/identity"
 	dto_discovery "github.com/mysterium/node/service_discovery/dto"
@@ -38,17 +37,21 @@ func (client *ClientFake) NodeSendStats(nodeKey string, sessionStats []dto.Sessi
 	return nil
 }
 
-func (client *ClientFake) SessionCreate(nodeKey string) (session dto.Session, err error) {
+func (client *ClientFake) Proposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error) {
+	log.Info(MYSTERIUM_API_LOG_PREFIX, "Fake proposals requested for node_key: ", nodeKey)
 	if proposal, ok := client.proposalsByProvider[nodeKey]; ok {
-		session = dto.Session{
-			Id:              nodeKey + "-session",
-			ServiceProposal: proposal,
-		}
-		return
+		proposals = []dto_discovery.ServiceProposal{proposal}
+	} else {
+		proposals = []dto_discovery.ServiceProposal{}
 	}
 
-	err = fmt.Errorf("Fake node not found: %s", nodeKey)
 	return
+}
+
+func (client *ClientFake) SessionCreate(nodeKey string) (dto.Session, error) {
+	return dto.Session{
+		Id: nodeKey + "-session",
+	}, nil
 }
 
 func (client *ClientFake) SessionSendStats(sessionId string, sessionStats dto.SessionStats) (err error) {

--- a/server/client_fake.go
+++ b/server/client_fake.go
@@ -37,7 +37,7 @@ func (client *ClientFake) NodeSendStats(nodeKey string, sessionStats []dto.Sessi
 	return nil
 }
 
-func (client *ClientFake) Proposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error) {
+func (client *ClientFake) FindProposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error) {
 	log.Info(MYSTERIUM_API_LOG_PREFIX, "Fake proposals requested for node_key: ", nodeKey)
 	if proposal, ok := client.proposalsByProvider[nodeKey]; ok {
 		proposals = []dto_discovery.ServiceProposal{proposal}

--- a/server/client_fake.go
+++ b/server/client_fake.go
@@ -48,12 +48,6 @@ func (client *ClientFake) Proposals(nodeKey string) (proposals []dto_discovery.S
 	return
 }
 
-func (client *ClientFake) SessionCreate(nodeKey string) (dto.Session, error) {
-	return dto.Session{
-		Id: nodeKey + "-session",
-	}, nil
-}
-
 func (client *ClientFake) SessionSendStats(sessionId string, sessionStats dto.SessionStats) (err error) {
 	log.Info(MYSTERIUM_API_LOG_PREFIX, "Session stats sent: ", sessionId)
 

--- a/server/client_rest.go
+++ b/server/client_rest.go
@@ -169,7 +169,7 @@ func parseResponseJson(response *http.Response, dto interface{}) error {
 
 func parseResponseError(response *http.Response) error {
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return errors.New(fmt.Sprintf("Server response invalid: %s", response.Status))
+		return errors.New(fmt.Sprintf("Server response invalid: %s (%s)", response.Status, response.Request.URL))
 	}
 
 	return nil

--- a/server/client_rest.go
+++ b/server/client_rest.go
@@ -92,25 +92,6 @@ func (client *clientRest) Proposals(nodeKey string) (proposals []dto_discovery.S
 	return
 }
 
-func (client *clientRest) SessionCreate(nodeKey string) (session dto.Session, err error) {
-	response, err := client.doRequest("POST", "client_create_session", dto.SessionStartRequest{
-		NodeKey: nodeKey,
-	})
-
-	if err == nil {
-		defer response.Body.Close()
-
-		err = parseResponseJson(response, &session)
-		if err != nil {
-			return
-		}
-
-		log.Info(MYSTERIUM_API_LOG_PREFIX, "Session created: ", session.Id)
-	}
-
-	return
-}
-
 func (client *clientRest) SessionSendStats(sessionId string, sessionStats dto.SessionStats) (err error) {
 	response, err := client.doRequest("POST", "client_send_stats", sessionStats)
 	if err == nil {

--- a/server/client_rest.go
+++ b/server/client_rest.go
@@ -71,7 +71,7 @@ func (client *clientRest) NodeSendStats(nodeKey string, sessionList []dto.Sessio
 	return nil
 }
 
-func (client *clientRest) Proposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error) {
+func (client *clientRest) FindProposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error) {
 	response, err := client.doRequest("GET", "proposals", dto.ProposalsRequest{
 		NodeKey: nodeKey,
 	})
@@ -86,7 +86,7 @@ func (client *clientRest) Proposals(nodeKey string) (proposals []dto_discovery.S
 		}
 		proposals = proposalsResponse.Proposals
 
-		log.Info(MYSTERIUM_API_LOG_PREFIX, "Proposals fetched: ", proposals)
+		log.Info(MYSTERIUM_API_LOG_PREFIX, "FindProposals fetched: ", proposals)
 	}
 
 	return

--- a/server/client_rest.go
+++ b/server/client_rest.go
@@ -77,18 +77,20 @@ func (client *clientRest) FindProposals(nodeKey string) (proposals []dto_discove
 	values.Set("node_key", nodeKey)
 	response, err := client.doGetRequest("proposals", values)
 
-	if err == nil {
-		defer response.Body.Close()
-
-		var proposalsResponse dto.ProposalsResponse
-		err = parseResponseJson(response, &proposalsResponse)
-		if err != nil {
-			return
-		}
-		proposals = proposalsResponse.Proposals
-
-		log.Info(MYSTERIUM_API_LOG_PREFIX, "FindProposals fetched: ", proposals)
+	if err != nil {
+		return
 	}
+
+	defer response.Body.Close()
+
+	var proposalsResponse dto.ProposalsResponse
+	err = parseResponseJson(response, &proposalsResponse)
+	if err != nil {
+		return
+	}
+	proposals = proposalsResponse.Proposals
+
+	log.Info(MYSTERIUM_API_LOG_PREFIX, "FindProposals fetched: ", proposals)
 
 	return
 }

--- a/server/client_rest.go
+++ b/server/client_rest.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/server/dto"
 	dto_discovery "github.com/mysterium/node/service_discovery/dto"
+	"net/url"
 )
 
 var mysteriumApiUrl string
@@ -33,7 +34,7 @@ type clientRest struct {
 }
 
 func (client *clientRest) RegisterIdentity(identity identity.Identity) (err error) {
-	response, err := client.doRequest("POST", "identities", dto.CreateIdentityRequest{
+	response, err := client.doPostRequest("identities", dto.CreateIdentityRequest{
 		Identity: identity.Address,
 	})
 
@@ -46,7 +47,7 @@ func (client *clientRest) RegisterIdentity(identity identity.Identity) (err erro
 }
 
 func (client *clientRest) NodeRegister(proposal dto_discovery.ServiceProposal) (err error) {
-	response, err := client.doRequest("POST", "node_register", dto.NodeRegisterRequest{
+	response, err := client.doPostRequest("node_register", dto.NodeRegisterRequest{
 		ServiceProposal: proposal,
 	})
 
@@ -59,7 +60,7 @@ func (client *clientRest) NodeRegister(proposal dto_discovery.ServiceProposal) (
 }
 
 func (client *clientRest) NodeSendStats(nodeKey string, sessionList []dto.SessionStats) (err error) {
-	response, err := client.doRequest("POST", "node_send_stats", dto.NodeStatsRequest{
+	response, err := client.doPostRequest("node_send_stats", dto.NodeStatsRequest{
 		NodeKey:  nodeKey,
 		Sessions: sessionList,
 	})
@@ -72,9 +73,9 @@ func (client *clientRest) NodeSendStats(nodeKey string, sessionList []dto.Sessio
 }
 
 func (client *clientRest) FindProposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error) {
-	response, err := client.doRequest("GET", "proposals", dto.ProposalsRequest{
-		NodeKey: nodeKey,
-	})
+	values := url.Values{}
+	values.Set("node_key", nodeKey)
+	response, err := client.doGetRequest("proposals", values)
 
 	if err == nil {
 		defer response.Body.Close()
@@ -93,7 +94,7 @@ func (client *clientRest) FindProposals(nodeKey string) (proposals []dto_discove
 }
 
 func (client *clientRest) SessionSendStats(sessionId string, sessionStats dto.SessionStats) (err error) {
-	response, err := client.doRequest("POST", "client_send_stats", sessionStats)
+	response, err := client.doPostRequest("client_send_stats", sessionStats)
 	if err == nil {
 		defer response.Body.Close()
 		log.Info(MYSTERIUM_API_LOG_PREFIX, "Session stats sent: ", sessionId)
@@ -102,14 +103,27 @@ func (client *clientRest) SessionSendStats(sessionId string, sessionStats dto.Se
 	return nil
 }
 
-func (client *clientRest) doRequest(method string, path string, payload interface{}) (*http.Response, error) {
+func (client *clientRest) doGetRequest(path string, values url.Values) (*http.Response, error) {
+	fullPath := fmt.Sprintf("%v/%v?%v", mysteriumApiUrl, path, values.Encode())
+	return client.executeRequest("GET", fullPath, nil)
+}
+
+func (client *clientRest) doPostRequest(path string, payload interface{}) (*http.Response, error) {
+	return client.doPayloadRequest("POST", path, payload)
+}
+
+func (client *clientRest) doPayloadRequest(method, path string, payload interface{}) (*http.Response, error) {
 	payloadJson, err := json.Marshal(payload)
 	if err != nil {
 		log.Critical(MYSTERIUM_API_LOG_PREFIX, err)
 		return nil, err
 	}
 
-	request, err := http.NewRequest(method, mysteriumApiUrl+"/"+path, bytes.NewBuffer(payloadJson))
+	return client.executeRequest(method, mysteriumApiUrl+"/"+path, payloadJson)
+}
+
+func (client *clientRest) executeRequest(method, fullPath string, payloadJson []byte) (*http.Response, error) {
+	request, err := http.NewRequest(method, fullPath, bytes.NewBuffer(payloadJson))
 	request.Header.Set("User-Agent", MYSTERIUM_API_CLIENT)
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")

--- a/server/dto/proposals_request.go
+++ b/server/dto/proposals_request.go
@@ -1,0 +1,5 @@
+package dto
+
+type ProposalsRequest struct {
+	NodeKey string `json:"node_key"`
+}

--- a/server/dto/proposals_response.go
+++ b/server/dto/proposals_response.go
@@ -1,0 +1,7 @@
+package dto
+
+import "github.com/mysterium/node/service_discovery/dto"
+
+type ProposalsResponse struct {
+	Proposals []dto.ServiceProposal `json:"proposals"`
+}

--- a/server/dto/session.go
+++ b/server/dto/session.go
@@ -1,5 +1,0 @@
-package dto
-
-type Session struct {
-	Id string `json:"session_key"`
-}

--- a/server/dto/session.go
+++ b/server/dto/session.go
@@ -1,8 +1,5 @@
 package dto
 
-import dto_distovery "github.com/mysterium/node/service_discovery/dto"
-
 type Session struct {
-	Id              string                        `json:"session_key"`
-	ServiceProposal dto_distovery.ServiceProposal `json:"service_proposal"`
+	Id string `json:"session_key"`
 }

--- a/server/dto/session_create_request.go
+++ b/server/dto/session_create_request.go
@@ -1,5 +1,0 @@
-package dto
-
-type SessionStartRequest struct {
-	NodeKey string `json:"node_key"`
-}

--- a/server/interface.go
+++ b/server/interface.go
@@ -1,15 +1,16 @@
 package server
 
 import (
+	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/server/dto"
 	dto_discovery "github.com/mysterium/node/service_discovery/dto"
-    "github.com/mysterium/node/identity"
 )
 
 type Client interface {
 	RegisterIdentity(identity identity.Identity) (err error)
 	NodeRegister(proposal dto_discovery.ServiceProposal) (err error)
 	NodeSendStats(nodeKey string, sessionStats []dto.SessionStats) (err error)
+	Proposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error)
 	SessionCreate(nodeKey string) (session dto.Session, err error)
 	SessionSendStats(sessionId string, sessionStats dto.SessionStats) (err error)
 }

--- a/server/interface.go
+++ b/server/interface.go
@@ -11,6 +11,5 @@ type Client interface {
 	NodeRegister(proposal dto_discovery.ServiceProposal) (err error)
 	NodeSendStats(nodeKey string, sessionStats []dto.SessionStats) (err error)
 	Proposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error)
-	SessionCreate(nodeKey string) (session dto.Session, err error)
 	SessionSendStats(sessionId string, sessionStats dto.SessionStats) (err error)
 }

--- a/server/interface.go
+++ b/server/interface.go
@@ -10,6 +10,6 @@ type Client interface {
 	RegisterIdentity(identity identity.Identity) (err error)
 	NodeRegister(proposal dto_discovery.ServiceProposal) (err error)
 	NodeSendStats(nodeKey string, sessionStats []dto.SessionStats) (err error)
-	Proposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error)
+	FindProposals(nodeKey string) (proposals []dto_discovery.ServiceProposal, err error)
 	SessionSendStats(sessionId string, sessionStats dto.SessionStats) (err error)
 }

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -91,6 +91,6 @@ func validateConnectionRequest(cr *connectionRequest) *validation.FieldErrorMap 
 func toStatusResponse(status client_connection.ConnectionStatus) statusResponse {
 	return statusResponse{
 		Status:    string(status.State),
-		SessionId: status.SessionId,
+		SessionId: string(status.SessionId),
 	}
 }

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"github.com/julienschmidt/httprouter"
 	"github.com/mysterium/node/client_connection"
+	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/tequilapi/utils"
 	"github.com/mysterium/node/tequilapi/validation"
 	"net/http"
-    "github.com/mysterium/node/identity"
 )
 
 type connectionRequest struct {
@@ -46,7 +46,7 @@ func (ce *connectionEndpoint) Create(resp http.ResponseWriter, req *http.Request
 		return
 	}
 
-	err = ce.manager.Connect( identity.FromAddress(cr.Identity), cr.NodeKey)
+	err = ce.manager.Connect(identity.FromAddress(cr.Identity), cr.NodeKey)
 
 	if err != nil {
 		utils.SendError(resp, err, http.StatusInternalServerError)


### PR DESCRIPTION
For client, proposals are fetched from a dedicated endpoint instead `/client-create-session`.

This should only be merged after updating discovery api DEV env from `release/v1`.