### PR TITLE
Show tests success or failure message

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -14,4 +14,8 @@ if [ -z "$ARGUMENTS" ]; then
     ARGUMENTS=`go list ./...`
 fi
 
-go test -cover ${ARGUMENTS}
+if go test -cover ${ARGUMENTS} ; then
+    echo "All tests passed."
+else
+    echo "Some tests failed!"
+fi


### PR DESCRIPTION
Sometimes it's easy to miss failing tests in long log list. This writes a short message at the end of logs - it allows to avoid scanning trough log list just to see if tests passed.