### PR TITLE
Updated go-homedir

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 47ad4023fef30b1530a180cb3751f54fc909765b9a87232a932df91c33cd29d4
-updated: 2018-08-08T16:26:30.362273+03:00
+hash: 3ea570ac2ccdb1094ce921eaa235022e4c94ad50439af00c7cc0978df568a8cc
+updated: 2018-08-13T10:53:12.577394+03:00
 imports:
 - name: github.com/aristanetworks/goarista
   version: b2d71c282dc706f4b4f6c15b65810e1202ecd53f
@@ -57,7 +57,7 @@ imports:
 - name: github.com/mattn/go-isatty
   version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 - name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: 58046073cbffe2f25d425fe1331102f55cf719de
 - name: github.com/MysteriumNetwork/payments
   version: 6fd859db4476d7a7630b88210b3b3ffc874dcf4d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,7 @@ import:
 - package: github.com/julienschmidt/httprouter
   version: 1.1.0
 - package: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: 58046073cbffe2f25d425fe1331102f55cf719de
 - package: github.com/chzyer/readline
   version: 1.4.0
 - package: github.com/oschwald/geoip2-golang


### PR DESCRIPTION
`mysterium_client` failed to run in launchd context due to bug in go-homedir. This PR updates package version which includes a needed fix.

https://github.com/mitchellh/go-homedir/pull/24