### PR TITLE
Rename client_connection package name to Go naming conventions

### DIFF
--- a/client/connection/interface.go
+++ b/client/connection/interface.go
@@ -1,4 +1,4 @@
-package client_connection
+package connection
 
 import (
 	"github.com/mysterium/node/communication"

--- a/client/connection/manager.go
+++ b/client/connection/manager.go
@@ -1,4 +1,4 @@
-package client_connection
+package connection
 
 import (
 	"errors"

--- a/client/connection/manager_test.go
+++ b/client/connection/manager_test.go
@@ -1,4 +1,4 @@
-package client_connection
+package connection
 
 import (
 	"errors"

--- a/client/connection/openvpn.go
+++ b/client/connection/openvpn.go
@@ -1,4 +1,4 @@
-package client_connection
+package connection
 
 import (
 	"github.com/mysterium/node/identity"

--- a/client/connection/status.go
+++ b/client/connection/status.go
@@ -1,4 +1,4 @@
-package client_connection
+package connection
 
 import "github.com/mysterium/node/session"
 

--- a/cmd/commands/client/command_client.go
+++ b/cmd/commands/client/command_client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
-	"github.com/mysterium/node/client_connection"
+	"github.com/mysterium/node/client/connection"
 	node_cmd "github.com/mysterium/node/cmd"
 	"github.com/mysterium/node/communication"
 	nats_dialog "github.com/mysterium/node/communication/nats/dialog"
@@ -48,14 +48,14 @@ func NewCommandWith(
 
 	statsKeeper := bytescount.NewSessionStatsKeeper(time.Now)
 
-	vpnClientFactory := client_connection.ConfigureVpnClientFactory(
+	vpnClientFactory := connection.ConfigureVpnClientFactory(
 		mysteriumClient,
 		options.DirectoryConfig,
 		options.DirectoryRuntime,
 		signerFactory,
 		statsKeeper,
 	)
-	connectionManager := client_connection.NewManager(mysteriumClient, dialogEstablisherFactory, vpnClientFactory, statsKeeper)
+	connectionManager := connection.NewManager(mysteriumClient, dialogEstablisherFactory, vpnClientFactory, statsKeeper)
 
 	router := tequilapi.NewAPIRouter()
 
@@ -76,7 +76,7 @@ func NewCommandWith(
 
 //Command represent entrypoint for Mysterium client with top level components
 type Command struct {
-	connectionManager client_connection.Manager
+	connectionManager connection.Manager
 	httpAPIServer     tequilapi.APIServer
 }
 
@@ -106,7 +106,7 @@ func (cmd *Command) Kill() error {
 	err := cmd.connectionManager.Disconnect()
 	if err != nil {
 		switch err {
-		case client_connection.ErrNoConnection:
+		case connection.ErrNoConnection:
 			fmt.Println("No active connection - proceeding")
 		default:
 			return err

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -3,7 +3,7 @@ package endpoints
 import (
 	"encoding/json"
 	"github.com/julienschmidt/httprouter"
-	"github.com/mysterium/node/client_connection"
+	"github.com/mysterium/node/client/connection"
 	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/ip"
 	"github.com/mysterium/node/openvpn/middlewares/client/bytescount"
@@ -23,12 +23,12 @@ type statusResponse struct {
 }
 
 type connectionEndpoint struct {
-	manager     client_connection.Manager
+	manager     connection.Manager
 	ipResolver  ip.Resolver
 	statsKeeper bytescount.SessionStatsKeeper
 }
 
-func NewConnectionEndpoint(manager client_connection.Manager, ipResolver ip.Resolver, statsKeeper bytescount.SessionStatsKeeper) *connectionEndpoint {
+func NewConnectionEndpoint(manager connection.Manager, ipResolver ip.Resolver, statsKeeper bytescount.SessionStatsKeeper) *connectionEndpoint {
 	return &connectionEndpoint{
 		manager:     manager,
 		ipResolver:  ipResolver,
@@ -58,7 +58,7 @@ func (ce *connectionEndpoint) Create(resp http.ResponseWriter, req *http.Request
 
 	if err != nil {
 		switch err {
-		case client_connection.ErrAlreadyExists:
+		case connection.ErrAlreadyExists:
 			utils.SendError(resp, err, http.StatusConflict)
 		default:
 			utils.SendError(resp, err, http.StatusInternalServerError)
@@ -73,7 +73,7 @@ func (ce *connectionEndpoint) Kill(resp http.ResponseWriter, req *http.Request, 
 	err := ce.manager.Disconnect()
 	if err != nil {
 		switch err {
-		case client_connection.ErrNoConnection:
+		case connection.ErrNoConnection:
 			utils.SendError(resp, err, http.StatusConflict)
 		default:
 			utils.SendError(resp, err, http.StatusInternalServerError)
@@ -117,7 +117,7 @@ func (ce *connectionEndpoint) GetStatistics(writer http.ResponseWriter, request 
 }
 
 // AddRoutesForConnection adds connections routes to given router
-func AddRoutesForConnection(router *httprouter.Router, manager client_connection.Manager, ipResolver ip.Resolver,
+func AddRoutesForConnection(router *httprouter.Router, manager connection.Manager, ipResolver ip.Resolver,
 	statsKeeper bytescount.SessionStatsKeeper) {
 	connectionEndpoint := NewConnectionEndpoint(manager, ipResolver, statsKeeper)
 	router.GET("/connection", connectionEndpoint.Status)
@@ -147,7 +147,7 @@ func validateConnectionRequest(cr *connectionRequest) *validation.FieldErrorMap 
 	return errors
 }
 
-func toStatusResponse(status client_connection.ConnectionStatus) statusResponse {
+func toStatusResponse(status connection.ConnectionStatus) statusResponse {
 	return statusResponse{
 		Status:    string(status.State),
 		SessionID: string(status.SessionID),

--- a/tequilapi/endpoints/connection_test.go
+++ b/tequilapi/endpoints/connection_test.go
@@ -3,7 +3,7 @@ package endpoints
 import (
 	"errors"
 	"github.com/julienschmidt/httprouter"
-	"github.com/mysterium/node/client_connection"
+	"github.com/mysterium/node/client/connection"
 	"github.com/mysterium/node/identity"
 	"github.com/mysterium/node/ip"
 	"github.com/mysterium/node/openvpn/middlewares/client/bytescount"
@@ -19,7 +19,7 @@ import (
 type fakeManager struct {
 	onConnectReturn    error
 	onDisconnectReturn error
-	onStatusReturn     client_connection.ConnectionStatus
+	onStatusReturn     connection.ConnectionStatus
 	disconnectCount    int
 	requestedConsumer  identity.Identity
 	requestedProvider  identity.Identity
@@ -31,7 +31,7 @@ func (fm *fakeManager) Connect(consumerID identity.Identity, providerID identity
 	return fm.onConnectReturn
 }
 
-func (fm *fakeManager) Status() client_connection.ConnectionStatus {
+func (fm *fakeManager) Status() connection.ConnectionStatus {
 
 	return fm.onStatusReturn
 }
@@ -107,8 +107,8 @@ func TestAddRoutesForConnectionAddsRoutes(t *testing.T) {
 
 func TestDisconnectingState(t *testing.T) {
 	var fakeManager = fakeManager{}
-	fakeManager.onStatusReturn = client_connection.ConnectionStatus{
-		State:     client_connection.Disconnecting,
+	fakeManager.onStatusReturn = connection.ConnectionStatus{
+		State:     connection.Disconnecting,
 		SessionID: "",
 	}
 
@@ -129,8 +129,8 @@ func TestDisconnectingState(t *testing.T) {
 
 func TestNotConnectedStateIsReturnedWhenNoConnection(t *testing.T) {
 	var fakeManager = fakeManager{}
-	fakeManager.onStatusReturn = client_connection.ConnectionStatus{
-		State:     client_connection.NotConnected,
+	fakeManager.onStatusReturn = connection.ConnectionStatus{
+		State:     connection.NotConnected,
 		SessionID: "",
 	}
 
@@ -152,8 +152,8 @@ func TestNotConnectedStateIsReturnedWhenNoConnection(t *testing.T) {
 
 func TestStateConnectingIsReturnedWhenIsConnectionInProgress(t *testing.T) {
 	var fakeManager = fakeManager{}
-	fakeManager.onStatusReturn = client_connection.ConnectionStatus{
-		State: client_connection.Connecting,
+	fakeManager.onStatusReturn = connection.ConnectionStatus{
+		State: connection.Connecting,
 	}
 
 	connEndpoint := NewConnectionEndpoint(&fakeManager, nil, nil)
@@ -174,8 +174,8 @@ func TestStateConnectingIsReturnedWhenIsConnectionInProgress(t *testing.T) {
 
 func TestConnectedStateAndSessionIdIsReturnedWhenIsConnected(t *testing.T) {
 	var fakeManager = fakeManager{}
-	fakeManager.onStatusReturn = client_connection.ConnectionStatus{
-		State:     client_connection.Connected,
+	fakeManager.onStatusReturn = connection.ConnectionStatus{
+		State:     connection.Connected,
 		SessionID: "My-super-session",
 	}
 
@@ -361,7 +361,7 @@ func TestGetStatisticsEndpointReturnsStatisticsWhenSessionIsNotStarted(t *testin
 
 func TestEndpointReturnsConflictStatusIfConnectionAlreadyExists(t *testing.T) {
 	manager := fakeManager{}
-	manager.onConnectReturn = client_connection.ErrAlreadyExists
+	manager.onConnectReturn = connection.ErrAlreadyExists
 
 	connectionEndpoint := NewConnectionEndpoint(&manager, nil, nil)
 
@@ -389,7 +389,7 @@ func TestEndpointReturnsConflictStatusIfConnectionAlreadyExists(t *testing.T) {
 
 func TestDisconnectReturnsConflictStatusIfConnectionDoesNotExist(t *testing.T) {
 	manager := fakeManager{}
-	manager.onDisconnectReturn = client_connection.ErrNoConnection
+	manager.onDisconnectReturn = connection.ErrNoConnection
 
 	connectionEndpoint := NewConnectionEndpoint(&manager, nil, nil)
 


### PR DESCRIPTION
Renamed `client_connection/` -> `client/connection/`