### PR TITLE
Quit cli when receiving command `quit`

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -332,7 +332,7 @@ func (c *cliApp) help() {
 
 // quit stops cli and client commands and exits application
 func (c *cliApp) quit() {
-	stop := utils.SoftKiller(c.Kill)
+	stop := utils.HardKiller(c.Kill)
 	stop()
 }
 


### PR DESCRIPTION
Currently the cli does not quit when told to.  We can use the `HardKiller` instead of the `SoftKiller` to fix this.

Closes #462

Signed-off-by: Tobin C. Harding <me@tobin.cc>