### PR TITLE
When creating identity, unlock it before registering

### DIFF
--- a/cmd/mysterium_server/command_run/factory.go
+++ b/cmd/mysterium_server/command_run/factory.go
@@ -48,10 +48,7 @@ func NewCommandWith(
 
 	return &CommandRun{
 		identityLoader: func() (identity.Identity, error) {
-			identitySelector := func() (identity.Identity, error) {
-				return identity_handler.SelectIdentity(identityHandler, options.NodeKey, options.Passphrase)
-			}
-			return identity_handler.LoadIdentity(identitySelector, identityManager, options.Passphrase)
+			return identity_handler.LoadIdentity(identityHandler, options.NodeKey, options.Passphrase)
 		},
 		createSigner:    createSigner,
 		ipifyClient:     ipifyClient,

--- a/cmd/mysterium_server/command_run/identity/handler.go
+++ b/cmd/mysterium_server/command_run/identity/handler.go
@@ -28,9 +28,13 @@ func NewHandler(
 	}
 }
 
-func (h *handler) UseExisting(address string) (id identity.Identity, err error) {
+func (h *handler) UseExisting(address, passphrase string) (id identity.Identity, err error) {
 	id, err = h.manager.GetIdentity(address)
 	if err != nil {
+		return
+	}
+
+	if err = h.manager.Unlock(id.Address, passphrase); err != nil {
 		return
 	}
 
@@ -38,10 +42,14 @@ func (h *handler) UseExisting(address string) (id identity.Identity, err error) 
 	return
 }
 
-func (h *handler) UseLast() (identity identity.Identity, err error) {
+func (h *handler) UseLast(passphrase string) (identity identity.Identity, err error) {
 	identity, err = h.cache.GetIdentity()
 	if err != nil || !h.manager.HasIdentity(identity.Address) {
 		return identity, errors.New("identity not found in cache")
+	}
+
+	if err = h.manager.Unlock(identity.Address, passphrase); err != nil {
+		return
 	}
 
 	return identity, nil
@@ -51,6 +59,10 @@ func (h *handler) UseNew(passphrase string) (id identity.Identity, err error) {
 	// if all fails, create a new one
 	id, err = h.manager.CreateNewIdentity(passphrase)
 	if err != nil {
+		return
+	}
+
+	if err = h.manager.Unlock(id.Address, passphrase); err != nil {
 		return
 	}
 

--- a/cmd/mysterium_server/command_run/identity/handler_fake.go
+++ b/cmd/mysterium_server/command_run/identity/handler_fake.go
@@ -9,11 +9,11 @@ type handlerFake struct {
 	LastAddress string
 }
 
-func (hf *handlerFake) UseExisting(address string) (identity.Identity, error) {
+func (hf *handlerFake) UseExisting(address, passphrase string) (identity.Identity, error) {
 	return identity.Identity{Address: address}, nil
 }
 
-func (hf *handlerFake) UseLast() (id identity.Identity, err error) {
+func (hf *handlerFake) UseLast(passphrase string) (id identity.Identity, err error) {
 	if hf.LastAddress != "" {
 		id = identity.Identity{Address: hf.LastAddress}
 	} else {

--- a/cmd/mysterium_server/command_run/identity/handler_test.go
+++ b/cmd/mysterium_server/command_run/identity/handler_test.go
@@ -14,7 +14,7 @@ var fakeSignerFactory = func(id identity.Identity) identity.Signer {
 var existingIdentity = identity.Identity{"existing"}
 var newIdentity = identity.Identity{"new"}
 
-func TestIdentityHandlerUseExistingSuccessful(t *testing.T) {
+func TestUseExistingSucceeds(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
 	client := server.NewClientFake()
 	cache := identity.NewIdentityCacheFake()
@@ -30,7 +30,7 @@ func TestIdentityHandlerUseExistingSuccessful(t *testing.T) {
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
 }
 
-func TestIdentityHandlerUseExistingWhenUnlockFails(t *testing.T) {
+func TestUseExistingFailsWhenUnlockFails(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
 	identityManager.MarkUnlockToFail()
 	client := server.NewClientFake()
@@ -45,7 +45,7 @@ func TestIdentityHandlerUseExistingWhenUnlockFails(t *testing.T) {
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
 }
 
-func TestIdentityHandlerUseExistingNotFound(t *testing.T) {
+func TestUseFailsWhenIdentityNotFound(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
 	client := server.NewClientFake()
 	cache := identity.NewIdentityCacheFake()
@@ -56,7 +56,7 @@ func TestIdentityHandlerUseExistingNotFound(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestIdentityHandlerUseLastSuccessful(t *testing.T) {
+func TestUseLastSucceeds(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
 	client := server.NewClientFake()
 	cache := identity.NewIdentityCacheFake()
@@ -76,7 +76,7 @@ func TestIdentityHandlerUseLastSuccessful(t *testing.T) {
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
 }
 
-func TestIdentityHandlerUseLastWhenUnlockFails(t *testing.T) {
+func TestUseLastFailsWhenUnlockFails(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
 	identityManager.MarkUnlockToFail()
 	client := server.NewClientFake()
@@ -96,7 +96,7 @@ func TestIdentityHandlerUseLastWhenUnlockFails(t *testing.T) {
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
 }
 
-func TestIdentityHandlerUseNewSuccessful(t *testing.T) {
+func TestUseNewSucceeds(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
 	client := server.NewClientFake()
 	cache := identity.NewIdentityCacheFake()
@@ -113,7 +113,7 @@ func TestIdentityHandlerUseNewSuccessful(t *testing.T) {
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
 }
 
-func TestIdentityHandlerUseNewWhenUnlockFails(t *testing.T) {
+func TestUseNewFailsWhenUnlockFails(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
 	identityManager.MarkUnlockToFail()
 	client := server.NewClientFake()

--- a/cmd/mysterium_server/command_run/identity/interface.go
+++ b/cmd/mysterium_server/command_run/identity/interface.go
@@ -4,7 +4,7 @@ import "github.com/mysterium/node/identity"
 
 // HandlerInterface allows selecting identity to be used
 type HandlerInterface interface {
-	UseExisting(address string) (identity.Identity, error)
-	UseLast() (identity.Identity, error)
+	UseExisting(address, passphrase string) (identity.Identity, error)
+	UseLast(passphrase string) (identity.Identity, error)
 	UseNew(passphrase string) (identity.Identity, error)
 }

--- a/cmd/mysterium_server/command_run/identity/loading.go
+++ b/cmd/mysterium_server/command_run/identity/loading.go
@@ -5,28 +5,13 @@ import "github.com/mysterium/node/identity"
 // Selector selects the identity
 type Selector func() (identity.Identity, error)
 
-// LoadIdentity selects and unlocks identity
-func LoadIdentity(identitySelector Selector, identityManager identity.IdentityManagerInterface, passphrase string) (identity.Identity, error) {
-	id, err := identitySelector()
-
-	if err != nil {
-		return id, err
-	}
-
-	if err = identityManager.Unlock(id.Address, passphrase); err != nil {
-		return id, err
-	}
-
-	return id, nil
-}
-
-//SelectIdentity selects lastUsed identity or creates and unlocks new one if keyOption is not present
-func SelectIdentity(identityHandler HandlerInterface, keyOption, passphrase string) (identity.Identity, error) {
+// LoadIdentity chooses which identity to use and invokes it using identityHandler
+func LoadIdentity(identityHandler HandlerInterface, keyOption, passphrase string) (identity.Identity, error) {
 	if len(keyOption) > 0 {
-		return identityHandler.UseExisting(keyOption)
+		return identityHandler.UseExisting(keyOption, passphrase)
 	}
 
-	if id, err := identityHandler.UseLast(); err == nil {
+	if id, err := identityHandler.UseLast(passphrase); err == nil {
 		return id, err
 	}
 

--- a/cmd/mysterium_server/command_run/identity/loading_test.go
+++ b/cmd/mysterium_server/command_run/identity/loading_test.go
@@ -15,52 +15,23 @@ var fakeFailureIdentitySelector = func() (identity.Identity, error) {
 	return identity.Identity{}, errors.New("selection failed")
 }
 
-func Test_LoadIdentity(t *testing.T) {
-	fakeIdentityManager := identity.NewIdentityManagerFake(nil, identity.Identity{})
-	id, err := LoadIdentity(fakeSuccessIdentitySelector, fakeIdentityManager, "pass")
-	assert.Equal(t, "fake", id.Address)
-	assert.Nil(t, err)
-
-	assert.Equal(t, "fake", fakeIdentityManager.LastUnlockAddress)
-	assert.Equal(t, "pass", fakeIdentityManager.LastUnlockPassphrase)
-}
-
-func Test_LoadIdentitySelectionFails(t *testing.T) {
-	fakeIdentityManager := identity.NewIdentityManagerFake(nil, identity.Identity{})
-	_, err := LoadIdentity(fakeFailureIdentitySelector, fakeIdentityManager, "pass")
-	assert.NotNil(t, err)
-
-	assert.Equal(t, "", fakeIdentityManager.LastUnlockAddress)
-	assert.Equal(t, "", fakeIdentityManager.LastUnlockPassphrase)
-}
-
-func Test_LoadIdentityUnlockFails(t *testing.T) {
-	fakeIdentityManager := identity.NewIdentityManagerFake(nil, identity.Identity{})
-	fakeIdentityManager.MarkUnlockToFail()
-	_, err := LoadIdentity(fakeSuccessIdentitySelector, fakeIdentityManager, "pass")
-	assert.NotNil(t, err)
-
-	assert.Equal(t, "fake", fakeIdentityManager.LastUnlockAddress)
-	assert.Equal(t, "pass", fakeIdentityManager.LastUnlockPassphrase)
-}
-
-func Test_SelectIdentityExisting(t *testing.T) {
+func Test_LoadIdentityExisting(t *testing.T) {
 	identityHandler := &handlerFake{}
-	id, err := SelectIdentity(identityHandler, "existing", "")
+	id, err := LoadIdentity(identityHandler, "existing", "")
 	assert.Equal(t, "existing", id.Address)
 	assert.Nil(t, err)
 }
 
-func Test_SelectIdentityLast(t *testing.T) {
+func Test_LoadIdentityLast(t *testing.T) {
 	identityHandler := &handlerFake{LastAddress: "last"}
-	id, err := SelectIdentity(identityHandler, "", "")
+	id, err := LoadIdentity(identityHandler, "", "")
 	assert.Equal(t, "last", id.Address)
 	assert.Nil(t, err)
 }
 
-func Test_SelectIdentityNew(t *testing.T) {
+func Test_LoadIdentityNew(t *testing.T) {
 	identityHandler := &handlerFake{}
-	id, err := SelectIdentity(identityHandler, "", "")
+	id, err := LoadIdentity(identityHandler, "", "")
 	assert.Equal(t, "new", id.Address)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Registering identity already requires identity to be unlocked, so `h.manager.Unlock(id.Address, passphrase)` has to be invoked before `h.identityAPI.RegisterIdentity(id, h.signerFactory(id))` in `UseNew` method in `handler.go`.
Since identity registration is done inside `UseNew`, that's why unlocking was moved inside identity handler methods.