### PR TITLE
Added token usage for Github API calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ env:
 
 before_install:
   - if [ -z "$BUILD_VERSION" ]; then
-      export BUILD_VERSION=$(curl -s https://api.github.com/repos/${TRAVIS_REPO_SLUG}/releases |
-      jq -r '( first(.[]  | select(.prerelease == true)) ) | .tag_name');
+      export BUILD_VERSION=$(
+        curl -s -H "Authorization:token $GIT_RELEASES_API_KEY"
+        https://api.github.com/repos/${TRAVIS_REPO_SLUG}/releases |
+        jq -r '( first(.[]  | select(.prerelease == true)) ) | .tag_name');
     fi
 
 cache:


### PR DESCRIPTION
Github limits the number of API calls, and since we are running our scripts on public and shared CI, there is a big chance that this limit already reached. 

This PR adds token usage to for API calls to extend this limit. 