### PR TITLE
Place Info.plist in root framework folder

### DIFF
--- a/bin/package_ios
+++ b/bin/package_ios
@@ -32,7 +32,7 @@ xgo \
 
 me=`whoami`
 sudo chown -R $me ${DIR_FRAMEWORK}
-cp -vp bin/package/ios/Info.plist ${DIR_FRAMEWORK}/Versions/A/Resources/Info.plist
+cp -vp bin/package/ios/Info.plist ${DIR_FRAMEWORK}/Info.plist
 
 (cd ${DIR_TEMP} && zip -r - .) > ${PACKAGE_FILE}
 rm -rf ${DIR_TEMP}


### PR DESCRIPTION
Can't find a source for this but AFAIK iOS frameworks need to have the `Info.plist` file in the root folder of the framework. Might need to `rm -rf ${DIR_FRAMEWORK}/Versions` but not sure if that's necessary. Don't have environment set up so can't test this. 