### PR TITLE
 Solved swagger errors

### DIFF
--- a/identity/registry/endpoints.go
+++ b/identity/registry/endpoints.go
@@ -85,8 +85,8 @@ func newRegistrationEndpoint(dataProvider RegistrationDataProvider, statusProvid
 //   - in: path
 //     name: id
 //     description: hex address of identity
-//     example: "0x0000000000000000000000000000000000000001"
 //     type: string
+//     required: true
 // responses:
 //   200:
 //     description: Registration status and data

--- a/tequilapi/doc.go
+++ b/tequilapi/doc.go
@@ -29,5 +29,7 @@
 //   Produces:
 //   - application/json
 //
+//   Version: dev
+//
 // swagger:meta
 package tequilapi

--- a/tequilapi/endpoints/identities.go
+++ b/tequilapi/endpoints/identities.go
@@ -160,7 +160,6 @@ func (endpoint *identitiesAPI) Create(resp http.ResponseWriter, request *http.Re
 // - name: id
 //   in: path
 //   description: Identity stored in keystore
-//   example: "0x0000000000000000000000000000000000000001"
 //   type: string
 //   required: true
 // - in: body
@@ -214,7 +213,6 @@ func (endpoint *identitiesAPI) Register(resp http.ResponseWriter, request *http.
 // - in: path
 //   name: id
 //   description: Identity stored in keystore
-//   example: "0x0000000000000000000000000000000000000001"
 //   type: string
 //   required: true
 // - in: body

--- a/tequilapi/endpoints/proposals.go
+++ b/tequilapi/endpoints/proposals.go
@@ -117,13 +117,11 @@ func NewProposalsEndpoint(mc server.Client, morqaClient metrics.QualityOracle) *
 //   - in: query
 //     name: providerId
 //     description: id of provider proposals
-//     example: "0x0000000000000000000000000000000000000001"
 //     type: string
 // parameters:
 //   - in: query
 //     name: serviceType
 //     description: the service type of the proposal
-//     example: "openvpn"
 //     type: string
 // responses:
 //   200:


### PR DESCRIPTION
- solves errors from `bin/swagger_generate && swagger validate tequilapi.json`
- fixed json can be used with ReDoc 