### PR TITLE
go-openvpn vertion bump up to 0.0.12

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@
 
 [[constraint]]
   name = "github.com/mysteriumnetwork/go-openvpn"
-  version = "0.0.11"
+  version = "0.0.12"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
needed to make sure that nodes restarts on redeployment