### PR TITLE
Filter out unsupported proposals

### DIFF
--- a/bin/check_golint
+++ b/bin/check_golint
@@ -44,7 +44,6 @@ MESSAGES_RECONFIGURE=()
 
 check_uncleaned_package "github.com/mysteriumnetwork/node/identity" 6
 check_uncleaned_package "github.com/mysteriumnetwork/node/tequilapi" 10
-check_uncleaned_package "github.com/mysteriumnetwork/node/service_discovery/dto" 13
 check_uncleaned_package "github.com/mysteriumnetwork/node/money" 4
 
 MESSAGES_ERROR_COUNT=`echo -n "${MESSAGES_ERROR}" | grep -c '^'`

--- a/server/mysterium_api.go
+++ b/server/mysterium_api.go
@@ -153,9 +153,10 @@ func (mApi *mysteriumAPI) FindProposals(providerID string, serviceType string) (
 	if err != nil {
 		return nil, err
 	}
-
-	log.Info(mysteriumAPILogPrefix, "Proposals fetched: ", len(proposalsResponse.Proposals))
-	return proposalsResponse.Proposals, nil
+	total := len(proposalsResponse.Proposals)
+	supported := supportedProposalsOnly(proposalsResponse.Proposals)
+	log.Info(mysteriumAPILogPrefix, "Total proposals: ", total, " supported: ", len(supported))
+	return supported, nil
 }
 
 // SendSessionStats sends session statistics
@@ -200,4 +201,13 @@ func (mApi *mysteriumAPI) doRequestAndParseResponse(req *http.Request, responseV
 	}
 
 	return ParseResponseJSON(resp, responseValue)
+}
+
+func supportedProposalsOnly(proposals []dto_discovery.ServiceProposal) (supported []dto_discovery.ServiceProposal) {
+	for _, proposal := range proposals {
+		if proposal.IsSupported() {
+			supported = append(supported, proposal)
+		}
+	}
+	return
 }

--- a/service_discovery/dto/contact.go
+++ b/service_discovery/dto/contact.go
@@ -36,7 +36,7 @@ type Contact struct {
 	Definition ContactDefinition `json:"definition"`
 }
 
-// ContactDefinition is marker interface for contacts of all types
+// ContactDefinition is interface for contacts of all types
 type ContactDefinition interface {
 }
 
@@ -50,8 +50,8 @@ var _ ContactDefinition = UnsupportedContactType{}
 type ContactDefinitionUnserializer func(*json.RawMessage) (ContactDefinition, error)
 
 // contact unserializer registry
-// TODO avoid global map variables and wrap this functionality into some kind of compoment?
-var contactDefinitionMap = make(map[string]ContactDefinitionUnserializer, 0)
+// TODO avoid global map variables and wrap this functionality into some kind of component?
+var contactDefinitionMap = make(map[string]ContactDefinitionUnserializer)
 
 // RegisterContactUnserializer registers unserializer for specified payment method
 func RegisterContactUnserializer(paymentMethod string, unserializer func(*json.RawMessage) (ContactDefinition, error)) {
@@ -88,8 +88,8 @@ func unserializeContact(contactType string, rawMessage *json.RawMessage) Contact
 	if !ok {
 		return UnsupportedContactType{}
 	}
-	definition, er := fn(rawMessage)
-	if er != nil {
+	definition, err := fn(rawMessage)
+	if err != nil {
 		return UnsupportedContactType{}
 	}
 

--- a/service_discovery/dto/location.go
+++ b/service_discovery/dto/location.go
@@ -17,6 +17,7 @@
 
 package dto
 
+// Location struct represents geographic location of service provider
 type Location struct {
 	Country string `json:"country,omitempty"`
 	City    string `json:"city,omitempty"`

--- a/service_discovery/dto/payment_method.go
+++ b/service_discovery/dto/payment_method.go
@@ -23,13 +23,13 @@ import (
 	"github.com/mysteriumnetwork/node/money"
 )
 
-// PaymentMethod is a marker interface for all types of payment methods
+// PaymentMethod is a interface for all types of payment methods
 type PaymentMethod interface {
 	// Service price per unit of metering
 	GetPrice() money.Money
 }
 
-// UnsupportedPaymentMethod represents payment method which is uknown to node (i.e. not registered)
+// UnsupportedPaymentMethod represents payment method which is unknown to node (i.e. not registered)
 type UnsupportedPaymentMethod struct {
 }
 
@@ -45,7 +45,8 @@ var _ PaymentMethod = UnsupportedPaymentMethod{}
 type PaymentMethodUnserializer func(*json.RawMessage) (PaymentMethod, error)
 
 // service payment method unserializer registry
-var paymentMethodMap = make(map[string]PaymentMethodUnserializer, 0)
+//TODO same idea as for contact global map
+var paymentMethodMap = make(map[string]PaymentMethodUnserializer)
 
 // RegisterPaymentMethodUnserializer registers unserializer for specified payment method type
 func RegisterPaymentMethodUnserializer(paymentMethod string, unserializer func(*json.RawMessage) (PaymentMethod, error)) {

--- a/service_discovery/dto/service_definition.go
+++ b/service_discovery/dto/service_definition.go
@@ -19,7 +19,7 @@ package dto
 
 import "encoding/json"
 
-// ServiceDefinition interface is marker interface for all service definition types
+// ServiceDefinition interface is interface for all service definition types
 type ServiceDefinition interface {
 	GetLocation() Location
 }
@@ -40,7 +40,8 @@ var _ ServiceDefinition = UnsupportedServiceDefinition{}
 type ServiceDefinitionUnserializer func(*json.RawMessage) (ServiceDefinition, error)
 
 // service definition unserializer registry
-var serviceDefinitionMap = make(map[string]ServiceDefinitionUnserializer, 10)
+//TODO same idea as for contact global map
+var serviceDefinitionMap = make(map[string]ServiceDefinitionUnserializer)
 
 // RegisterServiceDefinitionUnserializer registers deserializer for specified service definition
 func RegisterServiceDefinitionUnserializer(serviceType string, unserializer ServiceDefinitionUnserializer) {

--- a/service_discovery/dto/service_proposal.go
+++ b/service_discovery/dto/service_proposal.go
@@ -19,7 +19,6 @@ package dto
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/mysteriumnetwork/node/identity"
 )
@@ -28,6 +27,8 @@ const (
 	proposalFormat = "service-proposal/v1"
 )
 
+// ServiceProposal is top level structure which is presented to marked place by service provider, and looked up by service consumer
+// service proposal can be marked as unsupported by deserializer, because of unknown service, payment method, or contact type
 type ServiceProposal struct {
 	// Per provider unique serial number of service description provided
 	ID int `json:"id"`
@@ -54,101 +55,7 @@ type ServiceProposal struct {
 	ProviderContacts ContactList `json:"provider_contacts"`
 }
 
-// SetProviderContact updates service proposal description with general data
-func (proposal *ServiceProposal) SetProviderContact(providerID identity.Identity, providerContact Contact) {
-	proposal.Format = proposalFormat
-	// TODO This will be generated later
-	proposal.ID = 1
-	proposal.ProviderID = providerID.Address
-	proposal.ProviderContacts = ContactList{providerContact}
-}
-
-/**
- * Service definition unserializer registry logic
- */
-type ServiceDefinitionUnserializer func(*json.RawMessage) (ServiceDefinition, error)
-
-// service definition unserializer registry
-var serviceDefinitionMap map[string]ServiceDefinitionUnserializer = make(map[string]ServiceDefinitionUnserializer, 10)
-
-func RegisterServiceDefinitionUnserializer(serviceType string, unserializer ServiceDefinitionUnserializer) {
-	serviceDefinitionMap[serviceType] = unserializer
-}
-func unserializeServiceDefinition(serviceType string, message *json.RawMessage) (ServiceDefinition, error) {
-	if method, ok := serviceDefinitionMap[serviceType]; ok {
-		return method(message)
-	}
-
-	return nil, errors.New("Service unserializer '" + serviceType + "' doesn't exist")
-}
-
-/**
- * Payment method unserializer registry logic
- */
-type PaymentMethodUnserializer func(*json.RawMessage) (PaymentMethod, error)
-
-// service payment method unserializer registry
-var paymentMethodMap = make(map[string]PaymentMethodUnserializer, 0)
-
-func RegisterPaymentMethodUnserializer(paymentMethod string, unserializer func(*json.RawMessage) (PaymentMethod, error)) {
-	paymentMethodMap[paymentMethod] = unserializer
-}
-
-func unserializePaymentMethod(paymentMethod string, message *json.RawMessage) (PaymentMethod, error) {
-	if method, ok := paymentMethodMap[paymentMethod]; ok {
-		return method(message)
-	}
-
-	return nil, errors.New("Payment method unserializer '" + paymentMethod + "' doesn't exist")
-}
-
-/**
- * Contact unserializer registry logic
- */
-type ContactDefinitionUnserializer func(*json.RawMessage) (ContactDefinition, error)
-
-// service payment method unserializer registry
-var contactDefinitionMap = make(map[string]ContactDefinitionUnserializer, 0)
-
-func RegisterContactUnserializer(paymentMethod string, unserializer func(*json.RawMessage) (ContactDefinition, error)) {
-	contactDefinitionMap[paymentMethod] = unserializer
-}
-
-func unserializeContacts(message *json.RawMessage) (contactList ContactList, err error) {
-	if message == nil {
-		return
-	}
-
-	// get an array of raw definitions
-	var contacts []struct {
-		Type       string           `json:"type"`
-		Definition *json.RawMessage `json:"definition"`
-	}
-	if err = json.Unmarshal([]byte(*message), &contacts); err != nil {
-		return
-	}
-
-	contactList = make([]Contact, len(contacts))
-	for index, contactItem := range contacts {
-		if fn, ok := contactDefinitionMap[contactItem.Type]; ok {
-
-			definition, er := fn(contactItem.Definition)
-			if er != nil {
-				return
-			}
-
-			compiled := Contact{
-				Type:       contactItem.Type,
-				Definition: definition,
-			}
-
-			contactList[index] = compiled
-		}
-	}
-
-	return
-}
-
+// UnmarshalJSON is custom json unmarshaler to dynamically fill in ServiceProposal values
 func (proposal *ServiceProposal) UnmarshalJSON(data []byte) error {
 	var jsonData struct {
 		ID                int              `json:"id"`
@@ -171,19 +78,49 @@ func (proposal *ServiceProposal) UnmarshalJSON(data []byte) error {
 	proposal.PaymentMethodType = jsonData.PaymentMethodType
 
 	// run the service definition implementation from our registry
-	proposal.ServiceDefinition, _ = unserializeServiceDefinition(
+	proposal.ServiceDefinition = unserializeServiceDefinition(
 		jsonData.ServiceType,
 		jsonData.ServiceDefinition,
 	)
 
 	// run the payment method implementation from our registry
-	proposal.PaymentMethod, _ = unserializePaymentMethod(
+	proposal.PaymentMethod = unserializePaymentMethod(
 		jsonData.PaymentMethodType,
 		jsonData.PaymentMethod,
 	)
 
 	// run contact unserializer
-	proposal.ProviderContacts, _ = unserializeContacts(jsonData.ProviderContacts)
+	proposal.ProviderContacts = unserializeContacts(jsonData.ProviderContacts)
 
 	return nil
+}
+
+// SetProviderContact updates service proposal description with general data
+func (proposal *ServiceProposal) SetProviderContact(providerID identity.Identity, providerContact Contact) {
+	proposal.Format = proposalFormat
+	// TODO This will be generated later
+	proposal.ID = 1
+	proposal.ProviderID = providerID.Address
+	proposal.ProviderContacts = ContactList{providerContact}
+}
+
+// IsSupported function returns true if this service proposal can be used for connections by service consumer
+// can be used as a filter to filter out all proposals which are unsupported for any reason
+func (proposal *ServiceProposal) IsSupported() bool {
+	if _, serviceNotSupported := proposal.ServiceDefinition.(UnsupportedServiceDefinition); serviceNotSupported {
+		return false
+	}
+	if _, paymentNotSupported := proposal.PaymentMethod.(UnsupportedPaymentMethod); paymentNotSupported {
+		return false
+	}
+
+	for _, contact := range proposal.ProviderContacts {
+		if _, notSupported := contact.Definition.(UnsupportedContactType); notSupported {
+			continue
+		}
+		//at least one is supported - we are ok
+		return true
+	}
+
+	return false
 }

--- a/service_discovery/dto/service_proposal.go
+++ b/service_discovery/dto/service_proposal.go
@@ -27,7 +27,7 @@ const (
 	proposalFormat = "service-proposal/v1"
 )
 
-// ServiceProposal is top level structure which is presented to marked place by service provider, and looked up by service consumer
+// ServiceProposal is top level structure which is presented to marketplace by service provider, and looked up by service consumer
 // service proposal can be marked as unsupported by deserializer, because of unknown service, payment method, or contact type
 type ServiceProposal struct {
 	// Per provider unique serial number of service description provided
@@ -104,7 +104,7 @@ func (proposal *ServiceProposal) SetProviderContact(providerID identity.Identity
 	proposal.ProviderContacts = ContactList{providerContact}
 }
 
-// IsSupported function returns true if this service proposal can be used for connections by service consumer
+// IsSupported returns true if this service proposal can be used for connections by service consumer
 // can be used as a filter to filter out all proposals which are unsupported for any reason
 func (proposal *ServiceProposal) IsSupported() bool {
 	if _, serviceNotSupported := proposal.ServiceDefinition.(UnsupportedServiceDefinition); serviceNotSupported {

--- a/services/openvpn/discovery/service_poposal_test.go
+++ b/services/openvpn/discovery/service_poposal_test.go
@@ -44,6 +44,8 @@ func Test_ServiceProposal_UnserializeServiceDefinition(t *testing.T) {
 	expected := dto_discovery.ServiceProposal{
 		ServiceType:       "openvpn",
 		ServiceDefinition: dto_openvpn.ServiceDefinition{},
+		PaymentMethod:     dto_discovery.UnsupportedPaymentMethod{},
+		ProviderContacts:  dto_discovery.ContactList{},
 	}
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
The main idea how to handle proposals of uknown service,payment or contact types.
Proposal is considered unsupported if one of the following is true:

- Unknown service type
- Unnown payment type
- **All** contact types in contact list are unknown.

Such proposals will be filtered out and not returned by tequilapi