### PR TITLE
Reduce noise when running `check_golint`

### DIFF
--- a/bin/check_golint
+++ b/bin/check_golint
@@ -20,7 +20,9 @@ check_uncleaned_package () {
 
     PACKAGE_MESSAGES=`echo "${MESSAGES_ERROR}" | grep "${PACKAGE}"`
     PACKAGE_MESSAGES_COUNT=`echo -n "${PACKAGE_MESSAGES}" | grep -c '^'`
-    print_warning "[warning] ${PACKAGE_MESSAGES_COUNT} messages in '${PACKAGE}': \n${PACKAGE_MESSAGES}\n"
+    if [ ${PACKAGE_MESSAGES_COUNT} -gt 0 ]; then
+	print_warning "[warning] ${PACKAGE_MESSAGES_COUNT} messages in '${PACKAGE}': \n${PACKAGE_MESSAGES}\n"
+    fi
 
     MESSAGES_ERROR=`echo -n "${MESSAGES_ERROR}" | grep -v "${PACKAGE}"`
     if [ ${PACKAGE_MESSAGES_COUNT} -eq 0 ]; then


### PR DESCRIPTION
Currently `check_golint` script prints a bunch (5) of warning lines when there are _no_ messages to warn about, such as this (including the newlines):
```
[warning] 0 messages in 'github.com/mysteriumnetwork/node/identity': 


```
This is a off putting; if there are no issues there should be no output.  If 0 messages implies some error then we should warn about that explicitly (I don't know if this is the case so this patch takes the first route).

Only print warning message if there are more than 0 messages to show.

Signed-off-by: Tobin C. Harding <me@tobin.cc>