### PR TITLE
Add Tequilapi client timeout

### DIFF
--- a/tequilapi/api_test_utils.go
+++ b/tequilapi/api_test_utils.go
@@ -32,7 +32,7 @@ type TestClient interface {
 
 type testClient struct {
 	t       *testing.T
-	baseUrl string
+	baseURL string
 }
 
 // NewTestClient returns client for making test requests
@@ -44,7 +44,7 @@ func NewTestClient(t *testing.T, address string) TestClient {
 }
 
 func (tc *testClient) Get(path string) *http.Response {
-	resp, err := http.Get(tc.baseUrl + path)
+	resp, err := http.Get(tc.baseURL + path)
 	if err != nil {
 		assert.FailNow(tc.t, "Uh oh catched error: ", err.Error())
 	}

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -28,7 +28,7 @@ import (
 // NewClient returns a new instance of Client
 func NewClient(ip string, port int) *Client {
 	return &Client{
-		http: newHttpClient(
+		http: newHTTPClient(
 			fmt.Sprintf("http://%s:%d", ip, port),
 			"[Tequilapi.Client] ",
 			"goclient-v0.1",

--- a/tequilapi/client/http_client.go
+++ b/tequilapi/client/http_client.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	log "github.com/cihub/seelog"
 )
@@ -43,6 +44,7 @@ func newHTTPClient(baseURL string, logPrefix string, ua string) *httpClient {
 	return &httpClient{
 		http: &http.Client{
 			Transport: &http.Transport{},
+			Timeout:   time.Second * 120,
 		},
 		baseURL:   baseURL,
 		logPrefix: logPrefix,

--- a/tequilapi/client/http_client.go
+++ b/tequilapi/client/http_client.go
@@ -39,12 +39,12 @@ type httpRequestInterface interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func newHttpClient(baseUrl string, logPrefix string, ua string) *httpClient {
+func newHttpClient(baseURL string, logPrefix string, ua string) *httpClient {
 	return &httpClient{
 		http: &http.Client{
 			Transport: &http.Transport{},
 		},
-		baseUrl:   baseUrl,
+		baseURL:   baseURL,
 		logPrefix: logPrefix,
 		ua:        ua,
 	}
@@ -52,13 +52,13 @@ func newHttpClient(baseUrl string, logPrefix string, ua string) *httpClient {
 
 type httpClient struct {
 	http      httpRequestInterface
-	baseUrl   string
+	baseURL   string
 	logPrefix string
 	ua        string
 }
 
 func (client *httpClient) Get(path string, values url.Values) (*http.Response, error) {
-	basePath := fmt.Sprintf("%v/%v", client.baseUrl, path)
+	basePath := fmt.Sprintf("%v/%v", client.baseURL, path)
 
 	var fullPath string
 	params := values.Encode()
@@ -89,7 +89,7 @@ func (client httpClient) doPayloadRequest(method, path string, payload interface
 		return nil, err
 	}
 
-	return client.executeRequest(method, client.baseUrl+"/"+path, payloadJSON)
+	return client.executeRequest(method, client.baseURL+"/"+path, payloadJSON)
 }
 
 func (client *httpClient) executeRequest(method, fullPath string, payloadJSON []byte) (*http.Response, error) {

--- a/tequilapi/client/http_client.go
+++ b/tequilapi/client/http_client.go
@@ -39,7 +39,7 @@ type httpRequestInterface interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func newHttpClient(baseURL string, logPrefix string, ua string) *httpClient {
+func newHTTPClient(baseURL string, logPrefix string, ua string) *httpClient {
 	return &httpClient{
 		http: &http.Client{
 			Transport: &http.Transport{},


### PR DESCRIPTION
As described in issue #386 current tequilapi client does not use a timeout.  In current go version (1.11) stdlib `http.Client` does implement timeout functionality (also available in 1.9 and 1.10).

From `/usr/lib/go/src/net/http/client.go` (golang version 1.11.1):
```	
// A Client is an HTTP client. Its zero value (DefaultClient) is a
// usable client that uses DefaultTransport.
...
type Client struct {
...
// Timeout specifies a time limit for requests made by this
// Client. The timeout includes connection time, any
// redirects, and reading the response body. The timer remains
// running after Get, Head, Post, or Do return and will
// interrupt reading of the Response.Body.
//
// A Timeout of zero means no timeout.
//
// The Client cancels requests to the underlying Transport
// as if the Request's Context ended.
//
// For compatibility, the Client will also use the deprecated
// CancelRequest method on Transport if found. New
// RoundTripper implementations should use the Request's Context
// for cancelation instead of implementing CancelRequest.
Timeout time.Duration
```

We can use this to add a timeout to the tequilapi client.

First do a couple of clean up patches in `tequilapi/client`, with this PR applied `tequilapi/client/*.go` lint cleanly.  Use capital letters for acronyms as is standard Golang convention.  Then add timeout of 120 seconds to the tequilapi client.

Tested by setting timeout to 1 nanosecond and running client
```
build/myst/myst cli                                                                                                                           ✱ (git:tequilapi-timeout)
2018-10-18T05:02:55.358443336 [Info] Starting Mysterium Node (source.dev-build)
2018-10-18T05:02:55.361336074 [Info] [Openvpn check] OpenVPN 2.4.4 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] built on Sep  5 2018
2018-10-18T05:02:55.361379991 [Info] [Openvpn check] library versions: OpenSSL 1.1.0g  2 Nov 2017, LZO 2.08
2018-10-18T05:02:55.36139322 [Info] [Openvpn check] Originally developed by James Yonan
2018-10-18T05:02:55.361395925 [Info] [Openvpn check] Copyright (C) 2002-2017 OpenVPN Technologies, Inc. <sales@openvpn.net>
2018-10-18T05:02:55.361401316 [Info] [Openvpn check] Compile time defines: enable_async_push=no enable_comp_stub=no enable_crypto=yes enable_crypto_ofb_cfb=yes enable_debug=yes enable_def_auth=yes enable_dependency_tracking=no enable_dlopen=unknown enable_dlopen_self=unknown enable_dlopen_self_static=unknown enable_fast_install=needless enable_fragment=yes enable_iproute2=yes enable_libtool_lock=yes enable_lz4=yes enable_lzo=yes enable_maintainer_mode=no enable_management=yes enable_multihome=yes enable_pam_dlopen=no enable_pedantic=no enable_pf=yes enable_pkcs11=yes enable_plugin_auth_pam=yes enable_plugin_down_root=yes enable_plugins=yes enable_port_share=yes enable_selinux=no enable_server=yes enable_shared=yes enable_shared_with_static_runtimes=no enable_silent_rules=no enable_small=no enable_static=yes enable_strict=no enable_strict_options=no enable_systemd=yes enable_werror=no enable_win32_dll=yes enable_x509_alt_username=yes with_aix_soname=aix with_crypto_library=openssl with_gnu_ld=yes with_mem_check=no with_sysroot=no
2018-10-18T05:02:55.361412963 [Info] Using Eth endpoint: https://ropsten.infura.io
2018-10-18T05:02:55.361433519 [Info] Using Eth contract at address: 0xbe5F9CCea12Df756bF4a5Baf4c29A10c3ee7C83B
timeout
```

Closes: #386

Signed-off-by: Tobin C. Harding <me@tobin.cc> 