### PR TITLE
session stats are now reset

### DIFF
--- a/consumer/statistics/tracker.go
+++ b/consumer/statistics/tracker.go
@@ -44,6 +44,11 @@ func (sst *SessionStatisticsTracker) Retrieve() consumer.SessionStatistics {
 	return sst.sessionStats
 }
 
+// Reset resets session stats to 0
+func (sst *SessionStatisticsTracker) Reset() {
+	sst.sessionStats = consumer.SessionStatistics{}
+}
+
 // MarkSessionStart marks current time as session start time for statistics
 func (sst *SessionStatisticsTracker) markSessionStart() {
 	time := sst.timeGetter()


### PR DESCRIPTION
CLOSES #616.

*taken from #616*

Currently, the stats trackers session statistics are never reset. This results in a scenario where I can:

1) start a connection that tracks statistics(openvpn).
1) wait a bit until stats are accumulated.
1) disconnect
1) connect to a connection that does not track statistics(noop).
1) noop now sends out statistics with the byte count from openvpn instead of zeros, as it's supposed to do.