### PR TITLE
Fix call to `golint` in script `check_golint`

### DIFF
--- a/bin/check_golint
+++ b/bin/check_golint
@@ -37,7 +37,11 @@ if [ -z "$ARGUMENTS" ]; then
     ARGUMENTS=`go list ./...`
 fi
 
-MESSAGES_ERROR=`golint --set_exit_status --min_confidence=1 ${ARGUMENTS} 2>/dev/null`
+MESSAGES_ERROR=()
+for arg in ${ARGUMENTS[@]}; do
+    MESSAGES_ERROR+=`golint --set_exit_status --min_confidence=1 ${arg} 2>/dev/null`
+done
+
 MESSAGES_RECONFIGURE=()
 
 check_uncleaned_package "github.com/mysteriumnetwork/node/identity" 6


### PR DESCRIPTION
Currently `check_golint` is broken.  The current invocation of `golint` is failing when arguments are a list.  

This can be seen by calling `golint` directly from the command line with the same invocation as within the script and a list of two arguments:
```
$ golint --set_exit_status --min_confidence=1  github.com/mysteriumnetwork/node/client/stats github.com/mysteriumnetwork/node/cmd
open github.com/mysteriumnetwork/node/client/stats: no such file or directory
open github.com/mysteriumnetwork/node/cmd: no such file or directory
```

We can fix this by calling `golint` in a loop with a single argument each time instead of passing `golint` a list.

Call `golint` in a loop collecting the error messages into the array.

Signed-off-by: Tobin C. Harding <me@tobin.cc>