### PR TITLE
Semantic version for dev releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ env:
     - BUILD_VERSION=$TRAVIS_TAG
 
 before_install:
-  - if [ -z "${BUILD_VERSION/dev/}" ]; then export BUILD_VERSION="0-dev.$TRAVIS_BUILD_NUMBER"; fi
+  - if [ -z "$BUILD_VERSION" ]; then
+      export BUILD_VERSION=$(curl -s https://api.github.com/repos/${TRAVIS_REPO_SLUG}/releases |
+      jq -r '( first(.[]  | select(.prerelease == true)) ) | .tag_name');
+    fi
 
 cache:
   directories:
@@ -94,9 +97,9 @@ jobs:
     # Development bleeding-edge release (on master commits only)
     - stage: release-dev
       script:
-        - git tag -f dev
+        - git tag -f $BUILD_VERSION
         - git remote add gh https://${TRAVIS_REPO_SLUG%/*}:${GIT_RELEASES_API_KEY}@github.com/${TRAVIS_REPO_SLUG}.git
-        - git push -f gh dev
+        - git push -f gh $BUILD_VERSION
 
     - script:
       - bin/release_goreport
@@ -119,7 +122,7 @@ jobs:
       - docker load -i build/docker/myst_alpine.tgz
       - docker load -i build/docker/myst_ubuntu.tgz
       - bin/release_docker $TRAVIS_TAG
-      - if [ "$TRAVIS_TAG" != "dev" ]; then bin/release_docker latest; fi
+      - if [[ $TRAVIS_TAG != *-rc ]]; then bin/release_docker latest; fi
       name: "Pushing release to hub.docker.com"
 
 notifications:


### PR DESCRIPTION
This PR allows using versions like `0.5-rc` for pre-releases. 

Closes #434