### PR TITLE
added a step to update go report cards on master commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,10 @@ jobs:
       - bin/release_docker dev
       name: "Pushing dev docker images"
 
+    - script:
+      - bin/helpers/go-reports-update.sh
+      name: "Update Go Report Card"
+
     # Official release (on tags only)
     - stage: release
       script: bin/s3 sync s3://build-artifacts build/package

--- a/bin/helpers/go-reports-update.sh
+++ b/bin/helpers/go-reports-update.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -d "repo=github.com/mysteriumnetwork/node" https://goreportcard.com/checks


### PR DESCRIPTION
At the moment go report cards were not updated ever. Until I updated manually, we had a report card that was 7 months old.