### PR TITLE
Use basic type for proposalRes.Metrics to fix tequilapi documentation

### DIFF
--- a/tequilapi/endpoints/proposals.go
+++ b/tequilapi/endpoints/proposals.go
@@ -68,7 +68,8 @@ type proposalRes struct {
 	ServiceDefinition serviceDefinitionRes `json:"serviceDefinition"`
 
 	// Metrics of the service
-	Metrics json.RawMessage `json:"metrics,omitempty"`
+	// example: {"success": 1, "fail": 2, "timeout": 3}
+	Metrics []byte `json:"metrics,omitempty"`
 }
 
 func proposalToRes(p market.ServiceProposal) proposalRes {


### PR DESCRIPTION
Using `json.RawMessage` means that swagger will use description from `RawMessage` object, which is not very useful:

<img width="523" alt="screenshot 2019-02-14 at 17 07 43" src="https://user-images.githubusercontent.com/1409983/52795826-464be380-307b-11e9-9ad1-103b7f5ca77c.png">
<img width="491" alt="screenshot 2019-02-14 at 17 07 26" src="https://user-images.githubusercontent.com/1409983/52795824-464be380-307b-11e9-968b-26e5fef6b2ef.png">

If we want to have our own description, we can achieve that by using primitive data type (`[]byte`):

<img width="548" alt="screenshot 2019-02-14 at 17 06 56" src="https://user-images.githubusercontent.com/1409983/52795822-45b34d00-307b-11e9-80e6-b2893daa1dbf.png">
<img width="494" alt="screenshot 2019-02-14 at 17 07 03" src="https://user-images.githubusercontent.com/1409983/52795823-464be380-307b-11e9-9a20-096749519cd4.png">

Description works. As for example, it is not perfect, because `metrics` field is shown as a `string`, but it's much more useful and less confusing than `[0]` :D
