### PR TITLE
do not tag latest docker image for dev releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ jobs:
       - docker load -i build/docker/myst_alpine.tgz
       - docker load -i build/docker/myst_ubuntu.tgz
       - bin/release_docker $TRAVIS_TAG
-      - if [[ $TRAVIS_TAG != *-rc ]]; then bin/release_docker latest; fi
+      - if [[ $TRAVIS_TAG != *-rc ]] || [[ $TRAVIS_TAG != *-dev ]]; then bin/release_docker latest; fi
       name: "Pushing release to hub.docker.com"
     - script:
       - bin/s3 sync s3://travis-$TRAVIS_BUILD_NUMBER/build-artifacts build/package


### PR DESCRIPTION
We plan to have not xx-rc, but 0.0.0-dev releases for our master. 