### PR TITLE
Make --cli optional when running  bin/client_run

### DIFF
--- a/bin/client_run
+++ b/bin/client_run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo ./build/client/mysterium_client --runtime-dir=build/client --cli $@
+sudo ./build/client/mysterium_client --runtime-dir=build/client $@


### PR DESCRIPTION
Running `bin/client_run --help` prints out such option:
```
...
  -cli
    	Run an interactive CLI based Mysterium UI
...
```
But this flag is actually not used, because `--cli` option is always passed in.
Ignoring this flag and always running in cli mode is very confusing and inconvenient.