### PR TITLE
Cleanup terminal colors after printing tests output

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -16,11 +16,20 @@ fi
 
 SUCCESS_COLOR='\033[0;32m' # green
 FAILURE_COLOR="\033[0;31m" # red
+DEFAULT_COLOR="\033[0m"
+
+print_success () {
+    echo -e $SUCCESS_COLOR$1$DEFAULT_COLOR
+}
+
+print_error () {
+    echo -e $FAILURE_COLOR$1$DEFAULT_COLOR
+}
 
 if go test -cover ${ARGUMENTS} ; then
-    echo -e $SUCCESS_COLOR"All tests passed."
+    print_success "All tests passed."
     exit 0
 else
-    echo -e $FAILURE_COLOR"Some tests failed!"
+    print_error "Some tests failed!"
     exit -1
 fi

--- a/bin/test_e2e
+++ b/bin/test_e2e
@@ -4,7 +4,7 @@ PROJECT_NAME="node_e2e_test"
 PROJECT_FILE="e2e/docker-compose.yml"
 SUCCESS_COLOR='\033[0;32m' # green
 FAILURE_COLOR="\033[0;31m" # red
-DEFAULT_COLOR="\033[0;0m"
+DEFAULT_COLOR="\033[0m"
 
 dockerComposeCmd="docker-compose -f $PROJECT_FILE -p $PROJECT_NAME"
 


### PR DESCRIPTION
Not cleaning them results in green errors:
<img width="283" alt="screen shot 2018-05-23 at 16 34 48" src="https://user-images.githubusercontent.com/1409983/40427995-f7a4f622-5ea7-11e8-803f-6f85dbe85fe3.png">
