### PR TITLE
Increase NATS sender timeout to avoid early timeouts

### DIFF
--- a/communication/nats/sender.go
+++ b/communication/nats/sender.go
@@ -17,7 +17,7 @@ func NewSender(connection Connection, codec communication.Codec, topic string) *
 	return &senderNATS{
 		connection:     connection,
 		codec:          codec,
-		timeoutRequest: 500 * time.Millisecond,
+		timeoutRequest: 2 * time.Second,
 		messageTopic:   topic + ".",
 	}
 }

--- a/communication/nats/sender_test.go
+++ b/communication/nats/sender_test.go
@@ -20,7 +20,7 @@ func TestSenderNew(t *testing.T) {
 		&senderNATS{
 			connection:     connection,
 			codec:          codec,
-			timeoutRequest: 500 * time.Millisecond,
+			timeoutRequest: 2 * time.Second,
 			messageTopic:   "custom.",
 		},
 		NewSender(connection, codec, "custom"),


### PR DESCRIPTION
0.5s is too optimistic - we're making assumption that network is quite fast. With 2 seconds, we'll be on the safe side.