### PR TITLE
Increase NATS sender timeout from 2 seconds to 10

### DIFF
--- a/communication/nats/sender.go
+++ b/communication/nats/sender.go
@@ -34,7 +34,7 @@ func NewSender(connection Connection, codec communication.Codec, topic string) *
 	return &senderNATS{
 		connection:     connection,
 		codec:          codec,
-		timeoutRequest: 2 * time.Second,
+		timeoutRequest: 10 * time.Second,
 		messageTopic:   topic + ".",
 	}
 }

--- a/communication/nats/sender_test.go
+++ b/communication/nats/sender_test.go
@@ -36,7 +36,7 @@ func TestSenderNew(t *testing.T) {
 		&senderNATS{
 			connection:     connection,
 			codec:          codec,
-			timeoutRequest: 2 * time.Second,
+			timeoutRequest: 10 * time.Second,
 			messageTopic:   "custom.",
 		},
 		NewSender(connection, codec, "custom"),


### PR DESCRIPTION
2 seconds looks too small timeout for the service. 
I have started facing issues related to this timeout too often.