### PR TITLE
Smaller final binaries

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -24,7 +24,7 @@ export GOARCH=${GOARCH:-`go env GOHOSTARCH`}
 export GOBIN=`pwd`/build/myst
 echo "Compiling 'myst' for '$GOOS/$GOARCH'.."
 
-go build -ldflags="$(get_linker_ldflags)" -o $GOBIN/myst cmd/mysterium_node/mysterium_node.go 
+go build -ldflags="-w -s $(get_linker_ldflags)" -o $GOBIN/myst cmd/mysterium_node/mysterium_node.go 
 if [ $? -ne 0 ]; then
     print_error "Compile failed!"
     exit 1

--- a/bin/build_xgo
+++ b/bin/build_xgo
@@ -36,7 +36,7 @@ xgo \
     --targets="$XGO_TARGETS" \
     --dest=${DIR_TEMP} \
     --out=myst \
-    --ldflags="$(get_linker_ldflags)" \
+    --ldflags="-w -s $(get_linker_ldflags)" \
     $(pwd)/cmd/mysterium_node
 
 # Remove version from binary name:


### PR DESCRIPTION
Removing the debug information from binaries reduces the size of `myst` binary from 19MB to 13MB.