### PR TITLE
Add go vet to check for dead code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
 
 script:
   - bin/test
+  - bin/vet
   #run e2e on Pull Requests and linux env only - travis OSX VM doesnt support docker (yet?)
   - if [ "$TRAVIS_OS_NAME" == 'linux' ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
       bin/travis_scripts/check_docker.sh;

--- a/bin/test_commit
+++ b/bin/test_commit
@@ -1,0 +1,1 @@
+bin/test && bin/vet && bin/lint_git

--- a/bin/test_commit
+++ b/bin/test_commit
@@ -1,1 +1,8 @@
+#!/bin/bash
+
+# Runs tests and code quality checks
+#
+# Usage example:
+#> bin/test_commit
+
 bin/test && bin/vet && bin/lint_git

--- a/bin/vet
+++ b/bin/vet
@@ -1,0 +1,3 @@
+ARGUMENTS=`go list ./... | sed '/e2e/d'`
+
+go vet -unreachable ${ARGUMENTS}

--- a/bin/vet
+++ b/bin/vet
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ARGUMENTS=`go list ./... | sed '/e2e/d'`
 
 go vet -unreachable ${ARGUMENTS}

--- a/cmd/commands/cli/command_cli.go
+++ b/cmd/commands/cli/command_cli.go
@@ -66,8 +66,6 @@ func (c *Command) Run() (err error) {
 
 		c.handleActions(line)
 	}
-
-	return nil
 }
 
 // Kill stops cli

--- a/utils/cancelable_test.go
+++ b/utils/cancelable_test.go
@@ -51,7 +51,6 @@ func TestBlockingFunctionIsCancelled(t *testing.T) {
 		_, err := cancelable.
 			NewRequest(func() (interface{}, error) {
 				select {} //effective infinite loop - blocks forever
-				return 1, nil
 			}).Call()
 		errorChannel <- err
 	}()


### PR DESCRIPTION
Dead code is no good. Also, [go report card](https://goreportcard.com/report/github.com/MysteriumNetwork/node#go_vet) runs go vet, so not having dead code increases our score as well :)

`go vet` supports multiple checks - not sure if others are needed, but we can add more rules if we find them useful :)