### PR TITLE
disconnect is now solely responsible for calling the cleanup

### DIFF
--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -140,7 +140,7 @@ func (manager *connectionManager) startConnection(consumerID identity.Identity, 
 		}
 		if err != nil {
 			log.Info(managerLogPrefix, "Cancelling connection initiation", err)
-			_ = manager.Disconnect()
+			logDisconnectError(manager.Disconnect())
 		}
 	}()
 
@@ -290,7 +290,7 @@ func (manager *connectionManager) connectionWaiter(connection Connection) {
 		log.Info(managerLogPrefix, "Connection exited")
 	}
 
-	_ = manager.Disconnect()
+	logDisconnectError(manager.Disconnect())
 }
 
 func (manager *connectionManager) waitForConnectedState(stateChannel <-chan State, sessionID session.ID) error {
@@ -320,7 +320,7 @@ func (manager *connectionManager) consumeConnectionStates(stateChannel <-chan St
 	}
 
 	log.Debug(managerLogPrefix, "State updater stopCalled")
-	_ = manager.Disconnect()
+	logDisconnectError(manager.Disconnect())
 }
 
 func (manager *connectionManager) consumeStats(statisticsChannel <-chan consumer.SessionStatistics) {
@@ -340,5 +340,11 @@ func (manager *connectionManager) onStateChanged(state State) {
 		manager.setStatus(statusConnected(manager.sessionInfo.SessionID, manager.sessionInfo.Proposal))
 	case Reconnecting:
 		manager.setStatus(statusReconnecting())
+	}
+}
+
+func logDisconnectError(err error) {
+	if err != nil && err != ErrNoConnection {
+		log.Error(managerLogPrefix, "Disconnect error", err)
 	}
 }

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -145,14 +145,15 @@ func (tc *testContext) TestStatusReportsConnectingWhenConnectionIsInProgress() {
 	tc.connManager.Disconnect()
 }
 
-func (tc *testContext) TestStatusReportsDisconnectingThenNotConnected() {
+func (tc *testContext) TestStatusReportsNotConnected() {
 	tc.fakeConnectionFactory.mockConnection.onStopReportStates = []fakeState{}
 	err := tc.connManager.Connect(consumerID, activeProposal, ConnectParams{})
 	assert.NoError(tc.T(), err)
 	assert.Equal(tc.T(), statusConnected(establishedSessionID, activeProposal), tc.connManager.Status())
 
 	assert.NoError(tc.T(), tc.connManager.Disconnect())
-	assert.Equal(tc.T(), statusDisconnecting(), tc.connManager.Status())
+	// TODO: this switch now happens way too quickly to catch
+	// assert.Equal(tc.T(), statusDisconnecting(), tc.connManager.Status())
 	tc.fakeConnectionFactory.mockConnection.reportState(exitingState)
 	tc.fakeConnectionFactory.mockConnection.reportState(processExited)
 	waitABit()

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -102,6 +102,7 @@ func (tc *testContext) SetupTest() {
 			nil,
 			tc.mockStatistics,
 			sync.WaitGroup{},
+			nil,
 			sync.RWMutex{},
 		},
 	}
@@ -147,15 +148,27 @@ func (tc *testContext) TestStatusReportsConnectingWhenConnectionIsInProgress() {
 
 func (tc *testContext) TestStatusReportsNotConnected() {
 	tc.fakeConnectionFactory.mockConnection.onStopReportStates = []fakeState{}
+	tc.fakeConnectionFactory.mockConnection.stopBlock = make(chan struct{})
+	defer func() {
+		tc.fakeConnectionFactory.mockConnection.stopBlock = nil
+	}()
+
 	err := tc.connManager.Connect(consumerID, activeProposal, ConnectParams{})
 	assert.NoError(tc.T(), err)
 	assert.Equal(tc.T(), statusConnected(establishedSessionID, activeProposal), tc.connManager.Status())
 
-	assert.NoError(tc.T(), tc.connManager.Disconnect())
-	// TODO: this switch now happens way too quickly to catch
-	// assert.Equal(tc.T(), statusDisconnecting(), tc.connManager.Status())
+	go func() {
+		assert.NoError(tc.T(), tc.connManager.Disconnect())
+	}()
+
+	waitABit()
+	assert.Equal(tc.T(), statusDisconnecting(), tc.connManager.Status())
+
+	tc.fakeConnectionFactory.mockConnection.stopBlock <- struct{}{}
+
 	tc.fakeConnectionFactory.mockConnection.reportState(exitingState)
 	tc.fakeConnectionFactory.mockConnection.reportState(processExited)
+
 	waitABit()
 	assert.Equal(tc.T(), statusNotConnected(), tc.connManager.Status())
 }

--- a/core/connection/stubs_test.go
+++ b/core/connection/stubs_test.go
@@ -149,6 +149,7 @@ func (cff *connectionFactoryFake) CreateConnection(serviceType string, stateChan
 		stateCallback:       cff.mockConnection.stateCallback,
 		onStartReportStats:  cff.mockConnection.onStartReportStats,
 		fakeProcess:         sync.WaitGroup{},
+		stopBlock:           cff.mockConnection.stopBlock,
 	}
 
 	return &copy, nil
@@ -161,6 +162,7 @@ type connectionMock struct {
 	stateCallback       func(state fakeState)
 	onStartReportStats  consumer.SessionStatistics
 	fakeProcess         sync.WaitGroup
+	stopBlock           chan struct{}
 	sync.RWMutex
 }
 
@@ -191,6 +193,9 @@ func (foc *connectionMock) Wait() error {
 func (foc *connectionMock) Stop() {
 	for _, fakeState := range foc.onStopReportStates {
 		foc.reportState(fakeState)
+	}
+	if foc.stopBlock != nil {
+		<-foc.stopBlock
 	}
 	foc.fakeProcess.Done()
 }


### PR DESCRIPTION
We had an issue where certain cleanup operations could be called multiple times due to the fact that they were called both on the cancel side and the connection waiter. Now, only the disconnect method calls the cleanup operation.