### PR TITLE
cli: Warn if identity not passed to `registration`

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -387,6 +387,10 @@ func (c *cliApp) identities(argsString string) {
 }
 
 func (c *cliApp) registration(argsString string) {
+	if argsString == "" {
+		warn("Please supply identity")
+		return
+	}
 	status, err := c.tequilapi.IdentityRegistrationStatus(argsString)
 	if err != nil {
 		warn("Something went wrong: ", err)


### PR DESCRIPTION
Currently when using the cli if a user enters the command `registration`
without passing an identity they will get the obscure error:

```
[WARNING] Something went wrong:  server response invalid: 500 Internal Server Error (http://127.0.0.1:4053/identities//registration). Possible error: authentication needed: password or unlock
» 1541471455617838612 [Error] [Tequilapi.Client] server response invalid: 500 Internal Server Error (http://127.0.0.1:4053/identities//registration). Possible error: authentication needed: password or unlock
```

There is no indication in the cli that an identity must be passed to
this command.  We can make the user experience better by checking for
the identity and explicitly warning if not present.

Add warning if identity is not passed in a argument to `registration`.

With this applied we get:
```
» registration
[WARNING] Please supply identity
```

Signed-off-by: tcharding <me@tobin.cc>