### PR TITLE
Allow all localhost port origins, extend cors policy to regexp

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -419,5 +419,5 @@ func (di *Dependencies) bootstrapLocationComponents(options node.OptionsLocation
 
 var corsPolicy = tequilapi.WhitelistingCorsPolicy{
 	DefaultTrustedOrigin:  "https://mysterium.network",
-	AllowedOriginSuffixes: []string{"wallet.mysterium.network", "wallet-dev.mysterium.network", "localhost"},
+	AllowedOriginSuffixes: []string{"wallet.mysterium.network", "wallet-dev.mysterium.network", "localhost", "localhost:9080"},
 }

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -291,6 +291,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options) {
 
 	identity_registry.AddIdentityRegistrationEndpoint(router, di.IdentityRegistration, di.IdentityRegistry)
 
+	corsPolicy := tequilapi.NewMysteriumCorsPolicy()
 	httpAPIServer := tequilapi.NewServer(nodeOptions.TequilapiAddress, nodeOptions.TequilapiPort, router, corsPolicy)
 	metricsSender := metrics.CreateSender(nodeOptions.DisableMetrics, nodeOptions.MetricsAddress)
 
@@ -415,9 +416,4 @@ func (di *Dependencies) bootstrapLocationComponents(options node.OptionsLocation
 
 	di.LocationDetector = location.NewDetector(di.IPResolver, di.LocationResolver)
 	di.LocationOriginal = location.NewLocationCache(di.LocationDetector)
-}
-
-var corsPolicy = tequilapi.WhitelistingCorsPolicy{
-	DefaultTrustedOrigin:  "https://mysterium.network",
-	AllowedOriginSuffixes: []string{"wallet.mysterium.network", "wallet-dev.mysterium.network", "localhost", "localhost:9080"},
 }

--- a/tequilapi/api_test.go
+++ b/tequilapi/api_test.go
@@ -31,7 +31,7 @@ type tequilapiTestSuite struct {
 }
 
 func (testSuite *tequilapiTestSuite) SetupSuite() {
-	testSuite.server = NewServer("localhost", 0, NewAPIRouter(), WhitelistingCorsPolicy{})
+	testSuite.server = NewServer("localhost", 0, NewAPIRouter(), RegexpCorsPolicy{})
 
 	assert.NoError(testSuite.T(), testSuite.server.StartServing())
 	address, err := testSuite.server.Address()

--- a/tequilapi/doc.go
+++ b/tequilapi/doc.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package tequilapi Tequila API
+//
+// The purpose of this documentation is to provide developers an insight of how to
+// interact with Mysterium Node via Tequila API.
+// This should demonstrate all the possible API calls with described parameters and responses.
+//
+//   Host: 127.0.0.1:4050
+//
+//   Consumes:
+//   - application/json
+//
+//   Produces:
+//   - application/json
+//
+//   Version: dev
+//
+// swagger:meta
+package tequilapi

--- a/tequilapi/http_api_server_test.go
+++ b/tequilapi/http_api_server_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestLocalAPIServerPortIsAsExpected(t *testing.T) {
-	server := NewServer("localhost", 31337, nil, WhitelistingCorsPolicy{})
+	server := NewServer("localhost", 31337, nil, RegexpCorsPolicy{})
 
 	assert.NoError(t, server.StartServing())
 
@@ -40,6 +40,6 @@ func TestLocalAPIServerPortIsAsExpected(t *testing.T) {
 }
 
 func TestStopBeforeStartingListeningDoesNotCausePanic(t *testing.T) {
-	server := NewServer("", 12345, nil, WhitelistingCorsPolicy{})
+	server := NewServer("", 12345, nil, RegexpCorsPolicy{})
 	server.Stop()
 }

--- a/tequilapi/http_middlewares_test.go
+++ b/tequilapi/http_middlewares_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testCorsPolicy = WhitelistingCorsPolicy{
+var testCorsPolicy = RegexpCorsPolicy{
 	DefaultTrustedOrigin:  "https://mysterium.network",
 	AllowedOriginSuffixes: []string{"mysterium.network", "localhost"},
 }

--- a/tequilapi/mysterium_cors_policy_factory.go
+++ b/tequilapi/mysterium_cors_policy_factory.go
@@ -18,7 +18,7 @@
 package tequilapi
 
 func NewMysteriumCorsPolicy() CorsPolicy {
-	return WhitelistingCorsPolicy{
+	return RegexpCorsPolicy{
 		DefaultTrustedOrigin:  "https://mysterium.network",
 		AllowedOriginSuffixes: []string{"wallet(-dev)?\\.mysterium\\.network$", "localhost(:\\d+)?$"},
 	}

--- a/tequilapi/mysterium_cors_policy_factory.go
+++ b/tequilapi/mysterium_cors_policy_factory.go
@@ -15,21 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Package tequilapi Tequila API
-//
-// The purpose of this documentation is to provide developers an insight of how to
-// interact with Mysterium Node via Tequila API.
-// This should demonstrate all the possible API calls with described parameters and responses.
-//
-//   Host: 127.0.0.1:4050
-//
-//   Consumes:
-//   - application/json
-//
-//   Produces:
-//   - application/json
-//
-//   Version: dev
-//
-// swagger:meta
 package tequilapi
+
+func NewMysteriumCorsPolicy() CorsPolicy {
+	return WhitelistingCorsPolicy{
+		DefaultTrustedOrigin:  "https://mysterium.network",
+		AllowedOriginSuffixes: []string{"wallet(-dev)?\\.mysterium\\.network$", "localhost(:\\d+)?$"},
+	}
+}

--- a/tequilapi/mysterium_cors_policy_factory.go
+++ b/tequilapi/mysterium_cors_policy_factory.go
@@ -17,6 +17,7 @@
 
 package tequilapi
 
+// NewMysteriumCorsPolicy builds cors policy for Mysterium wallet and local applications
 func NewMysteriumCorsPolicy() CorsPolicy {
 	return RegexpCorsPolicy{
 		DefaultTrustedOrigin:  "https://mysterium.network",

--- a/tequilapi/mysterium_cors_policy_factory_test.go
+++ b/tequilapi/mysterium_cors_policy_factory_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tequilapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMysteriumCorsPolicy_ReturnsOnlyTrustedOrigins(t *testing.T) {
+	policy := NewMysteriumCorsPolicy()
+	tests := []struct {
+		requested       string
+		expectedAllowed string
+	}{
+		{
+			requested:       "http://localhost",
+			expectedAllowed: "http://localhost",
+		},
+		{
+			requested:       "http://localhost:8090",
+			expectedAllowed: "http://localhost:8090",
+		},
+		{
+			requested:       "http://localhost.evil",
+			expectedAllowed: "https://mysterium.network",
+		},
+		{
+			requested:       "https://wallet.mysterium.network",
+			expectedAllowed: "https://wallet.mysterium.network",
+		},
+		{
+			requested:       "https://wallet-dev.mysterium.network",
+			expectedAllowed: "https://wallet-dev.mysterium.network",
+		},
+		{
+			requested:       "https://wallet-dev.mysterium.network.fake",
+			expectedAllowed: "https://mysterium.network",
+		},
+		{
+			requested:       "https://wallet.mysteriumanetwork",
+			expectedAllowed: "https://mysterium.network",
+		},
+		{
+			requested:       "http://some-bad-people.com",
+			expectedAllowed: "https://mysterium.network",
+		},
+	}
+	for _, tt := range tests {
+		allowed := policy.AllowedOrigin(tt.requested)
+		assert.Equal(t, tt.expectedAllowed, allowed)
+	}
+}

--- a/tequilapi/whitelisting_cors_policy.go
+++ b/tequilapi/whitelisting_cors_policy.go
@@ -23,14 +23,14 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// WhitelistingCorsPolicy allows customizing CORS (Cross-Origin Resource Sharing) behaviour - whitelisting only specific domains
-type WhitelistingCorsPolicy struct {
+// RegexpCorsPolicy allows customizing CORS (Cross-Origin Resource Sharing) behaviour - whitelisting domains by regexp
+type RegexpCorsPolicy struct {
 	DefaultTrustedOrigin  string
 	AllowedOriginSuffixes []string
 }
 
 // AllowedOrigin returns the same request origin if it is allowed, or default origin if it is not allowed
-func (policy WhitelistingCorsPolicy) AllowedOrigin(requestOrigin string) string {
+func (policy RegexpCorsPolicy) AllowedOrigin(requestOrigin string) string {
 	if policy.isOriginAllowed(requestOrigin) {
 		return requestOrigin
 	}
@@ -38,7 +38,7 @@ func (policy WhitelistingCorsPolicy) AllowedOrigin(requestOrigin string) string 
 	return policy.DefaultTrustedOrigin
 }
 
-func (policy WhitelistingCorsPolicy) isOriginAllowed(origin string) bool {
+func (policy RegexpCorsPolicy) isOriginAllowed(origin string) bool {
 	for _, allowedSuffix := range policy.AllowedOriginSuffixes {
 		match, err := regexp.MatchString(allowedSuffix, origin)
 		if err != nil {

--- a/tequilapi/whitelisting_cors_policy.go
+++ b/tequilapi/whitelisting_cors_policy.go
@@ -17,7 +17,11 @@
 
 package tequilapi
 
-import "strings"
+import (
+	"regexp"
+
+	"github.com/ethereum/go-ethereum/log"
+)
 
 // WhitelistingCorsPolicy allows customizing CORS (Cross-Origin Resource Sharing) behaviour - whitelisting only specific domains
 type WhitelistingCorsPolicy struct {
@@ -36,7 +40,11 @@ func (policy WhitelistingCorsPolicy) AllowedOrigin(requestOrigin string) string 
 
 func (policy WhitelistingCorsPolicy) isOriginAllowed(origin string) bool {
 	for _, allowedSuffix := range policy.AllowedOriginSuffixes {
-		if strings.HasSuffix(origin, allowedSuffix) {
+		match, err := regexp.MatchString(allowedSuffix, origin)
+		if err != nil {
+			log.Warn("Failed to check regexp for origin", err)
+		}
+		if match {
 			return true
 		}
 	}

--- a/tequilapi/whitelisting_cors_policy_test.go
+++ b/tequilapi/whitelisting_cors_policy_test.go
@@ -25,8 +25,8 @@ import (
 
 func TestWhitelistingCorsPolicy_AllowedOrigin_ReturnsSameOrDefaultOrigin(t *testing.T) {
 	var policy = WhitelistingCorsPolicy{
-		DefaultTrustedOrigin:  "https://mysterium.network",
-		AllowedOriginSuffixes: []string{"mysterium.network", "localhost"},
+		DefaultTrustedOrigin:  "default",
+		AllowedOriginSuffixes: []string{"^full-match$", "end-match$"},
 	}
 
 	tests := []struct {
@@ -34,24 +34,20 @@ func TestWhitelistingCorsPolicy_AllowedOrigin_ReturnsSameOrDefaultOrigin(t *test
 		expectedAllowed string
 	}{
 		{
-			requested:       "http://localhost",
-			expectedAllowed: "http://localhost",
+			requested:       "full-match",
+			expectedAllowed: "full-match",
 		},
 		{
-			requested:       "https://wallet.mysterium.network",
-			expectedAllowed: "https://wallet.mysterium.network",
+			requested:       "a-full-match",
+			expectedAllowed: "default",
 		},
 		{
-			requested:       "https://mysterium.network",
-			expectedAllowed: "https://mysterium.network",
+			requested:       "end-match",
+			expectedAllowed: "end-match",
 		},
 		{
-			requested:       "https://any-future-subdomain.mysterium.network",
-			expectedAllowed: "https://any-future-subdomain.mysterium.network",
-		},
-		{
-			requested:       "http://some-bad-people.com",
-			expectedAllowed: "https://mysterium.network",
+			requested:       "the-end-match",
+			expectedAllowed: "the-end-match",
 		},
 	}
 

--- a/tequilapi/whitelisting_cors_policy_test.go
+++ b/tequilapi/whitelisting_cors_policy_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWhitelistingCorsPolicy_AllowedOrigin_ReturnsSameOrDefaultOrigin(t *testing.T) {
-	var policy = WhitelistingCorsPolicy{
+func TestRegexpCorsPolicy_AllowedOrigin_ReturnsSameOrDefaultOrigin(t *testing.T) {
+	var policy = RegexpCorsPolicy{
 		DefaultTrustedOrigin:  "default",
 		AllowedOriginSuffixes: []string{"^full-match$", "end-match$"},
 	}


### PR DESCRIPTION
Electron uses `localhost:9080` origin in development - and it seems port is dynamic, so we can solve this by supporting all ports on localhost.