### PR TITLE
use ethereum port mapping implementation for openvpn port mapping

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -98,6 +98,7 @@
     "event",
     "log",
     "metrics",
+    "p2p/nat",
     "p2p/netutil",
     "params",
     "rlp",
@@ -133,12 +134,36 @@
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  digest = "1:c00cc6d95a674b4b923ac069d364445043bc67836e9bd8aeff8440cfbe6a2cc7"
+  name = "github.com/huin/goupnp"
+  packages = [
+    ".",
+    "dcps/internetgateway1",
+    "dcps/internetgateway2",
+    "httpu",
+    "scpd",
+    "soap",
+    "ssdp",
+  ]
+  pruneopts = "UT"
+  revision = "656e61dfadd241c7cbdd22a023fa81ecb6860ea8"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:b352ae8b1a77cc6b48fc8e314e34a522cfc76d6ca3a06c93b29c9cde5de6771e"
   name = "github.com/jackpal/gateway"
   packages = ["."]
   pruneopts = "UT"
   revision = "cbcf4e3f3baee7952fc386c8b2534af4d267c875"
   version = "v1.0.5"
+
+[[projects]]
+  digest = "1:32b82e71cf24f8b78323e0d7903c4b90278486283965aa2a19b1ea13763b8f34"
+  name = "github.com/jackpal/go-nat-pmp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c9cfead9f2a36ddf3daa40ba269aa7f4bbba6b62"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:ccfa094742ce1c97fd3f6481e1bf98f3d9862510eee2bc0eb56e2745396bd330"
@@ -401,10 +426,13 @@
 
 [[projects]]
   branch = "release-branch.go1.11"
-  digest = "1:8f2aed8be0d0a5771da9df6a0bf28ffe8534643b97caf6c51c1dabb4a47d80c3"
+  digest = "1:7545d2e03cb4691b887fa2f1666ec3d757ffbf6adf8f8413a9ea96dd84808327"
   name = "golang.org/x/net"
   packages = [
     "bpf",
+    "html",
+    "html/atom",
+    "html/charset",
     "internal/iana",
     "internal/socket",
     "ipv4",
@@ -426,6 +454,32 @@
   ]
   pruneopts = "UT"
   revision = "98c5dad5d1a0e8a73845ecc8897d0bd56586511d"
+
+[[projects]]
+  digest = "1:aa4d6967a3237f8367b6bf91503964a77183ecf696f1273e8ad3551bb4412b5f"
+  name = "golang.org/x/text"
+  packages = [
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
+    "internal/gen",
+    "internal/tag",
+    "internal/utf8internal",
+    "language",
+    "runes",
+    "transform",
+    "unicode/cldr",
+  ]
+  pruneopts = "UT"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   digest = "1:a05bd2d296bc727082abcb63ff52615b4dcc6219d8b61e99fd83d605dc779a18"
@@ -518,6 +572,7 @@
     "github.com/ethereum/go-ethereum/core/types",
     "github.com/ethereum/go-ethereum/crypto",
     "github.com/ethereum/go-ethereum/ethclient",
+    "github.com/ethereum/go-ethereum/p2p/nat",
     "github.com/ethereum/go-ethereum/params",
     "github.com/gofrs/uuid",
     "github.com/jackpal/gateway",

--- a/nat/mapping/port_mapping.go
+++ b/nat/mapping/port_mapping.go
@@ -33,7 +33,7 @@ const (
 
 // PortMapping maps given port of given protocol from external IP on a gateway to local machine internal IP
 // 'name' denotes rule name added on a gateway.
-func PortMapping(protocol string, port int, name string) chan struct{} {
+func PortMapping(protocol string, port int, name string) func() {
 	mapperQuit := make(chan struct{})
 	go mapPort(portmap.Any(),
 		mapperQuit,
@@ -42,7 +42,7 @@ func PortMapping(protocol string, port int, name string) chan struct{} {
 		port,
 		name)
 
-	return mapperQuit
+	return func() { close(mapperQuit) }
 }
 
 // mapPort adds a port mapping on m and keeps it alive until c is closed.

--- a/nat/port_mapping.go
+++ b/nat/port_mapping.go
@@ -32,7 +32,7 @@ const (
 )
 
 // PortMapping maps given port of given protocol from external IP on a gateway to local machine internal IP
-//  'name' denotes rule name added on a gateway
+// 'name' denotes rule name added on a gateway.
 func PortMapping(protocol string, port int, name string) chan struct{} {
 	mapperQuit := make(chan struct{})
 	go mapPort(portmap.Any(),
@@ -55,7 +55,7 @@ func mapPort(m portmap.Interface, c chan struct{}, protocol string, extPort, int
 		m.DeleteMapping(protocol, extPort, intPort)
 	}()
 	if err := m.AddMapping(protocol, extPort, intPort, name, mapTimeout); err != nil {
-		log.Debugf("%s, Couldn't add port mapping: %v, %s", logPrefix, err, "retrying with permanent lease")
+		log.Debugf("%s, Couldn't add port mapping: %v, retrying with permanent lease", logPrefix, err)
 		if err := m.AddMapping(protocol, extPort, intPort, name, 0); err != nil {
 			// some gateways support only permanent leases
 			log.Debug(logPrefix, "Couldn't add port mapping: ", err)
@@ -74,7 +74,7 @@ func mapPort(m portmap.Interface, c chan struct{}, protocol string, extPort, int
 		case <-refresh.C:
 			log.Trace(logPrefix, "Refreshing port mapping")
 			if err := m.AddMapping(protocol, extPort, intPort, name, mapTimeout); err != nil {
-				log.Debugf("%s, Couldn't add port mapping: %v, %s", logPrefix, err, "retrying with permanent lease")
+				log.Debugf("%s, Couldn't add port mapping: %v, retrying with permanent lease", logPrefix, err)
 				if err := m.AddMapping(protocol, extPort, intPort, name, 0); err != nil {
 					// some gateways support only permanent leases
 					log.Debug(logPrefix, "Couldn't add port mapping: ", err)

--- a/nat/port_mapping.go
+++ b/nat/port_mapping.go
@@ -1,0 +1,86 @@
+package nat
+
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"time"
+
+	log "github.com/cihub/seelog"
+	portmap "github.com/ethereum/go-ethereum/p2p/nat"
+)
+
+const logPrefix = "[nat] "
+
+const (
+	mapTimeout        = 20 * time.Minute
+	mapUpdateInterval = 15 * time.Minute
+)
+
+// PortMapping maps given port of given protocol from external IP on a gateway to local machine internal IP
+//  'name' denotes rule name added on a gateway
+func PortMapping(protocol string, port int, name string) chan struct{} {
+	mapperQuit := make(chan struct{})
+	go mapPort(portmap.Any(),
+		mapperQuit,
+		protocol,
+		port,
+		port,
+		name)
+
+	return mapperQuit
+}
+
+// mapPort adds a port mapping on m and keeps it alive until c is closed.
+// This function is typically invoked in its own goroutine.
+func mapPort(m portmap.Interface, c chan struct{}, protocol string, extPort, intPort int, name string) {
+	refresh := time.NewTimer(mapUpdateInterval)
+	defer func() {
+		refresh.Stop()
+		log.Debug(logPrefix, "Deleting port mapping")
+		m.DeleteMapping(protocol, extPort, intPort)
+	}()
+	if err := m.AddMapping(protocol, extPort, intPort, name, mapTimeout); err != nil {
+		log.Debugf("%s, Couldn't add port mapping: %v, %s", logPrefix, err, "retrying with permanent lease")
+		if err := m.AddMapping(protocol, extPort, intPort, name, 0); err != nil {
+			// some gateways support only permanent leases
+			log.Debug(logPrefix, "Couldn't add port mapping: ", err)
+		} else {
+			log.Info(logPrefix, "Mapped network port: ", extPort)
+		}
+	} else {
+		log.Info(logPrefix, "Mapped network port")
+	}
+	for {
+		select {
+		case _, ok := <-c:
+			if !ok {
+				return
+			}
+		case <-refresh.C:
+			log.Trace(logPrefix, "Refreshing port mapping")
+			if err := m.AddMapping(protocol, extPort, intPort, name, mapTimeout); err != nil {
+				log.Debugf("%s, Couldn't add port mapping: %v, %s", logPrefix, err, "retrying with permanent lease")
+				if err := m.AddMapping(protocol, extPort, intPort, name, 0); err != nil {
+					// some gateways support only permanent leases
+					log.Debug(logPrefix, "Couldn't add port mapping: ", err)
+				}
+			}
+			refresh.Reset(mapUpdateInterval)
+		}
+	}
+}

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -54,6 +54,7 @@ func NewManager(
 		sessionConfigNegotiatorFactory: newSessionConfigNegotiatorFactory(nodeOptions.OptionsNetwork, serviceOptions),
 		vpnServerConfigFactory:         newServerConfigFactory(nodeOptions, serviceOptions),
 		vpnServerFactory:               newServerFactory(nodeOptions, sessionValidator),
+		serviceOptions:                 serviceOptions,
 	}
 }
 

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat"
+	"github.com/mysteriumnetwork/node/nat/mapping"
 	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn"
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/pkg/errors"
@@ -74,7 +75,7 @@ func (manager *Manager) Serve(providerID identity.Identity) (err error) {
 	}
 
 	if manager.outboundIP != manager.publicIP {
-		manager.mapperQuit = nat.PortMapping(
+		manager.mapperQuit = mapping.PortMapping(
 			manager.serviceOptions.OpenvpnProtocol,
 			manager.serviceOptions.OpenvpnPort,
 			"Myst node openvpn port mapping")

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -48,6 +48,7 @@ type SessionConfigNegotiatorFactory func(secPrimitives *tls.Primitives, outbound
 // Manager represents entrypoint for Openvpn service with top level components
 type Manager struct {
 	natService nat.NATService
+	mapperQuit chan struct{}
 
 	sessionConfigNegotiatorFactory SessionConfigNegotiatorFactory
 
@@ -59,6 +60,7 @@ type Manager struct {
 	publicIP        string
 	outboundIP      string
 	currentLocation string
+	serviceOptions  Options
 }
 
 // Serve starts service - does block
@@ -69,6 +71,13 @@ func (manager *Manager) Serve(providerID identity.Identity) (err error) {
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to add NAT forwarding rule")
+	}
+
+	if manager.outboundIP != manager.publicIP {
+		manager.mapperQuit = nat.PortMapping(
+			manager.serviceOptions.OpenvpnProtocol,
+			manager.serviceOptions.OpenvpnPort,
+			"Myst node openvpn port mapping")
 	}
 
 	primitives, err := primitiveFactory(manager.currentLocation, providerID.Address)
@@ -84,11 +93,14 @@ func (manager *Manager) Serve(providerID identity.Identity) (err error) {
 	if err = manager.vpnServer.Start(); err != nil {
 		return
 	}
+
 	return manager.vpnServer.Wait()
 }
 
 // Stop stops service
 func (manager *Manager) Stop() (err error) {
+	close(manager.mapperQuit)
+
 	if manager.vpnServer != nil {
 		manager.vpnServer.Stop()
 	}


### PR DESCRIPTION
Analysed ethereum project port mapping implementation and since it uses the same huin/goupnp library as we were planning to use and since their methods are exported I decided to reuse their code.

Whats implemented:
- on openvpn service startup launches port mapper, which tries to maintain service port mapping on a gateway 
- on openvpn service shutdown, mapper is terminated and rule on a gateway removed
- since ethereum does not handle the case when a gateway implements only persistent rule handling, rewrote their nat.Map method.
- launch mapper only if node being behind the NAT is detected.
 
Whats lacking:
- WG implementation. Will make it with separate PR.
