### PR TITLE
Temporary solution for wireguard resources rotation.

### DIFF
--- a/services/wireguard/resources/allocator.go
+++ b/services/wireguard/resources/allocator.go
@@ -26,7 +26,8 @@ import (
 	"sync"
 )
 
-const maxResources = 255
+// MaxResources sets the limit to the maximum number of wireguard connections.
+const MaxResources = 255
 
 // Allocator is mock wireguard resource handler.
 // It will manage lists of network interfaces names, IP addresses and port for endpoints.
@@ -82,7 +83,7 @@ func (a *Allocator) AllocateInterface() (string, error) {
 		return "", err
 	}
 
-	for i := 0; i < maxResources; i++ {
+	for i := 0; i < MaxResources; i++ {
 		if _, ok := a.Ifaces[i]; !ok {
 			a.Ifaces[i] = struct{}{}
 			if interfaceExists(ifaces, fmt.Sprintf("%s%d", interfacePrefix, i)) {
@@ -102,7 +103,7 @@ func (a *Allocator) AllocateIPNet() (net.IPNet, error) {
 	defer a.mu.Unlock()
 
 	var s string
-	for i := 0; i < maxResources; i++ {
+	for i := 0; i < MaxResources; i++ {
 		if _, ok := a.IPAddresses[i]; !ok {
 			a.IPAddresses[i] = struct{}{}
 			s = fmt.Sprintf("10.182.%d.0/24", i)
@@ -119,7 +120,7 @@ func (a *Allocator) AllocatePort() (int, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	for i := 52820; i < 52820+maxResources; i++ {
+	for i := 52820; i < 52820+MaxResources; i++ {
 		if _, ok := a.Ports[i]; !ok {
 			a.Ports[i] = struct{}{}
 			return i, nil

--- a/services/wireguard/service/service.go
+++ b/services/wireguard/service/service.go
@@ -21,9 +21,8 @@ import (
 	"encoding/json"
 	"sync"
 
-	"github.com/mysteriumnetwork/node/core/location"
-
 	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
@@ -68,6 +67,9 @@ type Manager struct {
 	publicIP        string
 	outboundIP      string
 	currentLocation string
+
+	mu   sync.Mutex // TODO this is a temporary solution to cleanup oldest used wireguard resources.
+	list []*func()  // TODO it should be removed once payment bases session cleanup implemented.
 }
 
 // ProvideConfig provides the config for consumer
@@ -77,6 +79,8 @@ func (manager *Manager) ProvideConfig(publicKey json.RawMessage) (session.Servic
 	if err != nil {
 		return nil, nil, err
 	}
+
+	manager.cleanOldEndpoints()
 
 	connectionEndpoint, err := manager.connectionEndpointFactory()
 	if err != nil {
@@ -110,7 +114,49 @@ func (manager *Manager) ProvideConfig(publicKey json.RawMessage) (session.Servic
 		}
 	}
 
-	return config, destroy, nil
+	return config, manager.once(destroy), nil
+}
+
+// TODO this is a temporary solution to cleanup oldest used wireguard resources.
+// TODO it should be removed once payment bases session cleanup implemented.
+func (manager *Manager) once(f func()) func() {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+
+	once := sync.Once{}
+	cleanOnce := func() {
+		once.Do(f)
+	}
+	manager.list = append(manager.list, &cleanOnce)
+
+	return func() {
+		cleanOnce()
+
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+
+		for i := range manager.list {
+			if manager.list[i] == &cleanOnce {
+				manager.list = append(manager.list[0:i], manager.list[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// TODO this is a temporary solution to cleanup oldest used wireguard resources.
+// TODO it should be removed once payment bases session cleanup implemented.
+func (manager *Manager) cleanOldEndpoints() {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+
+	if len(manager.list) >= resources.MaxResources-1 {
+		log.Warn(logPrefix, "We have reached a maximum number of interfaces. Cleaning up oldest one.")
+
+		f := *manager.list[0]
+		f()
+		manager.list = manager.list[1:]
+	}
 }
 
 // Serve starts service - does block


### PR DESCRIPTION
Once we are waiting for proper session cleanup in https://github.com/mysteriumnetwork/node/issues/672

This PR will allow rotating old wireguard resources (interfaces, subnets, listen ports) to allow new connections. 