### PR TITLE
fixed parsing of utf strings with boms for windows

### DIFF
--- a/nat/service_ics.go
+++ b/nat/service_ics.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
 )
 
@@ -176,8 +177,7 @@ func (ics *serviceICS) getPublicInterfaceName() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get interface from the default route")
 	}
-
-	ifaceID, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	ifaceID, err := strconv.Atoi(strings.TrimSpace(utils.RemoveErrorsAndBOMUTF8(string(out))))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse interface ID")
 	}
@@ -217,7 +217,7 @@ func (ics *serviceICS) getInternalInterfaceName() (string, error) {
 		return "", errors.Wrap(err, "failed to detect internal interface name")
 	}
 
-	ifaceName := strings.TrimSpace(string(out))
+	ifaceName := strings.TrimSpace(utils.RemoveErrorsAndBOMUTF8(string(out)))
 	if len(ifaceName) == 0 {
 		return "", errors.New("interface not found")
 	}

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// RemoveErrorsAndBOMUTF8 removes the bom and rune errors from UTF8 strings
+func RemoveErrorsAndBOMUTF8(in string) string {
+	return strings.Map(func(r rune) rune {
+		if r == utf8.RuneError || r == '\uFEFF' {
+			return -1
+		}
+		return r
+	}, in)
+}

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import "testing"
+
+func TestRemoveErrorsAndBOMUTF8(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{
+			name: "removes BOM",
+			args: string([]rune{'\uFEFF', '1', '2'}),
+			want: "12",
+		},
+		{
+			name: "removes error runes",
+			args: string([]rune{'1', '2', '\uFFFD'}),
+			want: "12",
+		},
+		{
+			name: "doesn't change legitimate strings",
+			args: string([]rune{'1', '2'}),
+			want: "12",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveErrorsAndBOMUTF8(tt.args); got != tt.want {
+				t.Errorf("RemoveErrorsAndBOMUTF8() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
currently, we've got an issue where ICS commands will fail on some win7 machines due to BOM being present in the output of a powershell command. This fixes it by removing the bom from the results.