### PR TITLE
Check if tequilapi.json is valid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,11 @@ jobs:
     - script: bin/check_govet
       name: "govet check"
 
+    - script:
+      - go get github.com/go-swagger/go-swagger/cmd/swagger/
+      - bin/check_swagger
+      name: "swagger check"
+
     # Build artifacts
     - stage: build
       script:

--- a/bin/check
+++ b/bin/check
@@ -9,3 +9,4 @@ bin/check_govet
 bin/check_golint
 bin/check_goimports
 bin/check_license
+bin/check_swagger

--- a/bin/check_swagger
+++ b/bin/check_swagger
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Checks whether swagger spec at "tequilapi.json" is valid against swagger specification 2.0.
+
+source bin/helpers/output.sh
+
+# generate tequilapi.json
+bin/swagger_generate
+
+# validate
+spec_file="tequilapi.json"
+validation_output=`swagger validate $spec_file 2>&1`
+
+# check if spec is valid
+found_errors=`echo $validation_output | grep 'is invalid against swagger specification'`
+if [[ $found_errors != "" ]]; then
+    echo "$validation_output"
+    print_error "Swagger specification has errors."
+    exit 1
+fi
+
+print_success "Swagger specification is valid."
+exit 0
+


### PR DESCRIPTION
- checks whether swagger spec at "tequilapi.json" is valid against swagger specification 2.0.
- added this check to travis