### PR TITLE
Cherrypick of "Identity check disabled by default, added flag to enable it. #363"

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -223,8 +223,12 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 	}
 
 	log.Info("Using Eth contract at address: ", network.PaymentsContractAddress.String())
-	if di.IdentityRegistry, err = identity_registry.NewIdentityRegistryContract(di.EtherClient, network.PaymentsContractAddress); err != nil {
-		return err
+	if options.IdentityCheck {
+		if di.IdentityRegistry, err = identity_registry.NewIdentityRegistryContract(di.EtherClient, network.PaymentsContractAddress); err != nil {
+			return err
+		}
+	} else {
+		di.IdentityRegistry = &identity_registry.FakeRegistry{Registered: true, RegistrationEventExists: true}
 	}
 
 	return nil

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -223,7 +223,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 	}
 
 	log.Info("Using Eth contract at address: ", network.PaymentsContractAddress.String())
-	if options.IdentityCheck {
+	if options.ExperimentIdentityCheck {
 		if di.IdentityRegistry, err = identity_registry.NewIdentityRegistryContract(di.EtherClient, network.PaymentsContractAddress); err != nil {
 			return err
 		}

--- a/cmd/flags_directory.go
+++ b/cmd/flags_directory.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 
@@ -26,40 +25,6 @@ import (
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/urfave/cli"
 )
-
-// ParseDirectoryArguments function takes directory options and fills in values from FlagSet structure
-func ParseDirectoryArguments(flags *flag.FlagSet, options *node.OptionsDirectory) error {
-
-	userHomeDir, err := homedir.Dir()
-	if err != nil {
-		return err
-	}
-
-	currentDir, err := getExecutableDir()
-	if err != nil {
-		return err
-	}
-
-	flags.StringVar(
-		&options.Data,
-		"data-dir",
-		filepath.Join(userHomeDir, ".mysterium"),
-		"Data directory containing keystore & other persistent files",
-	)
-	flags.StringVar(
-		&options.Config,
-		"config-dir",
-		filepath.Join(currentDir, "config"),
-		"Configs directory containing all configuration, script and helper files",
-	)
-	flags.StringVar(
-		&options.Runtime,
-		"runtime-dir",
-		currentDir,
-		"Runtime writable directory for temp files",
-	)
-	return nil
-}
 
 const (
 	dataDirFlag    = "data-dir"

--- a/cmd/flags_network.go
+++ b/cmd/flags_network.go
@@ -18,64 +18,10 @@
 package cmd
 
 import (
-	"flag"
-
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/urfave/cli"
 )
-
-// ParseArgumentsNetwork function parses (or registers) network options from flag library
-func ParseArgumentsNetwork(flags *flag.FlagSet, options *node.OptionsNetwork) {
-	flags.StringVar(
-		&options.DiscoveryAPIAddress,
-		"discovery-address",
-		metadata.DefaultNetwork.DiscoveryAPIAddress,
-		"Address (URL form) of discovery service",
-	)
-
-	flags.StringVar(
-		&options.BrokerAddress,
-		"broker-address",
-		metadata.DefaultNetwork.BrokerAddress,
-		"Address (IP or domain name) of message broker",
-	)
-
-	flags.BoolVar(
-		&options.Localnet,
-		"localnet",
-		false,
-		"Defines network configuration which expects locally deployed broker and discovery services",
-	)
-
-	flags.BoolVar(
-		&options.Testnet,
-		"testnet",
-		false,
-		"Defines test network configuration",
-	)
-
-	flags.BoolVar(
-		&options.ExperimentIdentityCheck,
-		"experiment-identity-check",
-		false,
-		"Enables experimental identity check",
-	)
-
-	flags.StringVar(
-		&options.EtherClientRPC,
-		"ether.client.rpc",
-		metadata.DefaultNetwork.EtherClientRPC,
-		"Url or IPC socket to connect to ethereum node, anything what ethereum client accepts - works",
-	)
-
-	flags.StringVar(
-		&options.EtherPaymentsAddress,
-		"ether.contract.payments",
-		metadata.DefaultNetwork.PaymentsContractAddress.String(),
-		"Address of payments contract",
-	)
-}
 
 var (
 	testFlag = cli.BoolFlag{

--- a/cmd/flags_network.go
+++ b/cmd/flags_network.go
@@ -56,7 +56,7 @@ func ParseArgumentsNetwork(flags *flag.FlagSet, options *node.OptionsNetwork) {
 	)
 
 	flags.BoolVar(
-		&options.IdentityCheck,
+		&options.ExperimentIdentityCheck,
 		"experiment-identity-check",
 		false,
 		"Enables experimental identity check",

--- a/cmd/flags_network.go
+++ b/cmd/flags_network.go
@@ -55,6 +55,13 @@ func ParseArgumentsNetwork(flags *flag.FlagSet, options *node.OptionsNetwork) {
 		"Defines test network configuration",
 	)
 
+	flags.BoolVar(
+		&options.IdentityCheck,
+		"experiment-identity-check",
+		false,
+		"Enables experimental identity check",
+	)
+
 	flags.StringVar(
 		&options.EtherClientRPC,
 		"ether.client.rpc",
@@ -78,6 +85,11 @@ var (
 	localnetFlag = cli.BoolFlag{
 		Name:  "localnet",
 		Usage: "Defines network configuration which expects locally deployed broker and discovery services",
+	}
+
+	identityCheckFlag = cli.BoolFlag{
+		Name:  "experiment-identity-check",
+		Usage: "Enables experimental identity check",
 	}
 
 	discoveryAddressFlag = cli.StringFlag{
@@ -108,6 +120,7 @@ func RegisterFlagsNetwork(flags *[]cli.Flag) {
 	*flags = append(
 		*flags,
 		testFlag, localnetFlag,
+		identityCheckFlag,
 		discoveryAddressFlag, brokerAddressFlag,
 		etherRpcFlag, etherContractPaymentsFlag,
 	)
@@ -118,6 +131,8 @@ func ParseFlagsNetwork(ctx *cli.Context) node.OptionsNetwork {
 	return node.OptionsNetwork{
 		ctx.GlobalBool(testFlag.Name),
 		ctx.GlobalBool(localnetFlag.Name),
+
+		ctx.GlobalBool(identityCheckFlag.Name),
 
 		ctx.GlobalString(discoveryAddressFlag.Name),
 		ctx.GlobalString(brokerAddressFlag.Name),

--- a/core/node/options_network.go
+++ b/core/node/options_network.go
@@ -22,6 +22,8 @@ type OptionsNetwork struct {
 	Testnet  bool
 	Localnet bool
 
+	IdentityCheck bool
+
 	DiscoveryAPIAddress string
 	BrokerAddress       string
 

--- a/core/node/options_network.go
+++ b/core/node/options_network.go
@@ -22,7 +22,7 @@ type OptionsNetwork struct {
 	Testnet  bool
 	Localnet bool
 
-	IdentityCheck bool
+	ExperimentIdentityCheck bool
 
 	DiscoveryAPIAddress string
 	BrokerAddress       string

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     command: >
       --ipify-url=http://ipify:3000
       --location.country=e2e-land
+      --experiment-identity-check
       --localnet
       --broker-address=broker
       --discovery-address=http://discovery/v1
@@ -43,6 +44,7 @@ services:
       - 4050
     command: >
       --ipify-url=http://ipify:3000
+      --experiment-identity-check
       --localnet
       --discovery-address=http://discovery/v1
       --ether.client.rpc=http://geth:8545


### PR DESCRIPTION
- We still need **paid-identity off (by default)** for upcoming 0.4 release (Quality Oracle)
- **paid-identity off (by default)** is very useful in developer environment