### PR TITLE
Fix failing test when running on Go 1.10

### DIFF
--- a/openvpn/primitives/ta_test.go
+++ b/openvpn/primitives/ta_test.go
@@ -29,7 +29,7 @@ func TestTLSCryptKeyFileContentsAreValid(t *testing.T) {
 	contentLen, _ := keyFile.Read(keyBytes)
 
 	if fileLen != contentLen {
-		t.Errorf("content lengh %s should be %s", contentLen, fileLen)
+		t.Errorf("content length %d, should be %d", contentLen, fileLen)
 		assert.Equal(t, contentLen, fileLen)
 	}
 


### PR DESCRIPTION
This test doesn't fail in Travis, but it does on local environment. I assume it's because I'm using Go 1.10 and Travis is using Go 1.9.2.