### PR TITLE
Add 'healthcheck' command to CLI

### DIFF
--- a/cmd/commands/cli/command_cli.go
+++ b/cmd/commands/cli/command_cli.go
@@ -111,6 +111,7 @@ func (c *Command) handleActions(line string) {
 		{"help", c.help},
 		{"status", c.status},
 		{"proposals", c.proposals},
+		{"healthcheck", c.healthcheck},
 		{"ip", c.ip},
 		{"disconnect", c.disconnect},
 		{"stop", c.stopClient},
@@ -241,6 +242,22 @@ func (c *Command) status() {
 			info("Bytes received:", statistics.BytesReceived)
 		}
 	}
+}
+
+func (c *Command) healthcheck() {
+	healthcheck, err := c.tequilapi.Healthcheck()
+	if err != nil {
+		warn(err)
+		return
+	}
+
+	info(fmt.Sprintf("Uptime: %v", healthcheck.Uptime))
+	info(fmt.Sprintf("Process: %v", healthcheck.Process))
+	info(fmt.Sprintf("Version: %v", healthcheck.Version))
+	info("Build info:")
+	info(fmt.Sprintf("  Commit: %v", healthcheck.BuildInfo.Commit))
+	info(fmt.Sprintf("  Branch: %v", healthcheck.BuildInfo.Branch))
+	info(fmt.Sprintf("  Build number: %v", healthcheck.BuildInfo.Branch))
 }
 
 func (c *Command) proposals() {
@@ -404,6 +421,7 @@ func newAutocompleter(tequilapi *tequilapi_client.Client, proposals []tequilapi_
 			readline.PcItem("list"),
 		),
 		readline.PcItem("status"),
+		readline.PcItem("healthcheck"),
 		readline.PcItem("proposals"),
 		readline.PcItem("ip"),
 		readline.PcItem("disconnect"),

--- a/cmd/commands/cli/command_cli.go
+++ b/cmd/commands/cli/command_cli.go
@@ -254,10 +254,8 @@ func (c *Command) healthcheck() {
 	info(fmt.Sprintf("Uptime: %v", healthcheck.Uptime))
 	info(fmt.Sprintf("Process: %v", healthcheck.Process))
 	info(fmt.Sprintf("Version: %v", healthcheck.Version))
-	info("Build info:")
-	info(fmt.Sprintf("  Commit: %v", healthcheck.BuildInfo.Commit))
-	info(fmt.Sprintf("  Branch: %v", healthcheck.BuildInfo.Branch))
-	info(fmt.Sprintf("  Build number: %v", healthcheck.BuildInfo.Branch))
+	buildString := metadata.FormatString(healthcheck.BuildInfo.Commit, healthcheck.BuildInfo.Branch, healthcheck.BuildInfo.BuildNumber)
+	info(buildString)
 }
 
 func (c *Command) proposals() {

--- a/metadata/build_info.go
+++ b/metadata/build_info.go
@@ -32,5 +32,9 @@ var (
 
 // BuildAsString returns all defined build constants as single string
 func BuildAsString() string {
-	return fmt.Sprintf("Branch: %s. Build id: %s. Commit: %s", BuildBranch, BuildNumber, BuildCommit)
+	return FormatString(BuildCommit, BuildBranch, BuildNumber)
+}
+
+func FormatString(commit, branch, buildNumber string) string {
+	return fmt.Sprintf("Branch: %s. Build id: %s. Commit: %s", branch, buildNumber, commit)
 }

--- a/metadata/build_info.go
+++ b/metadata/build_info.go
@@ -35,6 +35,7 @@ func BuildAsString() string {
 	return FormatString(BuildCommit, BuildBranch, BuildNumber)
 }
 
+// FormatString formats build info to string with given build data
 func FormatString(commit, branch, buildNumber string) string {
 	return fmt.Sprintf("Branch: %s. Build id: %s. Commit: %s", branch, buildNumber, commit)
 }

--- a/metadata/build_info_test.go
+++ b/metadata/build_info_test.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package metadata
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFormatString(t *testing.T) {
+	assert.Equal(
+		t,
+		"Branch: master. Build id: 1234. Commit: b34a335019aaaae51256d8a33dfdef70ba08b075",
+		FormatString("b34a335019aaaae51256d8a33dfdef70ba08b075", "master", "1234"),
+	)
+}

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -149,6 +149,18 @@ func (client *Client) Status() (StatusDTO, error) {
 	return status, err
 }
 
+// Healthcheck returns a healthcheck info
+func (client *Client) Healthcheck() (healthcheck HealthcheckDTO, err error) {
+	response, err := client.http.Get("healthcheck", url.Values{})
+	if err != nil {
+		return
+	}
+
+	defer response.Body.Close()
+	err = parseResponseJSON(response, &healthcheck)
+	return healthcheck, err
+}
+
 // Proposals returns all available proposals for services
 func (client *Client) Proposals() ([]ProposalDTO, error) {
 	response, err := client.http.Get("proposals", url.Values{})

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -67,3 +67,18 @@ type IdentityDTO struct {
 type IdentityList struct {
 	Identities []IdentityDTO `json:"identities"`
 }
+
+// HealthcheckDTO holds returned healthcheck response
+type HealthcheckDTO struct {
+	Uptime    string       `json:"uptime"`
+	Process   int          `json:"process"`
+	Version   string       `json:"version"`
+	BuildInfo BuildInfoDTO `json:"buildInfo"`
+}
+
+// BuildInfoDTO holds info about build
+type BuildInfoDTO struct {
+	Commit      string `json:"commit"`
+	Branch      string `json:"branch"`
+	BuildNumber string `json:"buildNumber"`
+}


### PR DESCRIPTION
It's inconvenient to inspect mysterium client without healthcheck.

<img width="423" alt="screen shot 2018-07-05 at 11 05 12" src="https://user-images.githubusercontent.com/1409983/42310338-d73d2f54-8043-11e8-94af-8dda40f69957.png">
