### PR TITLE
Force bin/build to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,11 @@ dep:
 dep-ensure:
 	dep ensure
 
-build:
+build: FORCE
 	./bin/build
 
 build-image:
 	./bin/package_docker
+
+FORCE: ;
+


### PR DESCRIPTION
Currently `make build` does not run because make depends on the timestamp of `bin/build` instead of on the timestamps of source files. We can just force the script to run.

Force `bin/build` to run when invoked via `make build`.

Signed-off-by: Tobin C. Harding <me@tobin.cc>