### PR TITLE
connection tests now do not race

### DIFF
--- a/core/connection/stub_connection.go
+++ b/core/connection/stub_connection.go
@@ -61,7 +61,17 @@ func (cff *connectionFactoryFake) CreateConnection(connectionParams ConnectOptio
 		}
 	}
 	cff.mockConnection.StateCallback(stateCallback)
-	return cff.mockConnection, nil
+
+	// we copy the values over, so that the factory always returns a new instance of connection
+	copy := connectionFake{
+		onStartReportStates: cff.mockConnection.onStartReportStates,
+		onStartReturnError:  cff.mockConnection.onStartReturnError,
+		onStopReportStates:  cff.mockConnection.onStopReportStates,
+		stateCallback:       cff.mockConnection.stateCallback,
+		fakeProcess:         sync.WaitGroup{},
+	}
+
+	return &copy, nil
 }
 
 type connectionFake struct {


### PR DESCRIPTION
The connection factory used for testing was implemented incorrectly. The factory always returned the same instance, so in situations where the connection was created multiple times a race condition could occur, since the state of the same connection was being mutated.