### PR TITLE
Add filter to cli command 'proposals'

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -121,7 +121,6 @@ func (c *cliApp) handleActions(line string) {
 		{"quit", c.quit},
 		{"help", c.help},
 		{"status", c.status},
-		{"proposals", c.proposals},
 		{"healthcheck", c.healthcheck},
 		{"ip", c.ip},
 		{"disconnect", c.disconnect},
@@ -138,6 +137,7 @@ func (c *cliApp) handleActions(line string) {
 		{command: "version", handler: c.version},
 		{command: "license", handler: c.license},
 		{command: "registration", handler: c.registration},
+		{command: "proposals", handler: c.proposals},
 	}
 
 	for _, cmd := range staticCmds {
@@ -278,18 +278,30 @@ func (c *cliApp) healthcheck() {
 	info(buildString)
 }
 
-func (c *cliApp) proposals() {
+func (c *cliApp) proposals(filter string) {
 	proposals := c.fetchProposals()
 	c.fetchedProposals = proposals
-	info(fmt.Sprintf("Found %v proposals", len(proposals)))
+
+	filterMsg := ""
+	if filter != "" {
+		filterMsg = fmt.Sprintf("(filter: '%s')", filter)
+	}
+	info(fmt.Sprintf("Found %v proposals %s", len(proposals), filterMsg))
 
 	for _, proposal := range proposals {
 		country := proposal.ServiceDefinition.LocationOriginate.Country
 		if country == "" {
 			country = "Unknown"
 		}
+
 		msg := fmt.Sprintf("- provider id: %v, proposal id: %v, country: %v", proposal.ProviderID, proposal.ID, country)
-		info(msg)
+
+		if filter == "" ||
+			strings.Contains(proposal.ProviderID, filter) ||
+			strings.Contains(country, filter) {
+
+			info(msg)
+		}
 	}
 }
 


### PR DESCRIPTION
Currently when using the cli and running command `proposals` we get all
the proposals back.  It would be nice to be able to narrow down the
search i.e using a filter.  We can filter based on the country and also
the provider ID.

Add filter term to command `proposals`.  No documentation added.  Needs
extending to include something in the output of `help` to show that this
feature exists.

With this applied
```
» proposals SG
2018-10-23T05:59:50.896303068 [Info] [Mysterium.api] Proposals fetched: 41
[INFO] Found 41 proposals (filter: 'SG')
[INFO] - provider id: 0x44ceda7262fcc48d591ee468c8a7319585d51aee, proposal id: 1, country: SG
[INFO] - provider id: 0xeed4ee266b2175a7f4063ecd59eef414b60f9d1d, proposal id: 1, country: SG
[INFO] - provider id: 0xf03f364719d09b37260872735c113baaee4f4f1a, proposal id: 1, country: SG
```

Signed-off-by: Tobin C. Harding <me@tobin.cc>