### PR TITLE
Get rid of tequilapi dependency in client package

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mysteriumnetwork/node/cmd"
 	"github.com/mysteriumnetwork/node/metadata"
 	tequilapi_client "github.com/mysteriumnetwork/node/tequilapi/client"
-	"github.com/mysteriumnetwork/node/tequilapi/endpoints"
 	"github.com/mysteriumnetwork/node/utils"
 	"github.com/urfave/cli"
 )
@@ -181,7 +180,7 @@ func (c *cliApp) connect(argsString string) {
 		}
 	}
 
-	connectOptions := endpoints.ConnectOptions{DisableKillSwitch: disableKill}
+	connectOptions := tequilapi_client.ConnectOptions{DisableKillSwitch: disableKill}
 
 	if consumerID == "new" {
 		id, err := c.tequilapi.NewIdentity(identityDefaultPassphrase)

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cihub/seelog"
 	tequilapi_client "github.com/mysteriumnetwork/node/tequilapi/client"
-	"github.com/mysteriumnetwork/node/tequilapi/endpoints"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -125,7 +124,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 	})
 	assert.NoError(t, err)
 
-	connectionStatus, err = tequilapi.Connect(consumerID, proposal.ProviderID, serviceType, endpoints.ConnectOptions{
+	connectionStatus, err = tequilapi.Connect(consumerID, proposal.ProviderID, serviceType, tequilapi_client.ConnectOptions{
 		DisableKillSwitch: true,
 	})
 
@@ -178,7 +177,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 	serviceTypeAssertionMap[serviceType](t, se)
 }
 
-type sessionAsserter func(t *testing.T, session endpoints.SessionDTO)
+type sessionAsserter func(t *testing.T, session tequilapi_client.SessionDTO)
 
 var serviceTypeAssertionMap = map[string]sessionAsserter{
 	"openvpn":   assertStatsNotZero,
@@ -186,12 +185,12 @@ var serviceTypeAssertionMap = map[string]sessionAsserter{
 	"wireguard": assertStatsNotZero,
 }
 
-func assertStatsNotZero(t *testing.T, session endpoints.SessionDTO) {
+func assertStatsNotZero(t *testing.T, session tequilapi_client.SessionDTO) {
 	assert.NotEqual(t, uint64(0), session.BytesSent)
 	assert.NotEqual(t, uint64(0), session.BytesReceived)
 }
 
-func assertStatsZero(t *testing.T, session endpoints.SessionDTO) {
+func assertStatsZero(t *testing.T, session tequilapi_client.SessionDTO) {
 	assert.Equal(t, uint64(0), session.BytesSent)
 	assert.Equal(t, uint64(0), session.BytesReceived)
 }

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-
-	"github.com/mysteriumnetwork/node/tequilapi/endpoints"
 )
 
 // NewClient returns a new instance of Client
@@ -86,12 +84,12 @@ func (client *Client) IdentityRegistrationStatus(address string) (RegistrationDa
 }
 
 // Connect initiates a new connection to a host identified by providerID
-func (client *Client) Connect(consumerID, providerID, serviceType string, options endpoints.ConnectOptions) (status StatusDTO, err error) {
+func (client *Client) Connect(consumerID, providerID, serviceType string, options ConnectOptions) (status StatusDTO, err error) {
 	payload := struct {
-		Identity    string                   `json:"consumerId"`
-		ProviderID  string                   `json:"providerId"`
-		ServiceType string                   `json:"serviceType"`
-		Options     endpoints.ConnectOptions `json:"connectOptions"`
+		Identity    string         `json:"consumerId"`
+		ProviderID  string         `json:"providerId"`
+		ServiceType string         `json:"serviceType"`
+		Options     ConnectOptions `json:"connectOptions"`
 	}{
 		Identity:    consumerID,
 		ProviderID:  providerID,
@@ -242,8 +240,8 @@ func (client *Client) Stop() error {
 }
 
 // GetSessions returns all sessions from history
-func (client *Client) GetSessions() (endpoints.SessionsDTO, error) {
-	sessions := endpoints.SessionsDTO{}
+func (client *Client) GetSessions() (SessionsDTO, error) {
+	sessions := SessionsDTO{}
 	response, err := client.http.Get("sessions", url.Values{})
 	if err != nil {
 		return sessions, err
@@ -255,7 +253,7 @@ func (client *Client) GetSessions() (endpoints.SessionsDTO, error) {
 }
 
 // filterSessionsByType removes all sessions of irrelevant types
-func filterSessionsByType(serviceType string, sessions endpoints.SessionsDTO) endpoints.SessionsDTO {
+func filterSessionsByType(serviceType string, sessions SessionsDTO) SessionsDTO {
 	matches := 0
 	for _, s := range sessions.Sessions {
 		if s.ServiceType == serviceType {
@@ -268,7 +266,7 @@ func filterSessionsByType(serviceType string, sessions endpoints.SessionsDTO) en
 }
 
 // filterSessionsByStatus removes all sessions with non matching status
-func filterSessionsByStatus(status string, sessions endpoints.SessionsDTO) endpoints.SessionsDTO {
+func filterSessionsByStatus(status string, sessions SessionsDTO) SessionsDTO {
 	matches := 0
 	for _, s := range sessions.Sessions {
 		if s.Status == status {
@@ -281,14 +279,14 @@ func filterSessionsByStatus(status string, sessions endpoints.SessionsDTO) endpo
 }
 
 // GetSessionsByType returns sessions from history filtered by type
-func (client *Client) GetSessionsByType(serviceType string) (endpoints.SessionsDTO, error) {
+func (client *Client) GetSessionsByType(serviceType string) (SessionsDTO, error) {
 	sessions, err := client.GetSessions()
 	sessions = filterSessionsByType(serviceType, sessions)
 	return sessions, err
 }
 
 // GetSessionsByStatus returns sessions from history filtered by their status
-func (client *Client) GetSessionsByStatus(status string) (endpoints.SessionsDTO, error) {
+func (client *Client) GetSessionsByStatus(status string) (SessionsDTO, error) {
 	sessions, err := client.GetSessions()
 	sessions = filterSessionsByStatus(status, sessions)
 	return sessions, err

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -103,3 +103,34 @@ type SignatureDTO struct {
 	S string `json:"s"`
 	V uint8  `json:"v"`
 }
+
+// ConnectOptions copied from tequilapi endpoint
+type ConnectOptions struct {
+	DisableKillSwitch bool `json:"killSwitch"`
+}
+
+// SessionsDTO copied from tequilapi endpoint
+type SessionsDTO struct {
+	Sessions []SessionDTO `json:"sessions"`
+}
+
+// SessionDTO copied from tequilapi endpoint
+type SessionDTO struct {
+	SessionID string `json:"sessionId"`
+
+	ProviderID string `json:"providerId"`
+
+	ServiceType string `json:"serviceType"`
+
+	ProviderCountry string `json:"providerCountry"`
+
+	DateStarted string `json:"dateStarted"`
+
+	BytesSent uint64 `json:"bytesSent"`
+
+	BytesReceived uint64 `json:"bytesReceived"`
+
+	Duration uint64 `json:"duration"`
+
+	Status string `json:"status"`
+}


### PR DESCRIPTION
Tequilapi client becomes very heavy when referended from other projects, because it has a few DTOs coming from parent tequilapi package - and there all the hell breaks loose. Get rid of that dependency