### PR TITLE
Initial mobile entrypoint for iOS/Swift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,11 @@ jobs:
       name: "Windows packages"
 
     - script:
+      - bin/package_ios amd64
+      - bin/s3 sync build/package s3://build-artifacts
+      name: "iOS packages"
+
+    - script:
       - bin/package_docker
       - docker save myst:alpine | gzip > myst_alpine.tgz
       - bin/s3 cp myst_alpine.tgz s3://docker-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,11 @@ jobs:
       name: "iOS packages"
 
     - script:
+      - bin/package_android amd64
+      - bin/s3 sync build/package s3://build-artifacts
+      name: "Android packages"
+
+    - script:
       - bin/package_docker
       - docker save myst:alpine | gzip > myst_alpine.tgz
       - bin/s3 cp myst_alpine.tgz s3://docker-images

--- a/bin/package/ios/Carthage.json
+++ b/bin/package/ios/Carthage.json
@@ -1,0 +1,4 @@
+{
+  "0.5.0": "https://releases.mysterium.network/Mysterium.framework-0.5.0.zip",
+  "0.5.0-rc1": "https://releases.mysterium.network/Mysterium.framework.zip"
+}

--- a/bin/package/ios/Info.plist
+++ b/bin/package/ios/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>17G65</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Mysterium</string>
+	<key>CFBundleIdentifier</key>
+	<string>network.mysterium.sdk.ios</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Mysterium</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.5.0-rc1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>70</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>9F2000</string>
+	<key>DTPlatformVersion</key>
+	<string>GM</string>
+	<key>DTSDKBuild</key>
+	<string>17E189</string>
+	<key>DTSDKName</key>
+	<string>macosx10.13</string>
+	<key>DTXcode</key>
+	<string>0941</string>
+	<key>DTXcodeBuild</key>
+	<string>10A255</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (C) 2018 The "MysteriumNetwork/node" Authors.</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+	</array>
+</dict>
+</plist>

--- a/bin/package_android
+++ b/bin/package_android
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+###########################################################################
+# Packaging script which creates Android AAR (Android Archive).
+#
+# Usage:
+#> bin/package_android <architecture>
+#
+# Package (specific architecture: arm64, arm):
+#> bin/package_android arm64
+
+set -e
+
+source bin/helpers/output.sh
+source bin/helpers/functions.sh
+
+ARCH=$1
+if [[ ! "$ARCH" =~ ^(arm64|arm)$ ]]; then
+    print_error "Missing architecture! Should be: arm64, arm"
+    exit 1
+fi
+
+DIR_BUILD="build/package"
+PACKAGE_FILE="${DIR_BUILD}/Mysterium.aar"
+
+gomobile bind -v \
+    -target=android/${ARCH} \
+    -o $PACKAGE_FILE \
+    github.com/mysteriumnetwork/node/mobile/mysterium
+
+rm ${DIR_BUILD}/Mysterium-sources.jar
+
+print_success "Android package '$PACKAGE_FILE' complete!"
+exit 0

--- a/bin/package_android
+++ b/bin/package_android
@@ -14,21 +14,9 @@ set -e
 source bin/helpers/output.sh
 source bin/helpers/functions.sh
 
-ARCH=$1
-if [[ ! "$ARCH" =~ ^(arm64|arm)$ ]]; then
-    print_error "Missing architecture! Should be: arm64, arm"
-    exit 1
-fi
-
 DIR_BUILD="build/package"
-PACKAGE_FILE="${DIR_BUILD}/Mysterium.aar"
 
-gomobile bind -v \
-    -target=android/${ARCH} \
-    -o $PACKAGE_FILE \
-    github.com/mysteriumnetwork/node/mobile/mysterium
-
-rm ${DIR_BUILD}/Mysterium-sources.jar
+xgo -image=mysteriumnetwork/xgo:1.11 -targets=android/* -v -out Mysterium -dest $DIR_BUILD `pwd`/mobile/mysterium
 
 print_success "Android package '$PACKAGE_FILE' complete!"
 exit 0

--- a/bin/package_android
+++ b/bin/package_android
@@ -16,7 +16,7 @@ source bin/helpers/functions.sh
 
 DIR_BUILD="build/package"
 
-xgo -image=mysteriumnetwork/xgo:1.11 -targets=android/* -v -out Mysterium -dest $DIR_BUILD `pwd`/mobile/mysterium
+xgo -image=mysteriumnetwork/xgo:1.11 -targets=android/* -out Mysterium -dest $DIR_BUILD `pwd`/mobile/mysterium
 
 print_success "Android package '$PACKAGE_FILE' complete!"
 exit 0

--- a/bin/package_ios
+++ b/bin/package_ios
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+###########################################################################
+# Packaging script which creates iOS framework (Swift compatible).
+#
+# Usage:
+#> bin/package_ios <architecture>
+#
+# Package (specific architecture: arm64, amd64):
+#> bin/package_ios arm64
+
+set -e
+
+source bin/helpers/output.sh
+source bin/helpers/functions.sh
+
+ARCH=$1
+if [[ ! "$ARCH" =~ ^(arm64|amd64)$ ]]; then
+    print_error "Missing architecture! Should be: arm64, amd64"
+    exit 1
+fi
+
+DIR_BUILD="build/package"
+PACKAGE_FILE="${DIR_BUILD}/Mysterium.framework"
+
+gomobile bind -v \
+    -target=ios/${ARCH} \
+    -o $PACKAGE_FILE \
+    github.com/mysteriumnetwork/node/mobile/mysterium
+
+print_success "iOS package '$PACKAGE_FILE' complete!"
+exit 0

--- a/bin/package_ios
+++ b/bin/package_ios
@@ -14,21 +14,13 @@ set -e
 source bin/helpers/output.sh
 source bin/helpers/functions.sh
 
-ARCH=$1
-if [[ ! "$ARCH" =~ ^(arm64|amd64)$ ]]; then
-    print_error "Missing architecture! Should be: arm64, amd64"
-    exit 1
-fi
-
 DIR_BUILD="build/package"
+mkdir -p $DIR_BUILD
 PACKAGE_FILE="${DIR_BUILD}/Mysterium.framework.zip"
 DIR_TEMP=`mktemp -d ${DIR_BUILD}/${tempname}.XXXXXX`
 DIR_FRAMEWORK="${DIR_TEMP}/Mysterium.framework"
 
-gomobile bind -v \
-    -target=ios/${ARCH} \
-    -o ${DIR_FRAMEWORK} \
-    github.com/mysteriumnetwork/node/mobile/mysterium
+xgo -image=mysteriumnetwork/xgo:1.11 -targets=ios/* -v -out Mysterium -dest $DIR_TEMP `pwd`/mobile/mysterium
 
 cp bin/package/ios/Info.plist ${DIR_FRAMEWORK}/Versions/A/Resources/Info.plist
 
@@ -36,4 +28,3 @@ cp bin/package/ios/Info.plist ${DIR_FRAMEWORK}/Versions/A/Resources/Info.plist
 rm -rf ${DIR_TEMP}
 
 print_success "iOS package '$PACKAGE_FILE' complete!"
-exit 0

--- a/bin/package_ios
+++ b/bin/package_ios
@@ -20,7 +20,7 @@ PACKAGE_FILE="${DIR_BUILD}/Mysterium.framework.zip"
 DIR_TEMP=`mktemp -d ${DIR_BUILD}/${tempname}.XXXXXX`
 DIR_FRAMEWORK="${DIR_TEMP}/Mysterium.framework"
 
-xgo -image=mysteriumnetwork/xgo:1.11 -targets=ios/* -v -out Mysterium -dest $DIR_TEMP `pwd`/mobile/mysterium
+xgo -image=mysteriumnetwork/xgo:1.11 -targets=ios/* -out Mysterium -dest $DIR_TEMP `pwd`/mobile/mysterium
 
 cp bin/package/ios/Info.plist ${DIR_FRAMEWORK}/Versions/A/Resources/Info.plist
 

--- a/bin/package_ios
+++ b/bin/package_ios
@@ -21,12 +21,19 @@ if [[ ! "$ARCH" =~ ^(arm64|amd64)$ ]]; then
 fi
 
 DIR_BUILD="build/package"
-PACKAGE_FILE="${DIR_BUILD}/Mysterium.framework"
+PACKAGE_FILE="${DIR_BUILD}/Mysterium.framework.zip"
+DIR_TEMP=`mktemp -d ${DIR_BUILD}/${tempname}.XXXXXX`
+DIR_FRAMEWORK="${DIR_TEMP}/Mysterium.framework"
 
 gomobile bind -v \
     -target=ios/${ARCH} \
-    -o $PACKAGE_FILE \
+    -o ${DIR_FRAMEWORK} \
     github.com/mysteriumnetwork/node/mobile/mysterium
+
+cp bin/package/ios/Info.plist ${DIR_FRAMEWORK}/Versions/A/Resources/Info.plist
+
+(cd ${DIR_TEMP} && zip -r - .) > ${PACKAGE_FILE}
+rm -rf ${DIR_TEMP}
 
 print_success "iOS package '$PACKAGE_FILE' complete!"
 exit 0

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -96,13 +96,14 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 
 	log.Infof("Starting Mysterium Node (%s)", metadata.VersionAsString())
 
-	if err := nodeOptions.Directories.Check(); err != nil {
-		return err
-	}
-
-	if err := nodeOptions.Openvpn.Check(); err != nil {
-		return err
-	}
+	// TODO Implement different check for in "mobile" package
+	//if err := nodeOptions.Directories.Check(); err != nil {
+	//	return err
+	//}
+	//
+	//if err := nodeOptions.Openvpn.Check(); err != nil {
+	//	return err
+	//}
 
 	if err := di.bootstrapNetworkComponents(nodeOptions.OptionsNetwork); err != nil {
 		return err

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -96,10 +96,9 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 
 	log.Infof("Starting Mysterium Node (%s)", metadata.VersionAsString())
 
-	// TODO Implement different check for in "mobile" package
-	//if err := nodeOptions.Directories.Check(); err != nil {
-	//	return err
-	//}
+	if err := nodeOptions.Directories.Check(); err != nil {
+		return err
+	}
 	//
 	//if err := nodeOptions.Openvpn.Check(); err != nil {
 	//	return err

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -99,10 +99,10 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	if err := nodeOptions.Directories.Check(); err != nil {
 		return err
 	}
-	//
-	//if err := nodeOptions.Openvpn.Check(); err != nil {
-	//	return err
-	//}
+
+	if err := nodeOptions.Openvpn.Check(); err != nil {
+		return err
+	}
 
 	if err := di.bootstrapNetworkComponents(nodeOptions.OptionsNetwork); err != nil {
 		return err
@@ -207,7 +207,8 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 
 	connectionFactory := service_openvpn.NewProcessBasedConnectionFactory(
 		di.MysteriumClient,
-		nodeOptions.Openvpn.BinaryPath,
+		// TODO instead of passing binary path here, Openvpn from node options could represent abstract vpn factory itself
+		nodeOptions.Openvpn.BinaryPath(),
 		nodeOptions.Directories.Config,
 		nodeOptions.Directories.Runtime,
 		di.StatsKeeper,

--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -59,8 +59,23 @@ func ParseFlagsNode(ctx *cli.Context) node.Options {
 		ctx.GlobalString(tequilapiAddressFlag.Name),
 		ctx.GlobalInt(tequilapiPortFlag.Name),
 
-		openvpn_core.ParseFlags(ctx),
+		wrapper{nodeOptions: openvpn_core.ParseFlags(ctx)},
 		ParseFlagsLocation(ctx),
 		ParseFlagsNetwork(ctx),
 	}
 }
+
+// TODO this struct will disappear when we unify go-openvpn embedded lib and external process based session creation/handling
+type wrapper struct {
+	nodeOptions openvpn_core.NodeOptions
+}
+
+func (w wrapper) Check() error {
+	return w.nodeOptions.Check()
+}
+
+func (w wrapper) BinaryPath() string {
+	return w.nodeOptions.BinaryPath
+}
+
+var _ node.Openvpn = wrapper{}

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -17,7 +17,12 @@
 
 package node
 
-import openvpn_core "github.com/mysteriumnetwork/go-openvpn/openvpn/core"
+// Openvpn interface is abstraction over real openvpn options to unblock mobile development
+// will disappear as soon as go-openvpn will unify common factory for openvpn creation
+type Openvpn interface {
+	Check() error
+	BinaryPath() string
+}
 
 // Options describes options which are required to start Node
 type Options struct {
@@ -26,7 +31,7 @@ type Options struct {
 	TequilapiAddress string
 	TequilapiPort    int
 
-	Openvpn  openvpn_core.NodeOptions
+	Openvpn  Openvpn
 	Location OptionsLocation
 	OptionsNetwork
 }

--- a/core/node/options_directory.go
+++ b/core/node/options_directory.go
@@ -40,12 +40,14 @@ type OptionsDirectory struct {
 
 // Check checks that configured dirs exist (which should contain info) and runtime dirs are created (if not exist)
 func (options *OptionsDirectory) Check() error {
-	err := ensureDirExists(options.Config)
-	if err != nil {
-		return err
-	}
 
-	err = ensureOrCreateDir(options.Runtime)
+	if options.Config != "" {
+		err := ensureDirExists(options.Config)
+		if err != nil {
+			return err
+		}
+	}
+	err := ensureOrCreateDir(options.Runtime)
 	if err != nil {
 		return err
 	}

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -24,7 +24,6 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/mitchellh/go-homedir"
-	openvpn_core "github.com/mysteriumnetwork/go-openvpn/openvpn/core"
 	"github.com/mysteriumnetwork/node/cmd"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/node"
@@ -66,7 +65,7 @@ func NewNode(appPath string) (*MobileNode, error) {
 		TequilapiPort:    4050,
 
 		// TODO Make Openvpn pluggable connection optional
-		Openvpn: openvpn_core.NodeOptions{},
+		Openvpn: noOpenvpnYet{},
 
 		Location: node.OptionsLocation{
 			IpifyUrl: "https://api.ipify.org/",
@@ -130,3 +129,16 @@ func (mobNode *MobileNode) Shutdown() error {
 func (mobNode *MobileNode) WaitUntilDies() error {
 	return mobNode.di.Node.Wait()
 }
+
+type noOpenvpnYet struct {
+}
+
+func (noOpenvpnYet) Check() error {
+	return nil
+}
+
+func (noOpenvpnYet) BinaryPath() string {
+	panic("implement me")
+}
+
+var _ node.Openvpn = noOpenvpnYet{}

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -32,17 +32,22 @@ import (
 )
 
 // NewNode function creates new Node
-func NewNode() {
+func NewNode(appPath string) {
 	var di cmd.Dependencies
 
-	userHomeDir, err := homedir.Dir()
-	if err != nil {
-		panic(err)
+	var dataDir, currentDir string
+	if appPath == "" {
+		currentDir, err := homedir.Dir()
+		if err != nil {
+			panic(err)
+		}
+		dataDir = filepath.Join(currentDir, ".mysterium")
+	} else {
+		dataDir = filepath.Join(appPath, ".mysterium")
+		currentDir = appPath
 	}
-	dataDir := filepath.Join(userHomeDir, ".mysterium")
-	currentDir := userHomeDir
 
-	err = di.Bootstrap(node.Options{
+	err := di.Bootstrap(node.Options{
 		Directories: node.OptionsDirectory{
 			Data:     dataDir,
 			Storage:  filepath.Join(dataDir, "db"),

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/metadata"
 	service_noop "github.com/mysteriumnetwork/node/services/noop"
 )
 
@@ -62,7 +63,14 @@ func NewNode() {
 			"",
 			"LT",
 		},
-		node.OptionsNetwork{Testnet: true},
+		node.OptionsNetwork{
+			true,
+			false,
+			metadata.TestnetDefinition.DiscoveryAPIAddress,
+			metadata.TestnetDefinition.BrokerAddress,
+			metadata.TestnetDefinition.EtherClientRPC,
+			metadata.DefaultNetwork.PaymentsContractAddress.String(),
+		},
 	})
 	if err != nil {
 		panic(err)
@@ -76,7 +84,7 @@ func NewNode() {
 	di.ConnectionRegistry.Register("openvpn", service_noop.NewConnectionCreator())
 
 	// TODO Remove later, this is for initial green path test only
-	testConnectFlow(&di, identity.FromAddress("0xd961ebabbdc17b7f82a18ef4f575d9e06f5a412d"))
+	//testConnectFlow(&di, identity.FromAddress("0xd961ebabbdc17b7f82a18ef4f575d9e06f5a412d"))
 
 	// TODO Return node startup/runtime errors to mobile
 	err = di.Node.Wait()

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysterium
+
+import (
+	"path/filepath"
+
+	log "github.com/cihub/seelog"
+	"github.com/mitchellh/go-homedir"
+	openvpn_core "github.com/mysteriumnetwork/go-openvpn/openvpn/core"
+	"github.com/mysteriumnetwork/node/cmd"
+	"github.com/mysteriumnetwork/node/core/node"
+)
+
+// NewNode function creates new Node
+func NewNode() {
+	var di cmd.Dependencies
+
+	userHomeDir, err := homedir.Dir()
+	if err != nil {
+		panic(err)
+	}
+	dataDir := filepath.Join(userHomeDir, ".mysterium")
+	currentDir := userHomeDir
+
+	err = di.Bootstrap(node.Options{
+		node.OptionsDirectory{
+			dataDir,
+			filepath.Join(dataDir, "db"),
+			filepath.Join(dataDir, "keystore"),
+			// TODO Embbed all config file to released artifacts
+			filepath.Join(currentDir, "config"),
+			// TODO Where to save runtime data
+			currentDir,
+		},
+
+		"127.0.0.1",
+		4050,
+
+		openvpn_core.NodeOptions{},
+		node.OptionsLocation{
+			"https://api.ipify.org/",
+			// TODO Embbed location DB to released artifacts
+			"",
+			"LT",
+		},
+		node.OptionsNetwork{Testnet: true},
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		log.Info("Shutdown Mysterium Node")
+		di.Shutdown()
+	}()
+
+	proposals, err := di.MysteriumClient.FindProposals("0xd961ebabbdc17b7f82a18ef4f575d9e06f5a412d")
+	if err != nil {
+		panic(err)
+	}
+	if len(proposals) < 1 {
+		panic("No FI server found")
+	}
+
+	log.Infof("Proposals: %#v", proposals)
+
+	// TODO Return node startup/runtime errors to mobile
+	err = di.Node.Wait()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -32,6 +32,7 @@ import (
 	service_noop "github.com/mysteriumnetwork/node/services/noop"
 )
 
+// MobileNode represents node object tuned for mobile devices
 type MobileNode struct {
 	di cmd.Dependencies
 }
@@ -88,6 +89,7 @@ func NewNode(appPath string) (*MobileNode, error) {
 	return &MobileNode{di}, nil
 }
 
+// TestConnectFlow checks whenever connection can be successfully established
 func (mobNode *MobileNode) TestConnectFlow() error {
 	consumers := mobNode.di.IdentityManager.GetIdentities()
 	var consumerID identity.Identity
@@ -119,10 +121,12 @@ func (mobNode *MobileNode) TestConnectFlow() error {
 	return mobNode.di.ConnectionManager.Disconnect()
 }
 
+// Shutdown function stops running mobile node
 func (mobNode *MobileNode) Shutdown() error {
 	return mobNode.di.Node.Kill()
 }
 
+// WaitUntilDies function returns when node stops
 func (mobNode *MobileNode) WaitUntilDies() error {
 	return mobNode.di.Node.Wait()
 }

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -138,7 +138,7 @@ func (noOpenvpnYet) Check() error {
 }
 
 func (noOpenvpnYet) BinaryPath() string {
-	panic("implement me")
+	return "no openvpn binary available on mobile"
 }
 
 var _ node.Openvpn = noOpenvpnYet{}

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -43,33 +43,32 @@ func NewNode() {
 	currentDir := userHomeDir
 
 	err = di.Bootstrap(node.Options{
-		node.OptionsDirectory{
-			dataDir,
-			filepath.Join(dataDir, "db"),
-			filepath.Join(dataDir, "keystore"),
+		Directories: node.OptionsDirectory{
+			Data:     dataDir,
+			Storage: filepath.Join(dataDir, "db"),
+			Keystore: filepath.Join(dataDir, "keystore"),
 			// TODO Embbed all config file to released artifacts
-			filepath.Join(currentDir, "config"),
+			Config: filepath.Join(currentDir, "config"),
 			// TODO Where to save runtime data
-			currentDir,
+			Runtime: currentDir,
 		},
 
-		"127.0.0.1",
-		4050,
+		TequilapiAddress: "127.0.0.1",
+		TequilapiPort:    4050,
 
-		openvpn_core.NodeOptions{},
-		node.OptionsLocation{
-			"https://api.ipify.org/",
-			// TODO Embbed location DB to released artifacts
-			"",
-			"LT",
+		// TODO Make Openvpn pluggable connection optional
+		Openvpn: openvpn_core.NodeOptions{},
+
+		Location: node.OptionsLocation{
+			IpifyUrl: "https://api.ipify.org/",
+			Country:  "LT",
 		},
-		node.OptionsNetwork{
-			true,
-			false,
-			metadata.TestnetDefinition.DiscoveryAPIAddress,
-			metadata.TestnetDefinition.BrokerAddress,
-			metadata.TestnetDefinition.EtherClientRPC,
-			metadata.DefaultNetwork.PaymentsContractAddress.String(),
+		OptionsNetwork: node.OptionsNetwork{
+			Testnet:              true,
+			DiscoveryAPIAddress:  metadata.TestnetDefinition.DiscoveryAPIAddress,
+			BrokerAddress:        metadata.TestnetDefinition.BrokerAddress,
+			EtherClientRPC:       metadata.TestnetDefinition.EtherClientRPC,
+			EtherPaymentsAddress: metadata.DefaultNetwork.PaymentsContractAddress.String(),
 		},
 	})
 	if err != nil {

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -45,7 +45,7 @@ func NewNode() {
 	err = di.Bootstrap(node.Options{
 		Directories: node.OptionsDirectory{
 			Data:     dataDir,
-			Storage: filepath.Join(dataDir, "db"),
+			Storage:  filepath.Join(dataDir, "db"),
 			Keystore: filepath.Join(dataDir, "keystore"),
 			// TODO Embbed all config file to released artifacts
 			Config: filepath.Join(currentDir, "config"),

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -81,7 +81,7 @@ func newServerConfigFactory(nodeOptions node.Options, serviceOptions Options) Se
 func newServerFactory(nodeOptions node.Options, sessionValidator *openvpn_session.Validator) ServerFactory {
 	return func(config *openvpn_service.ServerConfig) openvpn.Process {
 		return openvpn.CreateNewProcess(
-			nodeOptions.Openvpn.BinaryPath,
+			nodeOptions.Openvpn.BinaryPath(),
 			config.GenericConfig,
 			auth.NewMiddleware(sessionValidator.Validate, sessionValidator.Cleanup),
 			state.NewMiddleware(vpnStateCallback),


### PR DESCRIPTION
```
https://releases.mysterium.network/Carthage.json

import UIKit
import Mysterium

@UIApplicationMain
class AppDelegate: UIResponder, UIApplicationDelegate {
    
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
        
        MysteriumNewNode()
        print("Node created!!!")
        
        return true
    }

}
```

Updates #447

Leftover:
- [x] Create Xcode project with Golang compilation (in `research-ios`)
- [ ] Xcode Golang compile should have checksum
- [x] Inject ConnectionManager to DI container #446
- [x] Create dummy transport for ConnectionManager #446 
- [ ] ConnectionManager.Start() starts callbacking NetworkExtension for read/write of packets
- [ ] ConnectionManager.Stop() stop read/write of packets in NetworkExtension
- [x] TODO Implement different check for in "mobile" package
- [x] TODO Embbed all config file to released artifacts
- [x] TODO Where to save runtime data
- [x] TODO Embbed location DB to released artifacts #281
- [x] TODO Return node startup/runtime errors to mobile
- [x] Release artefact for iOS `gomobile bind -target=ios/arm64 -v github.com/mysteriumnetwork/node/mobile` #466 
- [ ] Strip debug symbols from .framework artefact
