### PR TITLE
Use single equals in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 	@echo "\nSee README.md for more."
 
 glide:
-	if [ "$(CMD_GLIDE)" == "" ] ; then curl https://glide.sh/get | sh ; fi
+	if [ "$(CMD_GLIDE)" = "" ] ; then curl https://glide.sh/get | sh ; fi
 
 dep:
 	glide install

--- a/bin/test
+++ b/bin/test
@@ -19,7 +19,7 @@ if [ -z "$ARGUMENTS" ]; then
     ARGUMENTS=`go list ./... | sed '/e2e/d'` #skip e2e package - integration tests by default
 fi
 
-if go test -timeout 3m -cover ${ARGUMENTS} ; then
+if go test -race -timeout 3m -cover ${ARGUMENTS} ; then
     print_success "All tests passed."
     exit 0
 else


### PR DESCRIPTION
Currently we use double equals ('==') within a shell test statement that uses single square brackets.  The standard comparison operator is '=' not '==' for single square brackets.   Although '==' works in `bash` it does
not work in all shells (e.g. `zsh`).

Use standard comparison operation '='

Signed-off-by: Tobin C. Harding <me@tobin.cc>