### PR TITLE
Lower timeout of unit tests from default 10m to 3 m

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -19,7 +19,7 @@ if [ -z "$ARGUMENTS" ]; then
     ARGUMENTS=`go list ./... | sed '/e2e/d'` #skip e2e package - integration tests by default
 fi
 
-if go test -cover ${ARGUMENTS} ; then
+if go test -timeout 3m -cover ${ARGUMENTS} ; then
     print_success "All tests passed."
     exit 0
 else


### PR DESCRIPTION
We have unpleasant situation that some tests are deadlocking somewhere and travis jobs sometimes catches that. Currently there is no chance to debug that, because default test execution timeout is 10 min as travis job itself. Decreasing timeout of unit tests gives us a chance to see go routine stacktraces  on such cases.