### PR TITLE
Tequilapi endpoint for service sessions

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -45,8 +45,9 @@ const cliCommandName = "cli"
 const serviceHelp = `service <action> [args]
 	start	<ProviderID> <ServiceType> [options]
 	stop	<ServiceID>
-	list
 	status	<ServiceID>
+	list
+	sessions
 
 	example: service start 0x7d5ee3557775aed0b85d691b036769c17349db23 openvpn --openvpn.port=1194 --openvpn.proto=UDP`
 
@@ -205,6 +206,8 @@ func (c *cliApp) service(argsString string) {
 		c.serviceGet(args[1])
 	case "list":
 		c.serviceList()
+	case "sessions":
+		c.serviceSessions()
 	default:
 		info(fmt.Sprintf("Unknown action provided: %s", action))
 		fmt.Println(serviceHelp)
@@ -251,6 +254,19 @@ func (c *cliApp) serviceList() {
 			"ID: "+service.ID,
 			"ProviderID: "+service.Proposal.ProviderID,
 			"Type: "+service.Proposal.ServiceType)
+	}
+}
+
+func (c *cliApp) serviceSessions() {
+	sessions, err := c.tequilapi.ServiceSessions()
+	if err != nil {
+		info("Failed to get a list of sessions: ", err)
+		return
+	}
+
+	status("Current sessions", len(sessions.Sessions))
+	for _, session := range sessions.Sessions {
+		status("ID: "+session.ID, "ConsumerID: "+session.ConsumerID)
 	}
 }
 
@@ -601,6 +617,7 @@ func newAutocompleter(tequilapi *tequilapi_client.Client, proposals []tequilapi_
 			readline.PcItem("stop"),
 			readline.PcItem("list"),
 			readline.PcItem("status"),
+			readline.PcItem("sessions"),
 		),
 		readline.PcItem(
 			"identities",

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -283,9 +283,9 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options) {
 	tequilapi_endpoints.AddRouteForStop(router, utils.SoftKiller(di.Shutdown))
 	tequilapi_endpoints.AddRoutesForIdentities(router, di.IdentityManager)
 	tequilapi_endpoints.AddRoutesForConnection(router, di.ConnectionManager, di.IPResolver, di.StatisticsTracker, di.MysteriumAPI)
+	tequilapi_endpoints.AddRoutesForConnectionSessions(router, di.SessionStorage)
 	tequilapi_endpoints.AddRoutesForLocation(router, di.ConnectionManager, di.LocationDetector, di.LocationOriginal)
 	tequilapi_endpoints.AddRoutesForProposals(router, di.MysteriumAPI, di.MysteriumMorqaClient)
-	tequilapi_endpoints.AddRoutesForSession(router, di.SessionStorage)
 	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, serviceTypesRequestParser)
 	tequilapi_endpoints.AddRoutesForPayout(router, di.IdentityManager, di.SignerFactory, di.MysteriumAPI)
 

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -287,8 +287,8 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options) {
 	tequilapi_endpoints.AddRoutesForLocation(router, di.ConnectionManager, di.LocationDetector, di.LocationOriginal)
 	tequilapi_endpoints.AddRoutesForProposals(router, di.MysteriumAPI, di.MysteriumMorqaClient)
 	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, serviceTypesRequestParser)
+	tequilapi_endpoints.AddRoutesForServiceSessions(router, di.ServiceSessionStorage)
 	tequilapi_endpoints.AddRoutesForPayout(router, di.IdentityManager, di.SignerFactory, di.MysteriumAPI)
-
 	identity_registry.AddIdentityRegistrationEndpoint(router, di.IdentityRegistration, di.IdentityRegistry)
 
 	corsPolicy := tequilapi.NewMysteriumCorsPolicy()

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -141,7 +141,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 	seelog.Info("Changed consumer IP: ", vpnIP)
 
 	// sessions history should be created after connect
-	sessionsDTO, err := tequilapi.GetSessionsByType(serviceType)
+	sessionsDTO, err := tequilapi.ConnectionSessionsByType(serviceType)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(sessionsDTO.Sessions))
@@ -165,7 +165,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 	assert.NoError(t, err)
 
 	// sessions history should be updated after disconnect
-	sessionsDTO, err = tequilapi.GetSessionsByType(serviceType)
+	sessionsDTO, err = tequilapi.ConnectionSessionsByType(serviceType)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(sessionsDTO.Sessions))
@@ -177,7 +177,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 	serviceTypeAssertionMap[serviceType](t, se)
 }
 
-type sessionAsserter func(t *testing.T, session tequilapi_client.SessionDTO)
+type sessionAsserter func(t *testing.T, session tequilapi_client.ConnectionSessionDTO)
 
 var serviceTypeAssertionMap = map[string]sessionAsserter{
 	"openvpn":   assertStatsNotZero,
@@ -185,12 +185,12 @@ var serviceTypeAssertionMap = map[string]sessionAsserter{
 	"wireguard": assertStatsNotZero,
 }
 
-func assertStatsNotZero(t *testing.T, session tequilapi_client.SessionDTO) {
+func assertStatsNotZero(t *testing.T, session tequilapi_client.ConnectionSessionDTO) {
 	assert.NotEqual(t, uint64(0), session.BytesSent)
 	assert.NotEqual(t, uint64(0), session.BytesReceived)
 }
 
-func assertStatsZero(t *testing.T, session tequilapi_client.SessionDTO) {
+func assertStatsZero(t *testing.T, session tequilapi_client.ConnectionSessionDTO) {
 	assert.Equal(t, uint64(0), session.BytesSent)
 	assert.Equal(t, uint64(0), session.BytesReceived)
 }

--- a/session/storage_memory.go
+++ b/session/storage_memory.go
@@ -43,6 +43,16 @@ func (storage *StorageMemory) Add(sessionInstance Session) {
 	storage.sessionMap[sessionInstance.ID] = sessionInstance
 }
 
+// GetAll returns all sessions in storage
+func (storage *StorageMemory) GetAll() ([]Session, error) {
+	i := 0
+	list := make([]Session, len(storage.sessionMap))
+	for _, se := range storage.sessionMap {
+		list[i] = se
+	}
+	return list, nil
+}
+
 // Find returns underlying session instance
 func (storage *StorageMemory) Find(id ID) (Session, bool) {
 	sessionInstance, found := storage.sessionMap[id]

--- a/session/storage_memory_test.go
+++ b/session/storage_memory_test.go
@@ -33,6 +33,7 @@ func TestStorage_FindSession_Existing(t *testing.T) {
 	storage := mockStorage(sessionExisting)
 
 	sessionInstance, found := storage.Find(sessionExisting.ID)
+
 	assert.True(t, found)
 	assert.Exactly(t, sessionExisting, sessionInstance)
 }
@@ -52,17 +53,32 @@ func TestStorage_Add(t *testing.T) {
 	}
 
 	storage.Add(sessionNew)
-	assert.Len(t, storage.sessionMap, 2)
-	assert.Exactly(t, sessionNew, storage.sessionMap[sessionNew.ID])
+	assert.Exactly(
+		t,
+		[]Session{sessionExisting, sessionNew},
+		storage.sessions,
+	)
+	assert.Exactly(
+		t,
+		map[ID]int{
+			sessionExisting.ID: 0,
+			sessionNew.ID:      1,
+		},
+		storage.sessionMap,
+	)
 }
 
 func TestStorage_GetAll(t *testing.T) {
 	sessionFirst := Session{ID: ID("id1")}
 	sessionSecond := Session{ID: ID("id2")}
 	storage := &StorageMemory{
-		sessionMap: map[ID]Session{
-			sessionFirst.ID:  sessionFirst,
-			sessionSecond.ID: sessionSecond,
+		sessions: []Session{
+			sessionFirst,
+			sessionSecond,
+		},
+		sessionMap: map[ID]int{
+			sessionFirst.ID:  0,
+			sessionSecond.ID: 1,
 		},
 	}
 
@@ -75,13 +91,15 @@ func TestStorage_Remove(t *testing.T) {
 	storage := mockStorage(sessionExisting)
 
 	storage.Remove(sessionExisting.ID)
+	assert.Len(t, storage.sessions, 0)
 	assert.Len(t, storage.sessionMap, 0)
 }
 
 func mockStorage(sessionInstance Session) *StorageMemory {
 	return &StorageMemory{
-		sessionMap: map[ID]Session{
-			sessionInstance.ID: sessionInstance,
+		sessions: []Session{sessionInstance},
+		sessionMap: map[ID]int{
+			sessionInstance.ID: 0,
 		},
 	}
 }

--- a/session/storage_memory_test.go
+++ b/session/storage_memory_test.go
@@ -56,6 +56,21 @@ func TestStorage_Add(t *testing.T) {
 	assert.Exactly(t, sessionNew, storage.sessionMap[sessionNew.ID])
 }
 
+func TestStorage_GetAll(t *testing.T) {
+	sessionFirst := Session{ID: ID("id1")}
+	sessionSecond := Session{ID: ID("id2")}
+	storage := &StorageMemory{
+		sessionMap: map[ID]Session{
+			sessionFirst.ID:  sessionFirst,
+			sessionSecond.ID: sessionSecond,
+		},
+	}
+
+	sessions, err := storage.GetAll()
+	assert.NoError(t, err)
+	assert.Equal(t, sessions, []Session{sessionFirst, sessionSecond})
+}
+
 func TestStorage_Remove(t *testing.T) {
 	storage := mockStorage(sessionExisting)
 

--- a/session/storage_memory_test.go
+++ b/session/storage_memory_test.go
@@ -64,7 +64,7 @@ func TestStorage_Add(t *testing.T) {
 			sessionExisting.ID: 0,
 			sessionNew.ID:      1,
 		},
-		storage.sessionMap,
+		storage.idToIndex,
 	)
 }
 
@@ -76,7 +76,7 @@ func TestStorage_GetAll(t *testing.T) {
 			sessionFirst,
 			sessionSecond,
 		},
-		sessionMap: map[ID]int{
+		idToIndex: map[ID]int{
 			sessionFirst.ID:  0,
 			sessionSecond.ID: 1,
 		},
@@ -92,13 +92,13 @@ func TestStorage_Remove(t *testing.T) {
 
 	storage.Remove(sessionExisting.ID)
 	assert.Len(t, storage.sessions, 0)
-	assert.Len(t, storage.sessionMap, 0)
+	assert.Len(t, storage.idToIndex, 0)
 }
 
 func mockStorage(sessionInstance Session) *StorageMemory {
 	return &StorageMemory{
 		sessions: []Session{sessionInstance},
-		sessionMap: map[ID]int{
+		idToIndex: map[ID]int{
 			sessionInstance.ID: 0,
 		},
 	}

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -240,16 +240,30 @@ func (client *Client) Stop() error {
 	return nil
 }
 
-// GetSessions returns all sessions from history
-func (client *Client) GetSessions() (SessionsDTO, error) {
-	sessions := SessionsDTO{}
-	response, err := client.http.Get("sessions", url.Values{})
+// ConnectionSessions returns all sessions from history
+func (client *Client) ConnectionSessions() (ConnectionSessionListDTO, error) {
+	sessions := ConnectionSessionListDTO{}
+	response, err := client.http.Get("connection-sessions", url.Values{})
 	if err != nil {
 		return sessions, err
 	}
 	defer response.Body.Close()
 
 	err = parseResponseJSON(response, &sessions)
+	return sessions, err
+}
+
+// ConnectionSessionsByType returns sessions from history filtered by type
+func (client *Client) ConnectionSessionsByType(serviceType string) (ConnectionSessionListDTO, error) {
+	sessions, err := client.ConnectionSessions()
+	sessions = filterSessionsByType(serviceType, sessions)
+	return sessions, err
+}
+
+// ConnectionSessionsByStatus returns sessions from history filtered by their status
+func (client *Client) ConnectionSessionsByStatus(status string) (ConnectionSessionListDTO, error) {
+	sessions, err := client.ConnectionSessions()
+	sessions = filterSessionsByStatus(status, sessions)
 	return sessions, err
 }
 
@@ -317,7 +331,7 @@ func (client *Client) ServiceStop(id string) error {
 }
 
 // filterSessionsByType removes all sessions of irrelevant types
-func filterSessionsByType(serviceType string, sessions SessionsDTO) SessionsDTO {
+func filterSessionsByType(serviceType string, sessions ConnectionSessionListDTO) ConnectionSessionListDTO {
 	matches := 0
 	for _, s := range sessions.Sessions {
 		if s.ServiceType == serviceType {
@@ -330,7 +344,7 @@ func filterSessionsByType(serviceType string, sessions SessionsDTO) SessionsDTO 
 }
 
 // filterSessionsByStatus removes all sessions with non matching status
-func filterSessionsByStatus(status string, sessions SessionsDTO) SessionsDTO {
+func filterSessionsByStatus(status string, sessions ConnectionSessionListDTO) ConnectionSessionListDTO {
 	matches := 0
 	for _, s := range sessions.Sessions {
 		if s.Status == status {
@@ -340,18 +354,4 @@ func filterSessionsByStatus(status string, sessions SessionsDTO) SessionsDTO {
 	}
 	sessions.Sessions = sessions.Sessions[:matches]
 	return sessions
-}
-
-// GetSessionsByType returns sessions from history filtered by type
-func (client *Client) GetSessionsByType(serviceType string) (SessionsDTO, error) {
-	sessions, err := client.GetSessions()
-	sessions = filterSessionsByType(serviceType, sessions)
-	return sessions, err
-}
-
-// GetSessionsByStatus returns sessions from history filtered by their status
-func (client *Client) GetSessionsByStatus(status string) (SessionsDTO, error) {
-	sessions, err := client.GetSessions()
-	sessions = filterSessionsByStatus(status, sessions)
-	return sessions, err
 }

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -330,6 +330,19 @@ func (client *Client) ServiceStop(id string) error {
 	return nil
 }
 
+// ServiceSessions returns all currently running sessions
+func (client *Client) ServiceSessions() (ServiceSessionListDTO, error) {
+	sessions := ServiceSessionListDTO{}
+	response, err := client.http.Get("service-sessions", url.Values{})
+	if err != nil {
+		return sessions, err
+	}
+	defer response.Body.Close()
+
+	err = parseResponseJSON(response, &sessions)
+	return sessions, err
+}
+
 // filterSessionsByType removes all sessions of irrelevant types
 func filterSessionsByType(serviceType string, sessions ConnectionSessionListDTO) ConnectionSessionListDTO {
 	matches := 0

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -113,13 +113,13 @@ type ConnectOptions struct {
 	DisableKillSwitch bool `json:"killSwitch"`
 }
 
-// SessionsDTO copied from tequilapi endpoint
-type SessionsDTO struct {
-	Sessions []SessionDTO `json:"sessions"`
+// ConnectionSessionListDTO copied from tequilapi endpoint
+type ConnectionSessionListDTO struct {
+	Sessions []ConnectionSessionDTO `json:"sessions"`
 }
 
-// SessionDTO copied from tequilapi endpoint
-type SessionDTO struct {
+// ConnectionSessionDTO copied from tequilapi endpoint
+type ConnectionSessionDTO struct {
 	SessionID       string `json:"sessionId"`
 	ProviderID      string `json:"providerId"`
 	ServiceType     string `json:"serviceType"`

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -143,3 +143,14 @@ type ServiceInfoDTO struct {
 	Status      string          `json:"status"`
 	Proposal    ProposalDTO     `json:"proposal"`
 }
+
+// ServiceSessionListDTO copied from tequilapi endpoint
+type ServiceSessionListDTO struct {
+	Sessions []ServiceSessionDTO `json:"sessions"`
+}
+
+// ServiceSessionDTO copied from tequilapi endpoint
+type ServiceSessionDTO struct {
+	ID         string `json:"id"`
+	ConsumerID string `json:"consumerId"`
+}

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -148,7 +148,7 @@ func (ce *ConnectionEndpoint) Status(resp http.ResponseWriter, _ *http.Request, 
 }
 
 // Create starts new connection
-// swagger:operation PUT /connection Connection createConnection
+// swagger:operation PUT /connection Connection connectionCreate
 // ---
 // summary: Starts new connection
 // description: Consumer opens connection to provider
@@ -228,7 +228,7 @@ func (ce *ConnectionEndpoint) Create(resp http.ResponseWriter, req *http.Request
 }
 
 // Kill stops connection
-// swagger:operation DELETE /connection Connection killConnection
+// swagger:operation DELETE /connection Connection connectionCancel
 // ---
 // summary: Stops connection
 // description: Stops current connection
@@ -258,7 +258,7 @@ func (ce *ConnectionEndpoint) Kill(resp http.ResponseWriter, req *http.Request, 
 }
 
 // GetIP responds with current ip, using its ip resolver
-// swagger:operation GET /connection/ip Location getIP
+// swagger:operation GET /connection/ip Connection connectionIP
 // ---
 // summary: Returns IP address
 // description: Returns current public IP address
@@ -290,7 +290,7 @@ func (ce *ConnectionEndpoint) GetIP(writer http.ResponseWriter, request *http.Re
 }
 
 // GetStatistics returns statistics about current connection
-// swagger:operation GET /connection/statistics Connection getStatistics
+// swagger:operation GET /connection/statistics Connection connectionStatistics
 // ---
 // summary: Returns connection statistics
 // description: Returns statistics about current connection

--- a/tequilapi/endpoints/connection_sessions.go
+++ b/tequilapi/endpoints/connection_sessions.go
@@ -98,11 +98,12 @@ func (endpoint *connectionSessionsEndpoint) List(resp http.ResponseWriter, reque
 		utils.SendError(resp, err, http.StatusInternalServerError)
 		return
 	}
+
 	sessionsSerializable := connectionSessionsList{Sessions: mapConnectionSessions(sessions, connectionSessionToDto)}
 	utils.WriteAsJSON(sessionsSerializable, resp)
 }
 
-// AddRoutesForConnectionSessions attaches sessions endpoints to router
+// AddRoutesForConnectionSessions attaches connection sessions endpoints to router
 func AddRoutesForConnectionSessions(router *httprouter.Router, sessionStorage connectionSessionStorage) {
 	sessionsEndpoint := NewConnectionSessionsEndpoint(sessionStorage)
 	router.GET("/connection-sessions", sessionsEndpoint.List)

--- a/tequilapi/endpoints/connection_sessions.go
+++ b/tequilapi/endpoints/connection_sessions.go
@@ -79,7 +79,7 @@ func NewConnectionSessionsEndpoint(sessionStorage connectionSessionStorage) *con
 	}
 }
 
-// swagger:operation GET /sessions ConnectionSessions listSessions
+// swagger:operation GET /sessions Connection connectionSessions
 // ---
 // summary: Returns sessions history
 // description: Returns list of sessions history

--- a/tequilapi/endpoints/service_sessions.go
+++ b/tequilapi/endpoints/service_sessions.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package endpoints
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/mysteriumnetwork/node/session"
+	"github.com/mysteriumnetwork/node/tequilapi/utils"
+)
+
+// serviceSessionsList defines session list representable as json
+// swagger:model ServiceSessionListDTO
+type serviceSessionsList struct {
+	Sessions []serviceSession `json:"sessions"`
+}
+
+// serviceSession represents the session object
+// swagger:model ServiceSessionDTO
+type serviceSession struct {
+	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
+	ID string `json:"id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	ConsumerID string `json:"consumerId"`
+}
+
+type serviceSessionsEndpoint struct{}
+
+// NewServiceSessionsEndpoint creates and returns sessions endpoint
+func NewServiceSessionsEndpoint() *serviceSessionsEndpoint {
+	return &serviceSessionsEndpoint{}
+}
+
+// swagger:operation GET /service/:id/sessions ServiceSessions listSessions
+// ---
+// summary: Returns current sessions
+// description: Returns list of sessions in currently running service
+// responses:
+//   200:
+//     description: List of sessions
+//     schema:
+//       "$ref": "#/definitions/ServiceSessionListDTO"
+//   500:
+//     description: Internal server error
+//     schema:
+//       "$ref": "#/definitions/ErrorMessageDTO"
+func (endpoint *serviceSessionsEndpoint) List(resp http.ResponseWriter, request *http.Request, params httprouter.Params) {
+	sessions := make([]session.Session, 0)
+
+	sessionsSerializable := serviceSessionsList{
+		Sessions: mapServiceSessions(sessions, serviceSessionToDto),
+	}
+	utils.WriteAsJSON(sessionsSerializable, resp)
+}
+
+func serviceSessionToDto(se session.Session) serviceSession {
+	return serviceSession{
+		ID:         string(se.ID),
+		ConsumerID: se.ConsumerID.Address,
+	}
+}
+
+func mapServiceSessions(sessions []session.Session, f func(session.Session) serviceSession) []serviceSession {
+	dtoArray := make([]serviceSession, len(sessions))
+	for i, se := range sessions {
+		dtoArray[i] = f(se)
+	}
+	return dtoArray
+}

--- a/tequilapi/endpoints/service_sessions.go
+++ b/tequilapi/endpoints/service_sessions.go
@@ -56,7 +56,7 @@ func NewServiceSessionsEndpoint(sessionStorage serviceSessionStorage) *serviceSe
 	}
 }
 
-// swagger:operation GET /service/:id/sessions ServiceSessions listSessions
+// swagger:operation GET /service/:id/sessions Service serviceSessions
 // ---
 // summary: Returns current sessions
 // description: Returns list of sessions in currently running service

--- a/tequilapi/endpoints/service_sessions_test.go
+++ b/tequilapi/endpoints/service_sessions_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package endpoints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/session"
+)
+
+var (
+	serviceSessionMock = session.Session{
+		ID:         session.ID("session1"),
+		ConsumerID: identity.FromAddress("ProviderID"),
+	}
+)
+
+func Test_ServiceSessionsEndpoint_SessionToDto(t *testing.T) {
+	se := serviceSessionMock
+	sessionDTO := serviceSessionToDto(se)
+
+	assert.Equal(t, string(serviceSessionMock.ID), sessionDTO.ID)
+	assert.Equal(t, serviceSessionMock.ConsumerID.Address, sessionDTO.ConsumerID)
+}

--- a/tequilapi/endpoints/service_sessions_test.go
+++ b/tequilapi/endpoints/service_sessions_test.go
@@ -18,6 +18,11 @@
 package endpoints
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,4 +44,63 @@ func Test_ServiceSessionsEndpoint_SessionToDto(t *testing.T) {
 
 	assert.Equal(t, string(serviceSessionMock.ID), sessionDTO.ID)
 	assert.Equal(t, serviceSessionMock.ConsumerID.Address, sessionDTO.ConsumerID)
+}
+
+func Test_ServiceSessionsEndpoint_List(t *testing.T) {
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"/irrelevant",
+		nil,
+	)
+	assert.Nil(t, err)
+
+	ssm := &serviceSessionStorageMock{
+		errToReturn: nil,
+		sessionsToReturn: []session.Session{
+			serviceSessionMock,
+		},
+	}
+
+	resp := httptest.NewRecorder()
+	handlerFunc := NewServiceSessionsEndpoint(ssm).List
+	handlerFunc(resp, req, nil)
+
+	parsedResponse := &serviceSessionsList{}
+	err = json.Unmarshal(resp.Body.Bytes(), parsedResponse)
+	assert.Nil(t, err)
+	assert.EqualValues(t, serviceSessionToDto(serviceSessionMock), parsedResponse.Sessions[0])
+}
+
+func Test_ServiceSessionsEndpoint_ListBubblesError(t *testing.T) {
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"/irrelevant",
+		nil,
+	)
+	assert.Nil(t, err)
+
+	mockErr := errors.New("something exploded")
+	ssm := &serviceSessionStorageMock{
+		errToReturn:      mockErr,
+		sessionsToReturn: []session.Session{},
+	}
+
+	resp := httptest.NewRecorder()
+	handlerFunc := NewServiceSessionsEndpoint(ssm).List
+	handlerFunc(resp, req, nil)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Equal(t,
+		fmt.Sprintf(`{"message":%q}%v`, mockErr.Error(), "\n"),
+		resp.Body.String(),
+	)
+}
+
+type serviceSessionStorageMock struct {
+	sessionsToReturn []session.Session
+	errToReturn      error
+}
+
+func (ssm *serviceSessionStorageMock) GetAll() ([]session.Session, error) {
+	return ssm.sessionsToReturn, ssm.errToReturn
 }

--- a/tequilapi/endpoints/service_sessions_test.go
+++ b/tequilapi/endpoints/service_sessions_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	serviceSessionMock = session.Session{
 		ID:         session.ID("session1"),
-		ConsumerID: identity.FromAddress("ProviderID"),
+		ConsumerID: identity.FromAddress("consumer1"),
 	}
 )
 


### PR DESCRIPTION
- Rename  endpoint `/sessions` to `/connection-sessions`
- Expose service sessions endpoint at `/service-sessions`
- Service sessions ATM has just minimal fields (id, consumerId)