### PR TITLE
Fix request error handling to avoid segmentation violation

### DIFF
--- a/server/mysterium_api.go
+++ b/server/mysterium_api.go
@@ -77,6 +77,8 @@ func (mApi *mysteriumApi) NodeSendStats(nodeKey string, signer identity.Signer) 
 	err = mApi.doRequest(req)
 	if err == nil {
 		log.Info(mysteriumApiLogPrefix, "Node stats sent: ", nodeKey)
+	} else {
+		log.Error(mysteriumApiLogPrefix, "Node stats failed: ", err)
 	}
 	return err
 }
@@ -117,9 +119,10 @@ func (mApi *mysteriumApi) SendSessionStats(sessionId string, sessionStats dto.Se
 
 func (mApi *mysteriumApi) doRequest(req *http.Request) error {
 	resp, err := mApi.http.Do(req)
-	if err == nil {
-		resp.Body.Close()
+	if err != nil {
+		return err
 	}
+	defer resp.Body.Close()
 	return parseResponseError(resp)
 }
 

--- a/server/mysterium_api.go
+++ b/server/mysterium_api.go
@@ -77,8 +77,6 @@ func (mApi *mysteriumApi) NodeSendStats(nodeKey string, signer identity.Signer) 
 	err = mApi.doRequest(req)
 	if err == nil {
 		log.Info(mysteriumApiLogPrefix, "Node stats sent: ", nodeKey)
-	} else {
-		log.Error(mysteriumApiLogPrefix, "Node stats failed: ", err)
 	}
 	return err
 }
@@ -120,6 +118,7 @@ func (mApi *mysteriumApi) SendSessionStats(sessionId string, sessionStats dto.Se
 func (mApi *mysteriumApi) doRequest(req *http.Request) error {
 	resp, err := mApi.http.Do(req)
 	if err != nil {
+		log.Error(mysteriumApiLogPrefix, err)
 		return err
 	}
 	defer resp.Body.Close()
@@ -129,12 +128,14 @@ func (mApi *mysteriumApi) doRequest(req *http.Request) error {
 func (mApi *mysteriumApi) doRequestAndParseResponse(req *http.Request, responseValue interface{}) error {
 	resp, err := mApi.http.Do(req)
 	if err != nil {
+		log.Error(mysteriumApiLogPrefix, err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	err = parseResponseError(resp)
 	if err != nil {
+		log.Error(mysteriumApiLogPrefix, err)
 		return err
 	}
 


### PR DESCRIPTION
In case request fails before reaching server (i.e. timeout) and no response is generated, such error occurs:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x43503e9]

goroutine 37 [running]:
github.com/mysterium/node/server.parseResponseError(0x0, 0x1, 0x1)
	/Users/donce/go/src/github.com/mysterium/node/server/response.go:12 +0x29
github.com/mysterium/node/server.(*mysteriumApi).doRequest(0xc420126500, 0xc4200b2300, 0x4469f00, 0xc4301cdec0)
	/Users/donce/go/src/github.com/mysterium/node/server/mysterium_api.go:127 +0x1a2
github.com/mysterium/node/server.(*mysteriumApi).NodeSendStats(0xc420126500, 0xc4200833e0, 0x2a, 0x47091a0, 0xc43017c0a0, 0xc42014e300, 0xc42013a030)
	/Users/donce/go/src/github.com/mysterium/node/server/mysterium_api.go:77 +0x12f
github.com/mysterium/node/cmd/mysterium_server/command_run.(*CommandRun).Run.func1(0xc42009cd90, 0xc4200833e0, 0x2a, 0x47091a0, 0xc43017c0a0)
	/Users/donce/go/src/github.com/mysterium/node/cmd/mysterium_server/command_run/command.go:78 +0x6f
created by github.com/mysterium/node/cmd/mysterium_server/command_run.(*CommandRun).Run
	/Users/donce/go/src/github.com/mysterium/node/cmd/mysterium_server/command_run/command.go:75 +0x6de
```
