### PR TITLE
Fixed travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,12 @@ jobs:
 
     # Test stage
     - stage: test
-      script: bin/test_e2e
+      script: bin/test
+      name: "Unit tests"
+
+    - script: bin/test_e2e
       name: "End-to-end tests"
       if: type = pull_request
-
-    - script: bin/test
-      name: "Unit tests"
 
     - script: bin/builder_run bin/check_golint
       name: "golint check"


### PR DESCRIPTION
The "End-to-end tests" job in the `test` stage have a condition for running only on pull requests. 
And if we are running build without pull request whole `test` stage is ignored because of this condition and other jobs going to stage for getting dependencies. And sometimes jobs starting before dependencies properly downloaded. 
This PR changes the order of jobs in `test` stage to skip only "E2E tests" for non pull requests builds.
