### PR TITLE
do not kill openvpn connect with different clientID

### DIFF
--- a/services/openvpn/session/client_map.go
+++ b/services/openvpn/session/client_map.go
@@ -33,7 +33,8 @@ type SessionMap interface {
 
 // clientMap extends current sessions with client id metadata from Openvpn
 type clientMap struct {
-	sessions         SessionMap
+	sessions SessionMap
+	// TODO: use clientID to kill OpenVPN session (client-kill {clientID}) when promise processor instructs so
 	sessionClientIDs map[session.ID]int
 	sessionMapLock   sync.Mutex
 }
@@ -45,10 +46,7 @@ func (cm *clientMap) FindClientSession(clientID int, id session.ID) (session.Ses
 		return session.Session{}, false, errors.New("no underlying session exists, possible break-in attempt")
 	}
 
-	sessionClientID, clientIDExist := cm.sessionClientIDs[id]
-	if clientIDExist && clientID != sessionClientID {
-		return sessionInstance, false, errors.New("provided clientID does not mach active clientID")
-	}
+	_, clientIDExist := cm.sessionClientIDs[id]
 
 	return sessionInstance, clientIDExist, nil
 }

--- a/services/openvpn/session/manager_auth_middleware_test.go
+++ b/services/openvpn/session/manager_auth_middleware_test.go
@@ -145,7 +145,7 @@ func TestSecondClientIsNotDisconnectedWhenFirstClientDisconnects(t *testing.T) {
 
 }
 
-func TestSecondClientWithTheSameCredentialsIsDisconnected(t *testing.T) {
+func TestSecondClientWithTheSameCredentialsIsConnected(t *testing.T) {
 	var firstClientConnected = []string{
 		">CLIENT:CONNECT,1,4",
 		">CLIENT:ENV,username=Boop!",
@@ -180,9 +180,9 @@ func TestSecondClientWithTheSameCredentialsIsDisconnected(t *testing.T) {
 	assert.True(t, fas.called)
 	assert.Equal(t, "Boop!", fas.username)
 	assert.Equal(t, "V6ifmvLuAT+hbtLBX/0xm3C0afywxTIdw1HqLmA4onpwmibHbxVhl50Gr3aRUZMqw1WxkfSIVdhpbCluHGBKsgE=", fas.password)
-	// second authentication with the same credentials but with different clientID should fail
+	// second authentication with the same credentials but with different clientID should succeed
 
-	assert.Equal(t, "client-deny 2 4 internal error", mockMangement.LastLine)
+	assert.Equal(t, "client-auth-nt 2 4", mockMangement.LastLine)
 }
 
 func feedLinesToMiddleware(middleware management.Middleware, lines []string) {

--- a/services/openvpn/session/validator_test.go
+++ b/services/openvpn/session/validator_test.go
@@ -65,14 +65,14 @@ func TestValidateReturnsTrueWhenSessionExistsAndSignatureIsValid(t *testing.T) {
 	assert.True(t, authenticated)
 }
 
-func TestValidateReturnsFalseWhenSessionExistsAndSignatureIsValidAndClientIDDiffers(t *testing.T) {
+func TestValidateReturnsTrueWhenSessionExistsAndSignatureIsValidAndClientIDDiffers(t *testing.T) {
 	validator := mockValidatorWithSession(identityExisting, sessionExisting)
 
 	validator.Validate(1, sessionExistingString, "not important")
 	authenticated, err := validator.Validate(2, sessionExistingString, "not important")
 
-	assert.Errorf(t, err, "provided clientID does not mach active clientID")
-	assert.False(t, authenticated)
+	assert.NoError(t, err)
+	assert.True(t, authenticated)
 }
 
 func TestValidateReturnsTrueWhenSessionExistsAndSignatureIsValidAndClientIDMatches(t *testing.T) {


### PR DESCRIPTION
Left clientID storage intact since we gonna do openvpn session termination using clientID from promise processor. 

closes #589