### PR TITLE
OpenVPN management network address

### DIFF
--- a/client/connection/openvpn.go
+++ b/client/connection/openvpn.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mysterium/node/openvpn/middlewares/client/auth"
 	"github.com/mysterium/node/openvpn/middlewares/client/bytescount"
 	"github.com/mysterium/node/openvpn/middlewares/state"
+	"github.com/mysterium/node/openvpn/management"
 	"github.com/mysterium/node/openvpn/session/credentials"
 	"github.com/mysterium/node/server"
 	"github.com/mysterium/node/session"
@@ -77,10 +78,15 @@ func ConfigureVpnClientFactory(
 
 		credentialsProvider := credentials.SignatureCredentialsProvider(vpnSession.ID, signer)
 
+		managementAddress, err := management.GetAvailableAddress()
+		if err != nil {
+			return nil, err
+		}
+
 		return openvpn.NewClient(
 			openvpnBinary,
 			vpnClientConfig,
-			runtimeDirectory,
+			managementAddress,
 			state.NewMiddleware(stateCallback),
 			bytescount.NewMiddleware(statsHandler, 1*time.Second),
 			auth.NewMiddleware(credentialsProvider),

--- a/openvpn/client.go
+++ b/openvpn/client.go
@@ -39,13 +39,17 @@ type openVpnClient struct {
 
 // NewClient creates openvpn client with given config params
 func NewClient(openvpnBinary string, config *ClientConfig, directoryRuntime string, middlewares ...management.Middleware) *openVpnClient {
+	managementAddress, err := management.GetAvailableAddress()
+	if err != nil {
+		return nil
+	}
+
 	// Add the management interface socketAddress to the config
-	socketAddress := tempFilename(directoryRuntime, "openvpn-management-", ".sock")
-	config.SetManagementSocket(socketAddress)
+	config.SetManagementSocket(managementAddress.IP, managementAddress.Port)
 
 	return &openVpnClient{
 		config:     config,
-		management: management.NewManagement(socketAddress, "[client-management] ", middlewares...),
+		management: management.NewManagement(managementAddress.String(), "[client-management] ", middlewares...),
 		process:    NewProcess(openvpnBinary, "[client-openvpn] "),
 	}
 }

--- a/openvpn/client.go
+++ b/openvpn/client.go
@@ -40,7 +40,7 @@ type openVpnClient struct {
 // NewClient creates openvpn client with given config params
 func NewClient(openvpnBinary string, config *ClientConfig, managementAddress *management.Address, middlewares ...management.Middleware) *openVpnClient {
 	// Add the management interface socketAddress to the config
-	config.SetManagementSocket(managementAddress.IP, managementAddress.Port)
+	config.SetManagementAddress(managementAddress.IP, managementAddress.Port)
 
 	return &openVpnClient{
 		config:     config,

--- a/openvpn/client.go
+++ b/openvpn/client.go
@@ -38,12 +38,7 @@ type openVpnClient struct {
 }
 
 // NewClient creates openvpn client with given config params
-func NewClient(openvpnBinary string, config *ClientConfig, directoryRuntime string, middlewares ...management.Middleware) *openVpnClient {
-	managementAddress, err := management.GetAvailableAddress()
-	if err != nil {
-		return nil
-	}
-
+func NewClient(openvpnBinary string, config *ClientConfig, managementAddress *management.Address, middlewares ...management.Middleware) *openVpnClient {
 	// Add the management interface socketAddress to the config
 	config.SetManagementSocket(managementAddress.IP, managementAddress.Port)
 

--- a/openvpn/config.go
+++ b/openvpn/config.go
@@ -58,8 +58,8 @@ func (c *Config) setFlag(name string) {
 	)
 }
 
-// SetManagementSocket creates unix socket style socket option for communication with openvpn process
-func (c *Config) SetManagementSocket(address string, port int) {
+// SetManagementAddress creates a TCP socket option for communication with openvpn process
+func (c *Config) SetManagementAddress(address string, port int) {
 	socketAddress := fmt.Sprintf("%s:%d", address, port)
 
 	c.setParam("management", socketAddress)

--- a/openvpn/config.go
+++ b/openvpn/config.go
@@ -20,6 +20,7 @@ package openvpn
 import (
 	"path/filepath"
 	"strconv"
+	"fmt"
 )
 
 // NewConfig creates new openvpn configuration structure and takes configuration directory as parameter for file param serialization
@@ -58,8 +59,10 @@ func (c *Config) setFlag(name string) {
 }
 
 // SetManagementSocket creates unix socket style socket option for communication with openvpn process
-func (c *Config) SetManagementSocket(socketAddress string) {
-	c.setParam("management", socketAddress+" unix")
+func (c *Config) SetManagementSocket(address string, port int) {
+	socketAddress := fmt.Sprintf("%s:%d", address, port)
+
+	c.setParam("management", socketAddress)
 	c.setFlag("management-client")
 }
 

--- a/openvpn/management/address.go
+++ b/openvpn/management/address.go
@@ -5,8 +5,12 @@ import (
 	"fmt"
 	"strings"
 	"strconv"
+	"github.com/kataras/iris/core/errors"
 )
 
+/**
+ * Used for OpenVPN management connection
+ */
 type Address struct {
 	IP   string
 	Port int
@@ -16,6 +20,12 @@ func (ma *Address) String() string {
 	return fmt.Sprintf("%s:%d", ma.IP, ma.Port)
 }
 
+/*
+ * Finds an available TCP port on 127.0.0.1
+ *
+ * OpenVPN management connection needs to listen on a known port
+ * using this method we can figure out which port/address to use
+ */
 func GetAvailableAddress() (*Address, error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -24,17 +34,24 @@ func GetAvailableAddress() (*Address, error) {
 
 	defer l.Close()
 
+	// get the actual bound address/port
 	address := l.Addr().(*net.TCPAddr)
 
 	return &Address{address.IP.String(), address.Port}, nil
 }
 
-func GetAddressFromString(address string) Address {
+func GetPortAndAddressFromString(address string) (*Address, error) {
 	str := strings.Split(address, ":")
-	port, _ := strconv.Atoi(str[1])
 
-	return Address{
-		IP:   str[0],
-		Port: port,
+	if len(str) < 2 {
+		return nil, errors.New("Failed to parse address string.")
 	}
+
+	port, err := strconv.Atoi(str[1])
+
+	if err != nil {
+		return nil, errors.New("Failed to parse port number.")
+	}
+
+	return &Address{str[0], port}, nil
 }

--- a/openvpn/management/address.go
+++ b/openvpn/management/address.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package management
 
 import (

--- a/openvpn/management/address.go
+++ b/openvpn/management/address.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"strconv"
-	"github.com/kataras/iris/core/errors"
+	"errors"
 )
 
 /**
@@ -29,7 +29,7 @@ func (ma *Address) String() string {
 func GetAvailableAddress() (*Address, error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, err
+		return nil, errors.New("Failed to open a connection for port discovery.")
 	}
 
 	defer l.Close()

--- a/openvpn/management/address.go
+++ b/openvpn/management/address.go
@@ -1,0 +1,40 @@
+package management
+
+import (
+	"net"
+	"fmt"
+	"strings"
+	"strconv"
+)
+
+type Address struct {
+	IP   string
+	Port int
+}
+
+func (ma *Address) String() string {
+	return fmt.Sprintf("%s:%d", ma.IP, ma.Port)
+}
+
+func GetAvailableAddress() (*Address, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	defer l.Close()
+
+	address := l.Addr().(*net.TCPAddr)
+
+	return &Address{address.IP.String(), address.Port}, nil
+}
+
+func GetAddressFromString(address string) Address {
+	str := strings.Split(address, ":")
+	port, _ := strconv.Atoi(str[1])
+
+	return Address{
+		IP:   str[0],
+		Port: port,
+	}
+}

--- a/openvpn/management/address_test.go
+++ b/openvpn/management/address_test.go
@@ -11,7 +11,26 @@ func TestAddress_String(t *testing.T) {
 }
 
 func TestGetAddressFromString(t *testing.T) {
-	addr := GetAddressFromString("127.0.0.1:8080")
+	addr, err := GetPortAndAddressFromString("127.0.0.1:8080")
+	assert.Nil(t, err)
 	assert.Equal(t, "127.0.0.1", addr.IP)
 	assert.Equal(t, 8080, addr.Port)
+}
+
+func TestGetAddressFromStringFails(t *testing.T) {
+	addr, err := GetPortAndAddressFromString("127.0.0.1::")
+	assert.Equal(t, "Failed to parse port number.", err.Error())
+	assert.Nil(t, addr)
+
+	addr, err = GetPortAndAddressFromString("::")
+	assert.Equal(t, "Failed to parse port number.", err.Error())
+	assert.Nil(t, addr)
+
+	addr, err = GetPortAndAddressFromString("127.0.0.1")
+	assert.Equal(t, "Failed to parse address string.", err.Error())
+	assert.Nil(t, addr)
+
+	addr, err = GetPortAndAddressFromString("")
+	assert.Equal(t, "Failed to parse address string.", err.Error())
+	assert.Nil(t, addr)
 }

--- a/openvpn/management/address_test.go
+++ b/openvpn/management/address_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package management
 
 import (

--- a/openvpn/management/address_test.go
+++ b/openvpn/management/address_test.go
@@ -1,0 +1,17 @@
+package management
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddress_String(t *testing.T) {
+	addr := Address{"127.0.0.1", 8080}
+	assert.Equal(t, "127.0.0.1:8080", addr.String())
+}
+
+func TestGetAddressFromString(t *testing.T) {
+	addr := GetAddressFromString("127.0.0.1:8080")
+	assert.Equal(t, "127.0.0.1", addr.IP)
+	assert.Equal(t, 8080, addr.Port)
+}

--- a/openvpn/server.go
+++ b/openvpn/server.go
@@ -66,7 +66,11 @@ type Server struct {
 func (server *Server) Start() error {
 	config := server.generateConfig()
 
-	address := management.GetAddressFromString(server.management.SocketAddress())
+	address, err := management.GetPortAndAddressFromString(server.management.SocketAddress())
+	if err != nil {
+		return err
+	}
+
 	config.SetManagementSocket(address.IP, address.Port)
 
 	// Start the management interface (if it isnt already started)

--- a/openvpn/server.go
+++ b/openvpn/server.go
@@ -71,7 +71,7 @@ func (server *Server) Start() error {
 		return err
 	}
 
-	config.SetManagementSocket(address.IP, address.Port)
+	config.SetManagementAddress(address.IP, address.Port)
 
 	// Start the management interface (if it isnt already started)
 	if err := server.management.Start(); err != nil {


### PR DESCRIPTION
Our current openvpn management connection is using unix sockets, this isn't supported in windows, therefore we need to switch to TCP.