### PR TITLE
Improvement/Merge client and server network options into single structure

### DIFF
--- a/cmd/commands/client/command_client.go
+++ b/cmd/commands/client/command_client.go
@@ -41,18 +41,9 @@ import (
 
 // NewCommand function creates new client command by given options
 func NewCommand(options CommandOptions) *Command {
-	networkDefinition := getNetworkDefinition(options)
-	return NewCommandWith(
-		options,
-		server.NewClient(networkDefinition.DiscoveryAPIAddress),
-	)
-}
+	networkDefinition := node_cmd.GetNetworkDefinition(options.NetworkOptions)
+	mysteriumClient := server.NewClient(networkDefinition.DiscoveryAPIAddress)
 
-// NewCommandWith does the same as NewCommand with possibility to override mysterium api client for external communication
-func NewCommandWith(
-	options CommandOptions,
-	mysteriumClient server.Client,
-) *Command {
 	nats_discovery.Bootstrap()
 	openvpn.Bootstrap()
 
@@ -177,21 +168,4 @@ func (cmd *Command) Kill() error {
 	log.Info("Api stopped")
 
 	return nil
-}
-
-// TODO this function can be aligned with server function when client and server options will merge into
-func getNetworkDefinition(options CommandOptions) metadata.NetworkDefinition {
-	network := metadata.DefaultNetwork
-
-	switch {
-	case options.Localnet:
-		network = metadata.LocalnetDefinition
-	}
-
-	//override defined values one by one from options
-	if options.DiscoveryAPIAddress != metadata.DefaultNetwork.DiscoveryAPIAddress {
-		network.DiscoveryAPIAddress = options.DiscoveryAPIAddress
-	}
-
-	return network
 }

--- a/cmd/commands/client/options.go
+++ b/cmd/commands/client/options.go
@@ -20,7 +20,6 @@ package client
 import (
 	"flag"
 	"github.com/mysterium/node/cmd"
-	"github.com/mysterium/node/metadata"
 	"path/filepath"
 )
 
@@ -39,11 +38,10 @@ type CommandOptions struct {
 	LicenseWarranty   bool
 	LicenseConditions bool
 
-	DiscoveryAPIAddress string
-	IpifyUrl            string
-
+	IpifyUrl         string
 	LocationDatabase string
-	Localnet         bool
+
+	cmd.NetworkOptions
 }
 
 // ParseArguments parses CLI flags and adds to CommandOptions structure
@@ -113,13 +111,6 @@ func ParseArguments(args []string) (options CommandOptions, err error) {
 	)
 
 	flags.StringVar(
-		&options.DiscoveryAPIAddress,
-		"discovery-address",
-		metadata.DefaultNetwork.DiscoveryAPIAddress,
-		"Address (URL form) of discovery service",
-	)
-
-	flags.StringVar(
 		&options.IpifyUrl,
 		"ipify-url",
 		"https://api.ipify.org/",
@@ -133,12 +124,7 @@ func ParseArguments(args []string) (options CommandOptions, err error) {
 		"Service location autodetect database of GeoLite2 format e.g. http://dev.maxmind.com/geoip/geoip2/geolite2/",
 	)
 
-	flags.BoolVar(
-		&options.Localnet,
-		"localnet",
-		false,
-		"Defines network configuration which expects localy deployed broker and discovery services",
-	)
+	cmd.ParseNetworkOptions(flags, &options.NetworkOptions)
 
 	err = flags.Parse(args[1:])
 	if err != nil {

--- a/cmd/commands/server/options.go
+++ b/cmd/commands/server/options.go
@@ -20,7 +20,6 @@ package server
 import (
 	"flag"
 	"github.com/mysterium/node/cmd"
-	"github.com/mysterium/node/metadata"
 	"path/filepath"
 )
 
@@ -37,9 +36,6 @@ type CommandOptions struct {
 	LocationCountry  string
 	LocationDatabase string
 
-	DiscoveryAPIAddress string
-	BrokerAddress       string
-
 	Version           bool
 	LicenseWarranty   bool
 	LicenseConditions bool
@@ -50,7 +46,7 @@ type CommandOptions struct {
 	OpenvpnPort int
 
 	AgreedTermsConditions bool
-	Localnet              bool
+	cmd.NetworkOptions
 }
 
 const defaultLocationDatabase = "GeoLite2-Country.mmdb"
@@ -122,19 +118,6 @@ func ParseArguments(args []string) (options CommandOptions, err error) {
 		"Service location country. If not given country is autodetected",
 	)
 
-	flags.StringVar(
-		&options.DiscoveryAPIAddress,
-		"discovery-address",
-		metadata.DefaultNetwork.DiscoveryAPIAddress,
-		"Address (URL form) of discovery service",
-	)
-	flags.StringVar(
-		&options.BrokerAddress,
-		"broker-address",
-		metadata.DefaultNetwork.BrokerAddress,
-		"Address (IP or domain name) of message broker",
-	)
-
 	flags.BoolVar(
 		&options.AgreedTermsConditions,
 		"agreed-terms-and-conditions",
@@ -168,12 +151,7 @@ func ParseArguments(args []string) (options CommandOptions, err error) {
 		"Address (URL form) of ipify service",
 	)
 
-	flags.BoolVar(
-		&options.Localnet,
-		"localnet",
-		false,
-		"Defines network configuration which expects localy deployed broker and discovery services",
-	)
+	cmd.ParseNetworkOptions(flags, &options.NetworkOptions)
 
 	err = flags.Parse(args[1:])
 	if err != nil {

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -80,7 +80,7 @@ func ParseNetworkOptions(flags *flag.FlagSet, options *NetworkOptions) {
 	flags.BoolVar(
 		&options.Testnet,
 		"testnet",
-		false,
+		true,
 		"Defines test network configuration",
 	)
 

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cmd
+
+import (
+	"flag"
+	"github.com/mysterium/node/metadata"
+)
+
+// NetworkOptions describes possible parameters of network configuration
+type NetworkOptions struct {
+	// DiscoveryAPIAddress defines address of discovery service
+	DiscoveryAPIAddress string
+	BrokerAddress       string
+	Localnet            bool
+	Testnet             bool
+}
+
+// GetNetworkDefinition function returns network definition combined from testnet/localnet flags and possible overrides
+func GetNetworkDefinition(options NetworkOptions) metadata.NetworkDefinition {
+	network := metadata.DefaultNetwork
+
+	switch {
+	case options.Testnet:
+		network = metadata.TestnetDefinition
+	case options.Localnet:
+		network = metadata.LocalnetDefinition
+	}
+
+	//override defined values one by one from options
+	if options.DiscoveryAPIAddress != metadata.DefaultNetwork.DiscoveryAPIAddress {
+		network.DiscoveryAPIAddress = options.DiscoveryAPIAddress
+	}
+
+	if options.BrokerAddress != metadata.DefaultNetwork.BrokerAddress {
+		network.BrokerAddress = options.BrokerAddress
+	}
+
+	return network
+}
+
+// ParseNetworkOptions function parses (or registers) network options from flag library
+func ParseNetworkOptions(flags *flag.FlagSet, options *NetworkOptions) {
+	flags.StringVar(
+		&options.DiscoveryAPIAddress,
+		"discovery-address",
+		metadata.DefaultNetwork.DiscoveryAPIAddress,
+		"Address (URL form) of discovery service",
+	)
+
+	flags.StringVar(
+		&options.BrokerAddress,
+		"broker-address",
+		metadata.DefaultNetwork.BrokerAddress,
+		"Address (IP or domain name) of message broker",
+	)
+
+	flags.BoolVar(
+		&options.Localnet,
+		"localnet",
+		false,
+		"Defines network configuration which expects localy deployed broker and discovery services",
+	)
+
+	flags.BoolVar(
+		&options.Testnet,
+		"testnet",
+		false,
+		"Defines test network configuration",
+	)
+
+}


### PR DESCRIPTION
1. New testnet option introduced (overrides any previously defined localnet)
2. Client and server network options now share common structure
3. Fuction to parse options from flags
4. Function to construct network definition from provided options