### PR TITLE
Bump geth version to 1.8.23 enable Constantinople fork by default

### DIFF
--- a/bin/localnet/docker-compose.yml
+++ b/bin/localnet/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   #private blockchain with single miner and single node
   geth:
-    image: mysteriumnetwork/geth:1.8.12
+    image: mysteriumnetwork/geth:1.8.23
     expose:
       - 8545
     volumes:

--- a/bin/localnet/geth/genesis.json
+++ b/bin/localnet/geth/genesis.json
@@ -1,12 +1,13 @@
 {
   "config": {
     "chainId": 69,
-    "homesteadBlock": 1,
-    "eip150Block": 1,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
     "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "eip155Block": 1,
-    "eip158Block": 1,
-    "byzantiumBlock": 1,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock" : 0,
     "clique": {
       "period": 2,
       "epoch": 30000


### PR DESCRIPTION
- Bump geth version to 1.8.23
- Enable Constantinople fork
- Enable Petersburg fork (enabled by default with Constantinople)
In case parameters are not clear [Ethereum genesis block](https://github.com/ethereum/go-ethereum/blob/master/params/config.go)