### PR TITLE
Use 127.0.0.1 by default for tequilapi to make CLI work with daemon client

### DIFF
--- a/cmd/commands/client/options.go
+++ b/cmd/commands/client/options.go
@@ -55,7 +55,7 @@ func ParseArguments(args []string) (options CommandOptions, err error) {
 	flags.StringVar(
 		&options.TequilapiAddress,
 		"tequilapi.address",
-		"localhost",
+		"127.0.0.1",
 		"IP address of interface to listen for incoming connections",
 	)
 	flags.IntVar(


### PR DESCRIPTION
When connecting from CLI to tequilapi (running as a daemon), `localhost` is intercepted by a daemon listener, so connection from CLI is not possible. `127.0.0.1` has an exception and CLI works.