### PR TITLE
payment pingpong now enabled by default

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -275,7 +275,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options) {
 	di.ConnectionRegistry = connection.NewRegistry()
 	di.ConnectionManager = connection.NewManager(
 		dialogFactory,
-		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory, time.Second*20),
+		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory, payment_factory.SendRetryDuration),
 		di.ConnectionRegistry.CreateConnection,
 		di.EventBus,
 	)
@@ -335,7 +335,7 @@ func newSessionManagerFactory(
 			// TODO: the ints and times here need to be passed in as well, or defined as constants
 			tracker := balance.NewBalanceTracker(&timeTracker, amountCalc, 0)
 			validator := validators.NewIssuedPromiseValidator(consumerID, receiverID, issuerID)
-			return session_payment.NewSessionBalance(sender, tracker, promiseChan, time.Second*240, time.Second*120, validator, promiseStorage, consumerID, receiverID, issuerID), nil
+			return session_payment.NewSessionBalance(sender, tracker, promiseChan, payment_factory.BalanceSendPeriod, payment_factory.PromiseWaitTimeout, validator, promiseStorage, consumerID, receiverID, issuerID), nil
 		}
 		return session.NewManager(
 			proposal,

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -275,7 +275,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options) {
 	di.ConnectionRegistry = connection.NewRegistry()
 	di.ConnectionManager = connection.NewManager(
 		dialogFactory,
-		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory, payment_factory.SendRetryDuration),
+		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory),
 		di.ConnectionRegistry.CreateConnection,
 		di.EventBus,
 	)

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -51,6 +51,7 @@ import (
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/nat"
 	service_noop "github.com/mysteriumnetwork/node/services/noop"
+	"github.com/mysteriumnetwork/node/services/openvpn"
 	service_openvpn "github.com/mysteriumnetwork/node/services/openvpn"
 	"github.com/mysteriumnetwork/node/services/openvpn/discovery/dto"
 	"github.com/mysteriumnetwork/node/session"
@@ -274,7 +275,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options) {
 	di.ConnectionRegistry = connection.NewRegistry()
 	di.ConnectionManager = connection.NewManager(
 		dialogFactory,
-		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory),
+		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory, time.Second*20),
 		di.ConnectionRegistry.CreateConnection,
 		di.EventBus,
 	)
@@ -306,8 +307,10 @@ func newSessionManagerFactory(
 ) session.ManagerFactory {
 	return func(dialog communication.Dialog) *session.Manager {
 		providerBalanceTrackerFactory := func(consumerID, receiverID, issuerID identity.Identity) (session.BalanceTracker, error) {
-			// if the flag ain't set, just return a noop balance tracker
-			if !nodeOptions.ExperimentPayments {
+			// We want backwards compatibility for openvpn on desktop providers, so no payments for them.
+			// Splitting this as a separate case just for that reason.
+			// TODO: remove this one day.
+			if proposal.ServiceType == openvpn.ServiceType {
 				return payments_noop.NewSessionBalance(), nil
 			}
 
@@ -316,7 +319,7 @@ func newSessionManagerFactory(
 			payment := dto.PaymentPerTime{
 				Price: money.Money{
 					Currency: money.CurrencyMyst,
-					Amount:   uint64(10),
+					Amount:   uint64(0),
 				},
 				Duration: time.Minute,
 			}
@@ -332,7 +335,7 @@ func newSessionManagerFactory(
 			// TODO: the ints and times here need to be passed in as well, or defined as constants
 			tracker := balance.NewBalanceTracker(&timeTracker, amountCalc, 0)
 			validator := validators.NewIssuedPromiseValidator(consumerID, receiverID, issuerID)
-			return session_payment.NewSessionBalance(sender, tracker, promiseChan, time.Second*5, time.Second*1, validator, promiseStorage, consumerID, receiverID, issuerID), nil
+			return session_payment.NewSessionBalance(sender, tracker, promiseChan, time.Second*240, time.Second*120, validator, promiseStorage, consumerID, receiverID, issuerID), nil
 		}
 		return session.NewManager(
 			proposal,

--- a/cmd/flags_network.go
+++ b/cmd/flags_network.go
@@ -38,11 +38,6 @@ var (
 		Usage: "Enables experimental identity check",
 	}
 
-	paymentCheckFlag = cli.BoolFlag{
-		Name:  "experiment-payments",
-		Usage: "Enables experimental payments check",
-	}
-
 	discoveryAddressFlag = cli.StringFlag{
 		Name:  "discovery-address",
 		Usage: "`URL` of discovery service",
@@ -78,7 +73,6 @@ func RegisterFlagsNetwork(flags *[]cli.Flag) {
 		*flags,
 		testFlag, localnetFlag,
 		identityCheckFlag,
-		paymentCheckFlag,
 		discoveryAddressFlag, brokerAddressFlag,
 		etherRPCFlag, etherContractPaymentsFlag,
 		qualityOracleFlag,
@@ -92,7 +86,6 @@ func ParseFlagsNetwork(ctx *cli.Context) node.OptionsNetwork {
 		ctx.GlobalBool(localnetFlag.Name),
 
 		ctx.GlobalBool(identityCheckFlag.Name),
-		ctx.GlobalBool(paymentCheckFlag.Name),
 
 		ctx.GlobalString(discoveryAddressFlag.Name),
 		ctx.GlobalString(brokerAddressFlag.Name),

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -174,7 +174,7 @@ func (manager *connectionManager) launchPayments(paymentInfo *promise.PaymentInf
 	payment := dto.PaymentPerTime{
 		Price: money.Money{
 			Currency: money.CurrencyMyst,
-			Amount:   uint64(10),
+			Amount:   uint64(0),
 		},
 		Duration: time.Minute,
 	}

--- a/core/node/options_network.go
+++ b/core/node/options_network.go
@@ -23,7 +23,6 @@ type OptionsNetwork struct {
 	Localnet bool
 
 	ExperimentIdentityCheck bool
-	ExperimentPayments      bool
 
 	DiscoveryAPIAddress string
 	BrokerAddress       string

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       --ipify-url=http://ipify:3000
       --location.country=e2e-land
       --experiment-identity-check
-      --experiment-payments
       --localnet
       --broker-address=broker
       --discovery-address=http://discovery/v1
@@ -47,7 +46,6 @@ services:
     command: >
       --ipify-url=http://ipify:3000
       --experiment-identity-check
-      --experiment-payments
       --localnet
       --discovery-address=http://discovery/v1
       --ether.client.rpc=http://geth:8545

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -88,7 +88,6 @@ func DefaultNetworkOptions() *MobileNetworkOptions {
 	return &MobileNetworkOptions{
 		Testnet:                 true,
 		ExperimentIdentityCheck: false,
-		ExperimentPayments:      false,
 		DiscoveryAPIAddress:     metadata.TestnetDefinition.DiscoveryAPIAddress,
 		BrokerAddress:           metadata.TestnetDefinition.BrokerAddress,
 		EtherClientRPC:          metadata.TestnetDefinition.EtherClientRPC,

--- a/session/payment/factory/payments.go
+++ b/session/payment/factory/payments.go
@@ -34,14 +34,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// SendRetryDuration is the time between sending retries for the consumer payments
-const SendRetryDuration = time.Second * 20
-
 // PromiseWaitTimeout is the time that the provider waits for the promise to arrive
-const PromiseWaitTimeout = time.Second * 120
+const PromiseWaitTimeout = time.Second * 10
 
 // BalanceSendPeriod is how often the provider will send balance messages to the consumer
-const BalanceSendPeriod = time.Second * 240
+const BalanceSendPeriod = time.Second * 20
 
 // PaymentIssuerFactoryFunc returns a factory for payment issuer. It will be noop if the experimental payment flag is not set
 func PaymentIssuerFactoryFunc(nodeOptions node.Options, signerFactory identity.SignerFactory, sendRetryDuration time.Duration) func(

--- a/session/payment/factory/payments.go
+++ b/session/payment/factory/payments.go
@@ -34,6 +34,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+// SendRetryDuration is the time between sending retries for the consumer payments
+const SendRetryDuration = time.Second * 20
+
+// PromiseWaitTimeout is the time that the provider waits for the promise to arrive
+const PromiseWaitTimeout = time.Second * 120
+
+// BalanceSendPeriod is how often the provider will send balance messages to the consumer
+const BalanceSendPeriod = time.Second * 240
+
 // PaymentIssuerFactoryFunc returns a factory for payment issuer. It will be noop if the experimental payment flag is not set
 func PaymentIssuerFactoryFunc(nodeOptions node.Options, signerFactory identity.SignerFactory, sendRetryDuration time.Duration) func(
 	initialState promise.PaymentInfo,

--- a/session/payment/factory/payments.go
+++ b/session/payment/factory/payments.go
@@ -41,13 +41,13 @@ const PromiseWaitTimeout = time.Second * 10
 const BalanceSendPeriod = time.Second * 20
 
 // PaymentIssuerFactoryFunc returns a factory for payment issuer. It will be noop if the experimental payment flag is not set
-func PaymentIssuerFactoryFunc(nodeOptions node.Options, signerFactory identity.SignerFactory, sendRetryDuration time.Duration) func(
+func PaymentIssuerFactoryFunc(nodeOptions node.Options, signerFactory identity.SignerFactory) func(
 	initialState promise.PaymentInfo,
 	paymentDefinition dto.PaymentPerTime,
 	messageChan chan balance.Message,
 	dialog communication.Dialog,
 	consumer, provider identity.Identity) (connection.PaymentIssuer, error) {
-	return paymentIssuerFactory(signerFactory, sendRetryDuration)
+	return paymentIssuerFactory(signerFactory)
 }
 
 func noopPaymentIssuerFactory(initialState promise.PaymentInfo,
@@ -59,7 +59,7 @@ func noopPaymentIssuerFactory(initialState promise.PaymentInfo,
 
 }
 
-func paymentIssuerFactory(signerFactory identity.SignerFactory, sendRetryDuration time.Duration) func(
+func paymentIssuerFactory(signerFactory identity.SignerFactory) func(
 	initialState promise.PaymentInfo,
 	paymentDefinition dto.PaymentPerTime,
 	messageChan chan balance.Message,
@@ -82,7 +82,7 @@ func paymentIssuerFactory(signerFactory identity.SignerFactory, sendRetryDuratio
 		amountCalc := session.AmountCalc{PaymentDef: paymentDefinition}
 
 		balanceTracker := balance.NewBalanceTracker(&timeTracker, amountCalc, initialState.FreeCredit)
-		payments := payment.NewSessionPayments(messageChan, ps, tracker, balanceTracker, sendRetryDuration)
+		payments := payment.NewSessionPayments(messageChan, ps, tracker, balanceTracker)
 		err := dialog.Receive(bl.GetConsumer())
 		return payments, errors.Wrap(err, "fail to receive from consumer")
 	}

--- a/session/payment/session_balance.go
+++ b/session/payment/session_balance.go
@@ -142,11 +142,7 @@ func (sb *SessionBalance) sendBalanceExpectPromise() error {
 	if err != nil {
 		return err
 	}
-	err = sb.receivePromiseOrTimeout()
-	if err != nil {
-		return err
-	}
-	return nil
+	return sb.receivePromiseOrTimeout()
 }
 
 func (sb *SessionBalance) loadInitialPromiseState() (promise.StoredPromise, error) {

--- a/session/payment/session_payments.go
+++ b/session/payment/session_payments.go
@@ -91,6 +91,8 @@ func (cpo *SessionPayments) Start() error {
 	}
 }
 
+const numberOfRetriesForSend = 5
+
 func (cpo *SessionPayments) issuePromise(balance balance.Message) error {
 	err := cpo.promiseTracker.AlignStateWithProvider(promise.State{
 		Seq:    balance.SequenceID,
@@ -116,7 +118,7 @@ func (cpo *SessionPayments) issuePromise(balance balance.Message) error {
 			SequenceID: issuedPromise.Promise.SeqNo,
 			Signature:  fmt.Sprintf("0x%v", hex.EncodeToString(issuedPromise.IssuerSignature)),
 		})
-	}, 5, cpo.sendRetryDuration)
+	}, numberOfRetriesForSend, cpo.sendRetryDuration)
 	if err != nil {
 		return err
 	}

--- a/session/payment/session_payments.go
+++ b/session/payment/session_payments.go
@@ -21,7 +21,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
+	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/session/balance"
 	"github.com/mysteriumnetwork/node/session/promise"
 	"github.com/mysteriumnetwork/payments/promises"
@@ -45,21 +47,25 @@ type SessionPayments struct {
 	peerPromiseSender PeerPromiseSender
 	promiseTracker    PromiseTracker
 	balanceTracker    BalanceTracker
+	sendRetryDuration time.Duration
 }
 
 // NewSessionPayments returns a new instance of consumer payment orchestrator
-func NewSessionPayments(balanceChan chan balance.Message, peerPromiseSender PeerPromiseSender, promiseTracker PromiseTracker, balanceTracker BalanceTracker) *SessionPayments {
+func NewSessionPayments(balanceChan chan balance.Message, peerPromiseSender PeerPromiseSender, promiseTracker PromiseTracker, balanceTracker BalanceTracker, sendRetryDuration time.Duration) *SessionPayments {
 	return &SessionPayments{
 		stop:              make(chan struct{}),
 		balanceChan:       balanceChan,
 		peerPromiseSender: peerPromiseSender,
 		promiseTracker:    promiseTracker,
 		balanceTracker:    balanceTracker,
+		sendRetryDuration: sendRetryDuration,
 	}
 }
 
 // balanceDifferenceThreshold determines the threshold where we'll cancel the session if there's a missmatch larger than the threshold provided between the provider and the consumer balances
 const balanceDifferenceThreshold uint64 = 20
+
+const sessionPaymentsLogPrefix = "[session-payments] "
 
 // ErrBalanceMissmatch represents an error that occurs when balances do not match
 var ErrBalanceMissmatch = errors.New("balance missmatch")
@@ -103,14 +109,18 @@ func (cpo *SessionPayments) issuePromise(balance balance.Message) error {
 	if err != nil {
 		return err
 	}
-	err = cpo.peerPromiseSender.Send(promise.Message{
-		Amount:     issuedPromise.Promise.Amount,
-		SequenceID: issuedPromise.Promise.SeqNo,
-		Signature:  fmt.Sprintf("0x%v", hex.EncodeToString(issuedPromise.IssuerSignature)),
-	})
+
+	err = cpo.sendWithRetry(func() error {
+		return cpo.peerPromiseSender.Send(promise.Message{
+			Amount:     issuedPromise.Promise.Amount,
+			SequenceID: issuedPromise.Promise.SeqNo,
+			Signature:  fmt.Sprintf("0x%v", hex.EncodeToString(issuedPromise.IssuerSignature)),
+		})
+	}, 5, cpo.sendRetryDuration)
 	if err != nil {
 		return err
 	}
+
 	cpo.balanceTracker.Add(amountToExtend)
 	return nil
 }
@@ -120,6 +130,26 @@ func (cpo *SessionPayments) validateBalanceDifference(balance uint64) error {
 	diff := calculateBalanceDifference(balance, myBalance)
 	if diff >= balanceDifferenceThreshold {
 		return ErrBalanceMissmatch
+	}
+	return nil
+}
+
+func (cpo *SessionPayments) sendWithRetry(send func() error, attempts int, delay time.Duration) error {
+	for i := 1; i <= attempts; i++ {
+		err := send()
+		if err == nil {
+			return nil
+		}
+		if i == attempts {
+			return err
+		}
+		log.Warn(sessionPaymentsLogPrefix, "sending failed ", err, " will retry...")
+
+		select {
+		case <-cpo.stop:
+			return errors.New("sending cancelled")
+		case <-time.After(delay):
+		}
 	}
 	return nil
 }

--- a/session/payment/session_payments_test.go
+++ b/session/payment/session_payments_test.go
@@ -76,7 +76,6 @@ func NewTestSessionPayments(bm chan balance.Message, ps PeerPromiseSender, pt Pr
 		ps,
 		pt,
 		bt,
-		0,
 	)
 }
 
@@ -114,26 +113,6 @@ func Test_SessionPayments_ReportsIssuingErrors(t *testing.T) {
 	go func() {
 		err := cpo.Start()
 		assert.Equal(t, customTracker.errToReturn, err)
-		testDone <- struct{}{}
-	}()
-
-	balanceChannel <- balance.Message{Balance: 0, SequenceID: 1}
-	<-testDone
-}
-
-func Test_SessionPayments_ReportsSendingErrors(t *testing.T) {
-	balanceChannel := make(chan balance.Message, 1)
-	customSender := newPromiseSender()
-	customSender.chanToWriteTo = make(chan promise.Message, 10)
-	err := errors.New("sending failed")
-	customSender.mockError = err
-
-	testDone := make(chan struct{})
-
-	cpo := NewTestSessionPayments(balanceChannel, customSender, promiseTracker, balanceTracker)
-	go func() {
-		err := cpo.Start()
-		assert.Equal(t, customSender.mockError, err)
 		testDone <- struct{}{}
 	}()
 

--- a/session/payment/session_payments_test.go
+++ b/session/payment/session_payments_test.go
@@ -76,6 +76,7 @@ func NewTestSessionPayments(bm chan balance.Message, ps PeerPromiseSender, pt Pr
 		ps,
 		pt,
 		bt,
+		0,
 	)
 }
 
@@ -123,6 +124,7 @@ func Test_SessionPayments_ReportsIssuingErrors(t *testing.T) {
 func Test_SessionPayments_ReportsSendingErrors(t *testing.T) {
 	balanceChannel := make(chan balance.Message, 1)
 	customSender := newPromiseSender()
+	customSender.chanToWriteTo = make(chan promise.Message, 10)
 	err := errors.New("sending failed")
 	customSender.mockError = err
 


### PR DESCRIPTION
enables the payment pingpong by default.

added a retry to send, increased the payment increments to 240secs and a 120sec timeout. Made the waiting for timeout  cancellable.