### PR TITLE
Use default min-confidence for linter on new code

### DIFF
--- a/bin/lint_git
+++ b/bin/lint_git
@@ -2,7 +2,8 @@
 
 # Shows linter warnings only for modified files.
 
-all_warnings=`bin/lint`
+packages=`go list ./...`
+all_warnings=`go run vendor/github.com/golang/lint/golint/*.go --set_exit_status ${packages}`
 
 for changed_file in `git diff --name-only origin/master`
   do


### PR DESCRIPTION
Running `bin/lint_git` lints **new** code with 0.8 (default) min-confidence.
Running `bin/lint` lints **all** code with 1.0 min-confidence.

This allows adapting new style for new code without refactoring all existing code at once.