### PR TITLE
port forwarding autoconfiguration for WG

### DIFF
--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -29,6 +29,7 @@ import (
 	identity_selector "github.com/mysteriumnetwork/node/identity/selector"
 	"github.com/mysteriumnetwork/node/metadata"
 	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn/service"
+	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/urfave/cli"
 )
 
@@ -167,6 +168,7 @@ func registerFlags(flags *[]cli.Flag) {
 		identityFlag, identityPassphraseFlag,
 	)
 	openvpn_service.RegisterFlags(flags)
+	wireguard_service.RegisterFlags(flags)
 }
 
 // parseFlags function fills in service command options from CLI context

--- a/cmd/service_bootstrap_desktop.go
+++ b/cmd/service_bootstrap_desktop.go
@@ -77,13 +77,12 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 		transportOptions := serviceOptions.(openvpn_service.Options)
 
 		mapPort := func() func() {
-			if location.OutIP != location.PubIP {
-				return mapping.PortMapping(
-					transportOptions.OpenvpnProtocol,
-					transportOptions.OpenvpnPort,
-					"Myst node openvpn port mapping")
-			}
-			return func() {}
+			return mapping.GetPortMappingFunc(
+				location.PubIP,
+				location.OutIP,
+				transportOptions.OpenvpnProtocol,
+				transportOptions.OpenvpnPort,
+				"Myst node OpenVPN port mapping")
 		}
 
 		proposal := openvpn_discovery.NewServiceProposalWithLocation(currentLocation, transportOptions.OpenvpnProtocol)

--- a/cmd/service_bootstrap_unix.go
+++ b/cmd/service_bootstrap_unix.go
@@ -48,17 +48,19 @@ func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options) {
 				return nil, market.ServiceProposal{}, err
 			}
 
+			wgOptions := serviceOptions.(wireguard_service.Options)
+
 			mapPort := func(port int) func() {
-				if location.OutIP != location.PubIP {
-					return mapping.PortMapping(
-						"UDP",
-						port,
-						"Myst node wireguard port mapping")
-				}
-				return func() {}
+				return mapping.GetPortMappingFunc(
+					location.PubIP,
+					location.OutIP,
+					"UDP",
+					port,
+					"Myst node wireguard(tm) port mapping")
 			}
 
-			return wireguard_service.NewManager(location, di.NATService, mapPort), wireguard_service.GetProposal(location.Country), nil
+			return wireguard_service.NewManager(location, di.NATService, mapPort, wgOptions),
+				wireguard_service.GetProposal(location.Country), nil
 		},
 	)
 }

--- a/core/location/location_info.go
+++ b/core/location/location_info.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package location
+
+// ServiceLocationInfo represents data needed to determine location and if service is behind the NAT
+type ServiceLocationInfo struct {
+	OutIP   string
+	PubIP   string
+	Country string
+}

--- a/nat/mapping/port_mapping.go
+++ b/nat/mapping/port_mapping.go
@@ -71,6 +71,7 @@ func addMapping(m portmap.Interface, protocol string, extPort, intPort int, name
 		if err := m.AddMapping(protocol, extPort, intPort, name, 0); err != nil {
 			// some gateways support only permanent leases
 			log.Debugf("%s Couldn't add port mapping for port %d: %v", logPrefix, extPort, err)
+			return
 		}
 	}
 	log.Info(logPrefix, "Mapped network port:", extPort)

--- a/nat/mapping/port_mapping.go
+++ b/nat/mapping/port_mapping.go
@@ -31,6 +31,14 @@ const (
 	mapUpdateInterval = 15 * time.Minute
 )
 
+// GetPortMappingFunc returns PortMapping function if service is behind NAT
+func GetPortMappingFunc(pubIP, outIP, protocol string, port int, description string) func() {
+	if pubIP != outIP {
+		return PortMapping(protocol, port, description)
+	}
+	return func() {}
+}
+
 // PortMapping maps given port of given protocol from external IP on a gateway to local machine internal IP
 // 'name' denotes rule name added on a gateway.
 func PortMapping(protocol string, port int, name string) func() {

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -21,6 +21,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 
+	"github.com/mysteriumnetwork/node/core/location"
+
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/auth"
@@ -38,23 +40,23 @@ import (
 func NewManager(
 	nodeOptions node.Options,
 	serviceOptions Options,
-	publicIP string,
-	outboundIP string,
-	currentLocation string,
+	location location.ServiceLocationInfo,
 	sessionMap openvpn_session.SessionMap,
 	natService nat.NATService,
+	mapPort func() (releasePortMapping func()),
 ) *Manager {
 	sessionValidator := openvpn_session.NewValidator(sessionMap, identity.NewExtractor())
 
 	return &Manager{
-		publicIP:                       publicIP,
-		outboundIP:                     outboundIP,
-		currentLocation:                currentLocation,
+		publicIP:                       location.PubIP,
+		outboundIP:                     location.OutIP,
+		currentLocation:                location.Country,
 		natService:                     natService,
 		sessionConfigNegotiatorFactory: newSessionConfigNegotiatorFactory(nodeOptions.OptionsNetwork, serviceOptions),
 		vpnServerConfigFactory:         newServerConfigFactory(nodeOptions, serviceOptions),
 		vpnServerFactory:               newServerFactory(nodeOptions, sessionValidator),
 		serviceOptions:                 serviceOptions,
+		mapPort:                        mapPort,
 	}
 }
 

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/consumer"
 	"github.com/mysteriumnetwork/node/core/connection"
+	"github.com/mysteriumnetwork/node/core/location"
 	wg "github.com/mysteriumnetwork/node/services/wireguard"
 	endpoint "github.com/mysteriumnetwork/node/services/wireguard/endpoint"
 	"github.com/mysteriumnetwork/node/services/wireguard/key"
@@ -57,7 +58,13 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 	c.config.Consumer.IPAddress = config.Consumer.IPAddress
 
 	resourceAllocator := resources.NewAllocator()
-	c.connectionEndpoint, err = endpoint.NewConnectionEndpoint("", "", &resourceAllocator)
+
+	// We do not need port mapping for consumer, since it initiates the session
+	fakePortMapper := func(port int) (releasePortMapping func()) {
+		return func() {}
+	}
+
+	c.connectionEndpoint, err = endpoint.NewConnectionEndpoint(location.ServiceLocationInfo{}, &resourceAllocator, fakePortMapper)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new connection endpoint")
 	}
@@ -71,6 +78,7 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 		return errors.Wrap(err, "failed to start connection endpoint")
 	}
 
+	// Provider requests to delay consumer connection since it might be in a process of setting up NAT traversal for given consumer
 	if config.Consumer.ConnectDelay > 0 {
 		log.Infof("%s delaying connect for %v milliseconds", logPrefix, config.Consumer.ConnectDelay)
 		time.Sleep(time.Duration(config.Consumer.ConnectDelay) * time.Millisecond)

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -57,7 +57,7 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 	c.config.Consumer.IPAddress = config.Consumer.IPAddress
 
 	resourceAllocator := resources.NewAllocator()
-	c.connectionEndpoint, err = endpoint.NewConnectionEndpoint("", &resourceAllocator)
+	c.connectionEndpoint, err = endpoint.NewConnectionEndpoint("", "", &resourceAllocator)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new connection endpoint")
 	}
@@ -69,6 +69,11 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 		c.stateChannel <- connection.NotConnected
 		c.connection.Done()
 		return errors.Wrap(err, "failed to start connection endpoint")
+	}
+
+	if config.Consumer.ConnectDelay > 0 {
+		log.Infof("%s delaying connect for %v milliseconds", logPrefix, config.Consumer.ConnectDelay)
+		time.Sleep(time.Duration(config.Consumer.ConnectDelay) * time.Millisecond)
 	}
 
 	if err := c.connectionEndpoint.AddPeer(c.config.Provider.PublicKey, &c.config.Provider.Endpoint); err != nil {

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -64,7 +64,7 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 		return func() {}
 	}
 
-	c.connectionEndpoint, err = endpoint.NewConnectionEndpoint(location.ServiceLocationInfo{}, &resourceAllocator, fakePortMapper)
+	c.connectionEndpoint, err = endpoint.NewConnectionEndpoint(location.ServiceLocationInfo{}, &resourceAllocator, fakePortMapper, 0)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new connection endpoint")
 	}

--- a/services/wireguard/endpoint/create.go
+++ b/services/wireguard/endpoint/create.go
@@ -27,7 +27,12 @@ import (
 )
 
 // NewConnectionEndpoint creates new wireguard connection endpoint.
-func NewConnectionEndpoint(location location.ServiceLocationInfo, resourceAllocator *resources.Allocator, portMap func(port int) (releasePortMapping func())) (wg.ConnectionEndpoint, error) {
+func NewConnectionEndpoint(
+	location location.ServiceLocationInfo,
+	resourceAllocator *resources.Allocator,
+	portMap func(port int) (releasePortMapping func()),
+	connectDelay int) (wg.ConnectionEndpoint, error) {
+
 	client, err := userspace.NewWireguardClient()
 	return &connectionEndpoint{
 		wgClient:           client,
@@ -35,5 +40,6 @@ func NewConnectionEndpoint(location location.ServiceLocationInfo, resourceAlloca
 		resourceAllocator:  resourceAllocator,
 		mapPort:            portMap,
 		releasePortMapping: func() {},
+		connectDelay:       connectDelay,
 	}, err
 }

--- a/services/wireguard/endpoint/create.go
+++ b/services/wireguard/endpoint/create.go
@@ -26,11 +26,13 @@ import (
 )
 
 // NewConnectionEndpoint creates new wireguard connection endpoint.
-func NewConnectionEndpoint(publicIP string, resourceAllocator *resources.Allocator) (wg.ConnectionEndpoint, error) {
+func NewConnectionEndpoint(publicIP, outIP string, resourceAllocator *resources.Allocator) (wg.ConnectionEndpoint, error) {
 	client, err := userspace.NewWireguardClient()
 	return &connectionEndpoint{
-		wgClient:          client,
-		publicIP:          publicIP,
-		resourceAllocator: resourceAllocator,
+		wgClient:           client,
+		publicIP:           publicIP,
+		outboundIP:         outIP,
+		resourceAllocator:  resourceAllocator,
+		releasePortMapping: func() {},
 	}, err
 }

--- a/services/wireguard/endpoint/create.go
+++ b/services/wireguard/endpoint/create.go
@@ -20,19 +20,20 @@
 package endpoint
 
 import (
+	"github.com/mysteriumnetwork/node/core/location"
 	wg "github.com/mysteriumnetwork/node/services/wireguard"
 	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
 	"github.com/mysteriumnetwork/node/services/wireguard/resources"
 )
 
 // NewConnectionEndpoint creates new wireguard connection endpoint.
-func NewConnectionEndpoint(publicIP, outIP string, resourceAllocator *resources.Allocator) (wg.ConnectionEndpoint, error) {
+func NewConnectionEndpoint(location location.ServiceLocationInfo, resourceAllocator *resources.Allocator, portMap func(port int) (releasePortMapping func())) (wg.ConnectionEndpoint, error) {
 	client, err := userspace.NewWireguardClient()
 	return &connectionEndpoint{
 		wgClient:           client,
-		publicIP:           publicIP,
-		outboundIP:         outIP,
+		location:           location,
 		resourceAllocator:  resourceAllocator,
+		mapPort:            portMap,
 		releasePortMapping: func() {},
 	}, err
 }

--- a/services/wireguard/endpoint/create_linux.go
+++ b/services/wireguard/endpoint/create_linux.go
@@ -21,6 +21,7 @@ package endpoint
 
 import (
 	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/node/core/location"
 	wg "github.com/mysteriumnetwork/node/services/wireguard"
 	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/kernelspace"
 	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
@@ -29,7 +30,7 @@ import (
 )
 
 // NewConnectionEndpoint creates new wireguard connection endpoint.
-func NewConnectionEndpoint(publicIP, outIP string, resourceAllocator *resources.Allocator) (wg.ConnectionEndpoint, error) {
+func NewConnectionEndpoint(location location.ServiceLocationInfo, resourceAllocator *resources.Allocator, mapPort func(port int) (releasePortMapping func())) (wg.ConnectionEndpoint, error) {
 	wgClient, err := getWGClient()
 	if err != nil {
 		return nil, err
@@ -37,10 +38,10 @@ func NewConnectionEndpoint(publicIP, outIP string, resourceAllocator *resources.
 
 	return &connectionEndpoint{
 		wgClient:           wgClient,
-		publicIP:           publicIP,
-		outboundIP:         outIP,
+		location:           location,
 		resourceAllocator:  resourceAllocator,
 		releasePortMapping: func() {},
+		mapPort:            mapPort,
 	}, nil
 }
 

--- a/services/wireguard/endpoint/create_linux.go
+++ b/services/wireguard/endpoint/create_linux.go
@@ -29,16 +29,18 @@ import (
 )
 
 // NewConnectionEndpoint creates new wireguard connection endpoint.
-func NewConnectionEndpoint(publicIP string, resourceAllocator *resources.Allocator) (wg.ConnectionEndpoint, error) {
+func NewConnectionEndpoint(publicIP, outIP string, resourceAllocator *resources.Allocator) (wg.ConnectionEndpoint, error) {
 	wgClient, err := getWGClient()
 	if err != nil {
 		return nil, err
 	}
 
 	return &connectionEndpoint{
-		wgClient:          wgClient,
-		publicIP:          publicIP,
-		resourceAllocator: resourceAllocator,
+		wgClient:           wgClient,
+		publicIP:           publicIP,
+		outboundIP:         outIP,
+		resourceAllocator:  resourceAllocator,
+		releasePortMapping: func() {},
 	}, nil
 }
 

--- a/services/wireguard/endpoint/create_linux.go
+++ b/services/wireguard/endpoint/create_linux.go
@@ -30,7 +30,12 @@ import (
 )
 
 // NewConnectionEndpoint creates new wireguard connection endpoint.
-func NewConnectionEndpoint(location location.ServiceLocationInfo, resourceAllocator *resources.Allocator, mapPort func(port int) (releasePortMapping func())) (wg.ConnectionEndpoint, error) {
+func NewConnectionEndpoint(
+	location location.ServiceLocationInfo,
+	resourceAllocator *resources.Allocator,
+	mapPort func(port int) (releasePortMapping func()),
+	connectDelay int) (wg.ConnectionEndpoint, error) {
+
 	wgClient, err := getWGClient()
 	if err != nil {
 		return nil, err
@@ -42,6 +47,7 @@ func NewConnectionEndpoint(location location.ServiceLocationInfo, resourceAlloca
 		resourceAllocator:  resourceAllocator,
 		releasePortMapping: func() {},
 		mapPort:            mapPort,
+		connectDelay:       connectDelay,
 	}, nil
 }
 

--- a/services/wireguard/endpoint/endpoint.go
+++ b/services/wireguard/endpoint/endpoint.go
@@ -30,7 +30,6 @@ import (
 )
 
 const logPrefix = "[wireguard-connection-endpoint] "
-const connectDelayForPortMap = 2000
 
 type wgClient interface {
 	ConfigureDevice(name string, config wg.DeviceConfig, subnet net.IPNet) error
@@ -78,9 +77,6 @@ func (ce *connectionEndpoint) Start(config *wg.ServiceConfig) error {
 	if config == nil {
 		// nil config mean its a provider Start
 		ce.releasePortMapping = ce.mapPort(port)
-		if ce.location.OutIP != ce.location.PubIP {
-			ce.connectDelay = connectDelayForPortMap
-		}
 		privateKey, err := key.GeneratePrivateKey()
 		if err != nil {
 			return err
@@ -124,7 +120,9 @@ func (ce *connectionEndpoint) Config() (wg.ServiceConfig, error) {
 	config.Provider.Endpoint = ce.endpoint
 	config.Consumer.IPAddress = ce.ipAddr
 	config.Consumer.IPAddress.IP = consumerIP(ce.ipAddr)
-	config.Consumer.ConnectDelay = ce.connectDelay
+	if ce.location.OutIP != ce.location.PubIP {
+		config.Consumer.ConnectDelay = ce.connectDelay
+	}
 	return config, nil
 }
 

--- a/services/wireguard/service/flags.go
+++ b/services/wireguard/service/flags.go
@@ -23,9 +23,26 @@ import (
 )
 
 // Options describes options which are required to start Wireguard service
-type Options struct{}
+type Options struct {
+	ConnectDelay int
+}
+
+var (
+	delayFlag = cli.IntFlag{
+		Name:  "connect.delay",
+		Usage: "Consumer is delayed by specified time (2000 millisec default) if provider is behind NAT",
+		Value: 2000,
+	}
+)
+
+// RegisterFlags function register Wireguard flags to flag list
+func RegisterFlags(flags *[]cli.Flag) {
+	*flags = append(*flags, delayFlag)
+}
 
 // ParseFlags function fills in Wireguard options from CLI context
-func ParseFlags(_ *cli.Context) service.Options {
-	return Options{}
+func ParseFlags(ctx *cli.Context) service.Options {
+	return Options{
+		ConnectDelay: ctx.Int(delayFlag.Name),
+	}
 }

--- a/services/wireguard/service/service.go
+++ b/services/wireguard/service/service.go
@@ -38,7 +38,12 @@ import (
 const logPrefix = "[service-wireguard] "
 
 // NewManager creates new instance of Wireguard service
-func NewManager(location location.ServiceLocationInfo, natService nat.NATService, portMap func(port int) (releasePortMapping func())) *Manager {
+func NewManager(
+	location location.ServiceLocationInfo,
+	natService nat.NATService,
+	portMap func(port int) (releasePortMapping func()),
+	options Options) *Manager {
+
 	resourceAllocator := resources.NewAllocator()
 	return &Manager{
 		natService: natService,
@@ -48,7 +53,7 @@ func NewManager(location location.ServiceLocationInfo, natService nat.NATService
 		currentLocation: location.OutIP,
 
 		connectionEndpointFactory: func() (wg.ConnectionEndpoint, error) {
-			return endpoint.NewConnectionEndpoint(location, &resourceAllocator, portMap)
+			return endpoint.NewConnectionEndpoint(location, &resourceAllocator, portMap, options.ConnectDelay)
 		},
 	}
 }

--- a/services/wireguard/service/service.go
+++ b/services/wireguard/service/service.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"sync"
 
+	"github.com/mysteriumnetwork/node/core/location"
+
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
@@ -36,17 +38,17 @@ import (
 const logPrefix = "[service-wireguard] "
 
 // NewManager creates new instance of Wireguard service
-func NewManager(publicIP, outIP, country string, natService nat.NATService) *Manager {
+func NewManager(location location.ServiceLocationInfo, natService nat.NATService, portMap func(port int) (releasePortMapping func())) *Manager {
 	resourceAllocator := resources.NewAllocator()
 	return &Manager{
 		natService: natService,
 
-		publicIP:        publicIP,
-		outboundIP:      outIP,
-		currentLocation: country,
+		publicIP:        location.PubIP,
+		outboundIP:      location.OutIP,
+		currentLocation: location.OutIP,
 
 		connectionEndpointFactory: func() (wg.ConnectionEndpoint, error) {
-			return endpoint.NewConnectionEndpoint(publicIP, outIP, &resourceAllocator)
+			return endpoint.NewConnectionEndpoint(location, &resourceAllocator, portMap)
 		},
 	}
 }

--- a/services/wireguard/service/service.go
+++ b/services/wireguard/service/service.go
@@ -46,7 +46,7 @@ func NewManager(publicIP, outIP, country string, natService nat.NATService) *Man
 		currentLocation: country,
 
 		connectionEndpointFactory: func() (wg.ConnectionEndpoint, error) {
-			return endpoint.NewConnectionEndpoint(publicIP, &resourceAllocator)
+			return endpoint.NewConnectionEndpoint(publicIP, outIP, &resourceAllocator)
 		},
 	}
 }

--- a/services/wireguard/wireguard.go
+++ b/services/wireguard/wireguard.go
@@ -104,8 +104,9 @@ type ServiceConfig struct {
 		Endpoint  net.UDPAddr
 	}
 	Consumer struct {
-		PrivateKey string `json:"-"`
-		IPAddress  net.IPNet
+		PrivateKey   string `json:"-"`
+		IPAddress    net.IPNet
+		ConnectDelay int
 	}
 }
 
@@ -116,8 +117,9 @@ func (s ServiceConfig) MarshalJSON() ([]byte, error) {
 		Endpoint  string `json:"endpoint"`
 	}
 	type consumer struct {
-		PrivateKey string `json:"private_key"`
-		IPAddress  string `json:"ip_address"`
+		PrivateKey   string `json:"private_key"`
+		IPAddress    string `json:"ip_address"`
+		ConnectDelay int    `json:"connect_delay"`
 	}
 
 	return json.Marshal(&struct {
@@ -129,7 +131,8 @@ func (s ServiceConfig) MarshalJSON() ([]byte, error) {
 			s.Provider.Endpoint.String(),
 		},
 		consumer{
-			IPAddress: s.Consumer.IPAddress.String(),
+			IPAddress:    s.Consumer.IPAddress.String(),
+			ConnectDelay: s.Consumer.ConnectDelay,
 		},
 	})
 }
@@ -141,8 +144,9 @@ func (s *ServiceConfig) UnmarshalJSON(data []byte) error {
 		Endpoint  string `json:"endpoint"`
 	}
 	type consumer struct {
-		PrivateKey string `json:"private_key"`
-		IPAddress  string `json:"ip_address"`
+		PrivateKey   string `json:"private_key"`
+		IPAddress    string `json:"ip_address"`
+		ConnectDelay int    `json:"connect_delay"`
 	}
 	var config struct {
 		Provider provider `json:"provider"`
@@ -166,6 +170,7 @@ func (s *ServiceConfig) UnmarshalJSON(data []byte) error {
 	s.Provider.PublicKey = config.Provider.PublicKey
 	s.Consumer.IPAddress = *ipnet
 	s.Consumer.IPAddress.IP = ip
+	s.Consumer.ConnectDelay = config.Consumer.ConnectDelay
 
 	return nil
 }


### PR DESCRIPTION
Uses IGD (upnp) and PMP protocols to enable port forwarding for WG
 - Reuses the same Ethereum port mapping code
 - Maps port for each WG session separately since WG instance sits on separate port
 - Instruct client to postpone connect for some time for mappings to get activated

If client connects while mappings are not active - FW throttles (blacklists) incoming requests for some random time and WG session fails to establish.  In case WG provider is behind NAT we instruct client to delay connect for mappings to get active.
