### PR TITLE
service manager now removes the service from the pool if it stops

### DIFF
--- a/cmd/service_bootstrap_desktop.go
+++ b/cmd/service_bootstrap_desktop.go
@@ -167,7 +167,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) {
 		sessionManagerFactory := newSessionManagerFactory(proposal, di.ServiceSessionStorage, di.PromiseStorage, nodeOptions)
 		return session.NewDialogHandler(sessionManagerFactory, configProvider.ProvideConfig, di.PromiseStorage, identity.FromAddress(proposal.ProviderID))
 	}
-	newDiscovery := func() *registry.Discovery {
+	newDiscovery := func() service.DiscoveryService {
 		return registry.NewService(di.IdentityRegistry, di.IdentityRegistration, di.MysteriumAPI, di.SignerFactory)
 	}
 	di.ServicesManager = service.NewManager(

--- a/cmd/service_bootstrap_desktop.go
+++ b/cmd/service_bootstrap_desktop.go
@@ -167,7 +167,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) {
 		sessionManagerFactory := newSessionManagerFactory(proposal, di.ServiceSessionStorage, di.PromiseStorage, nodeOptions)
 		return session.NewDialogHandler(sessionManagerFactory, configProvider.ProvideConfig, di.PromiseStorage, identity.FromAddress(proposal.ProviderID))
 	}
-	newDiscovery := func() service.DiscoveryService {
+	newDiscovery := func() service.Discovery {
 		return registry.NewService(di.IdentityRegistry, di.IdentityRegistration, di.MysteriumAPI, di.SignerFactory)
 	}
 	di.ServicesManager = service.NewManager(

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -49,10 +49,10 @@ type DialogWaiterFactory func(providerID identity.Identity, serviceType string) 
 type DialogHandlerFactory func(market.ServiceProposal, session.ConfigNegotiator) communication.DialogHandler
 
 // DiscoveryFactory initiates instance which is able announce service discoverability
-type DiscoveryFactory func() DiscoveryService
+type DiscoveryFactory func() Discovery
 
-// DiscoveryService registers the service to the discovery api periodically
-type DiscoveryService interface {
+// Discovery registers the service to the discovery api periodically
+type Discovery interface {
 	Start(ownIdentity identity.Identity, proposal market.ServiceProposal)
 	Stop()
 	Wait()

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
-	discovery_registry "github.com/mysteriumnetwork/node/market/proposals/registry"
 	"github.com/mysteriumnetwork/node/session"
 )
 
@@ -50,7 +49,14 @@ type DialogWaiterFactory func(providerID identity.Identity, serviceType string) 
 type DialogHandlerFactory func(market.ServiceProposal, session.ConfigNegotiator) communication.DialogHandler
 
 // DiscoveryFactory initiates instance which is able announce service discoverability
-type DiscoveryFactory func() *discovery_registry.Discovery
+type DiscoveryFactory func() DiscoveryService
+
+// DiscoveryService registers the service to the discovery api periodically
+type DiscoveryService interface {
+	Start(ownIdentity identity.Identity, proposal market.ServiceProposal)
+	Stop()
+	Wait()
+}
 
 // NewManager creates new instance of pluggable instances manager
 func NewManager(
@@ -122,14 +128,21 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 
 	go func() {
 		instance.state = Running
-		err = service.Serve(providerID)
+		serveErr := service.Serve(providerID)
+		if serveErr != nil {
+			log.Error("Service serve failed: ", serveErr)
+		}
+
 		instance.state = NotRunning
-		if err != nil {
-			log.Error("Service serve failed: ", err)
+
+		stopErr := manager.servicePool.Stop(id)
+		if stopErr != nil {
+			log.Error("Service stop failed: ", stopErr)
 		}
 
 		discovery.Wait()
 	}()
+
 	return id, nil
 }
 

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -39,8 +39,8 @@ func TestManager_StartRemovesServiceFromPoolIfServiceCrashes(t *testing.T) {
 		return &mockCopy, proposalMock, nil
 	})
 
-	discoveryService := mockDiscoveryService{}
-	discoveryFactory := MockDiscoveryFactoryFunc(&discoveryService)
+	discovery := mockDiscovery{}
+	discoveryFactory := MockDiscoveryFactoryFunc(&discovery)
 	manager := NewManager(
 		registry,
 		MockDialogWaiterFactory,
@@ -50,7 +50,7 @@ func TestManager_StartRemovesServiceFromPoolIfServiceCrashes(t *testing.T) {
 	_, err := manager.Start(identity.FromAddress(proposalMock.ProviderID), serviceType, struct{}{})
 	assert.Nil(t, err)
 
-	discoveryService.Wait()
+	discovery.Wait()
 	assert.Len(t, manager.servicePool.List(), 0)
 }
 
@@ -62,8 +62,8 @@ func TestManager_StartDoesNotCrashIfStoppedByUser(t *testing.T) {
 		return &mockCopy, proposalMock, nil
 	})
 
-	discoveryService := mockDiscoveryService{}
-	discoveryFactory := MockDiscoveryFactoryFunc(&discoveryService)
+	discovery := mockDiscovery{}
+	discoveryFactory := MockDiscoveryFactoryFunc(&discovery)
 	manager := NewManager(
 		registry,
 		MockDialogWaiterFactory,
@@ -74,6 +74,6 @@ func TestManager_StartDoesNotCrashIfStoppedByUser(t *testing.T) {
 	assert.Nil(t, err)
 	err = manager.Stop(id)
 	assert.Nil(t, err)
-	discoveryService.Wait()
+	discovery.Wait()
 	assert.Len(t, manager.servicePool.List(), 0)
 }

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/market"
+)
+
+var (
+	serviceType = "the-very-awesome-test-service-type"
+)
+
+func TestManager_StartRemovesServiceFromPoolIfServiceCrashes(t *testing.T) {
+	registry := NewRegistry()
+	mockCopy := *serviceMock
+	mockCopy.onStartReturnError = errors.New("some error")
+	registry.Register(serviceType, func(options Options) (Service, market.ServiceProposal, error) {
+		return &mockCopy, proposalMock, nil
+	})
+
+	discoveryService := mockDiscoveryService{}
+	discoveryFactory := MockDiscoveryFactoryFunc(&discoveryService)
+	manager := NewManager(
+		registry,
+		MockDialogWaiterFactory,
+		MockDialogHandlerFactory,
+		discoveryFactory,
+	)
+	_, err := manager.Start(identity.FromAddress(proposalMock.ProviderID), serviceType, struct{}{})
+	assert.Nil(t, err)
+
+	discoveryService.Wait()
+	assert.Len(t, manager.servicePool.List(), 0)
+}
+
+func TestManager_StartDoesNotCrashIfStoppedByUser(t *testing.T) {
+	registry := NewRegistry()
+	mockCopy := *serviceMock
+	mockCopy.mockProcess = make(chan struct{})
+	registry.Register(serviceType, func(options Options) (Service, market.ServiceProposal, error) {
+		return &mockCopy, proposalMock, nil
+	})
+
+	discoveryService := mockDiscoveryService{}
+	discoveryFactory := MockDiscoveryFactoryFunc(&discoveryService)
+	manager := NewManager(
+		registry,
+		MockDialogWaiterFactory,
+		MockDialogHandlerFactory,
+		discoveryFactory,
+	)
+	id, err := manager.Start(identity.FromAddress(proposalMock.ProviderID), serviceType, struct{}{})
+	assert.Nil(t, err)
+	err = manager.Stop(id)
+	assert.Nil(t, err)
+	discoveryService.Wait()
+	assert.Len(t, manager.servicePool.List(), 0)
+}

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -157,7 +157,7 @@ type Instance struct {
 	service      RunnableService
 	proposal     market.ServiceProposal
 	dialogWaiter communication.DialogWaiter
-	discovery    DiscoveryService
+	discovery    Discovery
 }
 
 // Options returns options used to start service

--- a/core/service/pool_test.go
+++ b/core/service/pool_test.go
@@ -70,6 +70,12 @@ func Test_Pool_StopDoesNotStop(t *testing.T) {
 	assert.EqualError(t, err, "ErrorCollection(I dont want to stop)")
 }
 
+func Test_Pool_StopReturnsErrIfInstanceDoesNotExist(t *testing.T) {
+	pool := NewPool()
+	err := pool.Stop("something")
+	assert.Equal(t, ErrNoSuchInstance, err)
+}
+
 func Test_Pool_StopAllDoesNotStopOneInstance(t *testing.T) {
 	service := &mockService{killErr: errors.New("I dont want to stop")}
 	instance := &Instance{service: service}

--- a/core/service/stub_service.go
+++ b/core/service/stub_service.go
@@ -19,22 +19,33 @@ package service
 
 import (
 	"encoding/json"
+	"sync"
 
+	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/session"
 )
 
 var _ Service = &serviceFake{}
 
 type serviceFake struct {
+	mockProcess        chan struct{}
 	onStartReturnError error
 }
 
 func (service *serviceFake) Serve(identity.Identity) error {
+	if service.mockProcess != nil {
+		for range service.mockProcess {
+		}
+	}
 	return service.onStartReturnError
 }
 
 func (service *serviceFake) Stop() error {
+	if service.mockProcess != nil {
+		close(service.mockProcess)
+	}
 	return nil
 }
 
@@ -44,4 +55,62 @@ func (service *serviceFake) GetType() string {
 
 func (service *serviceFake) ProvideConfig(publicKey json.RawMessage) (session.ServiceConfiguration, session.DestroyCallback, error) {
 	return struct{}{}, func() {}, nil
+}
+
+type mockDialogWaiter struct {
+	contact  market.Contact
+	stopErr  error
+	serveErr error
+	startErr error
+}
+
+func (mdw *mockDialogWaiter) Start() (market.Contact, error) {
+	return mdw.contact, mdw.startErr
+}
+
+func (mdw *mockDialogWaiter) Stop() error {
+	return mdw.stopErr
+}
+
+func (mdw *mockDialogWaiter) ServeDialogs(_ communication.DialogHandler) error {
+	return mdw.serveErr
+}
+
+// MockDialogWaiterFactory returns a new instance of communication dialog waiter.
+func MockDialogWaiterFactory(providerID identity.Identity, serviceType string) (communication.DialogWaiter, error) {
+	return &mockDialogWaiter{}, nil
+}
+
+type mockDialogHandler struct {
+}
+
+func (mdh *mockDialogHandler) Handle(communication.Dialog) error {
+	return nil
+}
+
+// MockDialogHandlerFactory creates a new mock dialog handler
+func MockDialogHandlerFactory(market.ServiceProposal, session.ConfigNegotiator) communication.DialogHandler {
+	return &mockDialogHandler{}
+}
+
+type mockDiscoveryService struct {
+	wg sync.WaitGroup
+}
+
+func (mds *mockDiscoveryService) Start(ownIdentity identity.Identity, proposal market.ServiceProposal) {
+	mds.wg.Add(1)
+}
+func (mds *mockDiscoveryService) Stop() {
+	mds.wg.Done()
+}
+
+func (mds *mockDiscoveryService) Wait() {
+	mds.wg.Wait()
+}
+
+// MockDiscoveryFactoryFunc returns a discovery factory which in turn returns the discovery service.
+func MockDiscoveryFactoryFunc(ds DiscoveryService) DiscoveryFactory {
+	return func() DiscoveryService {
+		return ds
+	}
 }

--- a/core/service/stub_service.go
+++ b/core/service/stub_service.go
@@ -93,24 +93,24 @@ func MockDialogHandlerFactory(market.ServiceProposal, session.ConfigNegotiator) 
 	return &mockDialogHandler{}
 }
 
-type mockDiscoveryService struct {
+type mockDiscovery struct {
 	wg sync.WaitGroup
 }
 
-func (mds *mockDiscoveryService) Start(ownIdentity identity.Identity, proposal market.ServiceProposal) {
+func (mds *mockDiscovery) Start(ownIdentity identity.Identity, proposal market.ServiceProposal) {
 	mds.wg.Add(1)
 }
-func (mds *mockDiscoveryService) Stop() {
+func (mds *mockDiscovery) Stop() {
 	mds.wg.Done()
 }
 
-func (mds *mockDiscoveryService) Wait() {
+func (mds *mockDiscovery) Wait() {
 	mds.wg.Wait()
 }
 
 // MockDiscoveryFactoryFunc returns a discovery factory which in turn returns the discovery service.
-func MockDiscoveryFactoryFunc(ds DiscoveryService) DiscoveryFactory {
-	return func() DiscoveryService {
+func MockDiscoveryFactoryFunc(ds Discovery) DiscoveryFactory {
+	return func() Discovery {
 		return ds
 	}
 }


### PR DESCRIPTION
Before this change, the service could crash and still stay in the service list. Now it gets removed. To do this, the pool needed to be added under a lock, since a few racing goroutines would access it.