### PR TITLE
WIP: add Makefile to install glide, build server and client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: server client
+
+default: help
+
+CMD_GLIDE := $(shell which glide)
+BUILD_OUTPUT = build
+
+help:
+	@echo "Select a sub command \n"
+	@echo "glide:\t Install package manager 'glide'"
+	@echo "dep:\t Get dependencies"
+	@echo "server:\t Build Mysterium server"
+	@echo "client:\t Build Mysterium client"
+	@echo "help:\t Display this help"
+	@echo "\nSee README.md for more."
+
+glide:
+	if [ "$(CMD_GLIDE)" == "" ] ; then curl https://glide.sh/get | sh ; fi
+
+dep:
+	glide install
+
+server:
+	go build -o $(BUILD_OUTPUT)/server cmd/mysterium_server/mysterium_server.go
+
+client:
+	go build -o $(BUILD_OUTPUT)/client cmd/mysterium_client/mysterium_client.go

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dep:
 	glide install
 
 server:
-	go build -o $(BUILD_OUTPUT)/server cmd/mysterium_server/mysterium_server.go
+	./bin/server_build
 
 client:
-	go build -o $(BUILD_OUTPUT)/client cmd/mysterium_client/mysterium_client.go
+	./bin/client_build


### PR DESCRIPTION
Described in Issue #23 
Makefile supports:

- [X] install glide
- [X] build server binary
- [X] build client binary
- [ ] build server Docker image
- [ ] build client Docker image

Please take time to review, thank you.