### PR TITLE
Add script for linting only modified files

### DIFF
--- a/bin/lint_git
+++ b/bin/lint_git
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Shows linter warnings only for modified files.
+
+all_warnings=`bin/lint`
+
+for changed_file in `git diff --name-only origin/master`
+  do
+    echo "$all_warnings" | grep "$changed_file"
+  done


### PR DESCRIPTION
This allows adapting linter warnings for new code easier. Example when running from branch:
<img width="1464" alt="screen shot 2018-01-29 at 17 50 10" src="https://user-images.githubusercontent.com/1409983/35519446-ede60dae-051c-11e8-8535-ec731d7885df.png">
