### PR TITLE
Fix command run error handling, which sometimes results in infinite loop

### DIFF
--- a/cmd/mysterium_client/mysterium_client.go
+++ b/cmd/mysterium_client/mysterium_client.go
@@ -18,7 +18,7 @@ func main() {
 	}
 
 	cmdRun := run.NewCommand(options)
-	if cmdRun.Run(); err != nil {
+	if err := cmdRun.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
I've experienced this when port `4050` was already in use. In this case, node was running in loop without any output.