### PR TITLE
cli: Warn if unknown sub-command passed to `identities`

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -342,6 +342,14 @@ func (c *cliApp) identities(argsString string) {
 		return
 	}
 
+	switch argsString {
+	case "new", "list": // Known sub-commands.
+	default:
+		warnf("Unknown sub-command '%s'\n", argsString)
+		fmt.Println(usage)
+		return
+	}
+
 	args := strings.Fields(argsString)
 	if len(args) < 1 {
 		info(usage)

--- a/cmd/commands/cli/io.go
+++ b/cmd/commands/cli/io.go
@@ -36,6 +36,11 @@ func warn(items ...interface{}) {
 	fmt.Println(items...)
 }
 
+func warnf(format string, items ...interface{}) {
+	fmt.Printf(warningColor + "[WARNING] \033[0m")
+	fmt.Printf(format, items...)
+}
+
 func success(items ...interface{}) {
 	fmt.Printf(successColor + "[SUCCESS] \033[0m")
 	fmt.Println(items...)


### PR DESCRIPTION
Currently if a user passes an unknown sub-command to the `identities`
command we fail silently.  We check for zero args and provide usage, we
might as well check for incorrect args and provide usage also.  This
gives us `identities help` for free.

Add check on the sub command for `identities` and print usage string if
incorrect.

Signed-off-by: tcharding <me@tobin.cc>