### PR TITLE
Bug/powershell bom outputs

### DIFF
--- a/nat/factory_windows.go
+++ b/nat/factory_windows.go
@@ -26,6 +26,6 @@ func NewService() NATService {
 	return &serviceICS{
 		ifaces:          make(map[string]RuleForwarding),
 		setICSAddresses: setICSAddresses,
-		powerShell:      utils.Powershell,
+		powerShell:      utils.PowerShell,
 	}
 }

--- a/nat/factory_windows.go
+++ b/nat/factory_windows.go
@@ -26,6 +26,6 @@ func NewService() NATService {
 	return &serviceICS{
 		ifaces:          make(map[string]RuleForwarding),
 		setICSAddresses: setICSAddresses,
-		powerShell:      utils.PowerShell,
+		powerShell:      utils.Powershell,
 	}
 }

--- a/nat/service_ics.go
+++ b/nat/service_ics.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	log "github.com/cihub/seelog"
-	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
 )
 
@@ -176,7 +175,7 @@ func (ics *serviceICS) getPublicInterfaceName() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get interface from the default route")
 	}
-	ifaceID, err := strconv.Atoi(strings.TrimSpace(utils.RemoveErrorsAndBOMUTF8(string(out))))
+	ifaceID, err := strconv.Atoi(strings.TrimSpace(string(out)))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse interface ID")
 	}
@@ -216,7 +215,7 @@ func (ics *serviceICS) getInternalInterfaceName() (string, error) {
 		return "", errors.Wrap(err, "failed to detect internal interface name")
 	}
 
-	ifaceName := strings.TrimSpace(utils.RemoveErrorsAndBOMUTF8(string(out)))
+	ifaceName := strings.TrimSpace(string(out))
 	if len(ifaceName) == 0 {
 		return "", errors.New("interface not found")
 	}

--- a/nat/service_ics.go
+++ b/nat/service_ics.go
@@ -58,11 +58,17 @@ func (ics *serviceICS) Enable() error {
 }
 
 func (ics *serviceICS) enableRemoteAccessService() error {
-	status, err := ics.powerShell("Get-Service RemoteAccess | foreach { $_.StartType }")
+	status, err := ics.powerShell(`(Get-WmiObject Win32_Service -filter "Name='RemoteAccess'").StartMode`)
 	if err != nil {
 		return errors.Wrap(err, "failed to get RemoteAccess service startup type")
 	}
-	ics.remoteAccessStatus = string(status)
+
+	statusStringified := strings.ToLower(strings.TrimSpace(string(status)))
+	if statusStringified == "auto" {
+		ics.remoteAccessStatus = "automatic"
+	} else {
+		ics.remoteAccessStatus = statusStringified
+	}
 
 	if _, err := ics.powerShell("Set-Service -Name RemoteAccess -StartupType automatic"); err != nil {
 		return errors.Wrap(err, "failed to set RemoteAccess service startup type to automatic")

--- a/utils/command_windows.go
+++ b/utils/command_windows.go
@@ -22,10 +22,10 @@ import (
 	"os/exec"
 )
 
-func PowerShell(cmd string) ([]byte, error) {
+func Powershell(cmd string) ([]byte, error) {
 	out, err := exec.Command("powershell", "-Command", cmd).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("'powershell -Command %v': %v output: %s", cmd, err, string(out))
+		return nil, fmt.Errorf("'powershell -Command %v': %v output: %s", cmd, RemoveErrorsAndBOMUTF8(err.Error()), RemoveErrorsAndBOMUTF8Byte(out))
 	}
-	return out, nil
+	return RemoveErrorsAndBOMUTF8Byte(out), nil
 }

--- a/utils/command_windows.go
+++ b/utils/command_windows.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 )
 
-func Powershell(cmd string) ([]byte, error) {
+func PowerShell(cmd string) ([]byte, error) {
 	out, err := exec.Command("powershell", "-Command", cmd).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("'powershell -Command %v': %v output: %s", cmd, RemoveErrorsAndBOMUTF8(err.Error()), RemoveErrorsAndBOMUTF8Byte(out))

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -31,3 +31,8 @@ func RemoveErrorsAndBOMUTF8(in string) string {
 		return r
 	}, in)
 }
+
+// RemoveErrorsAndBOMUTF8Byte removes the bom and rune errors from UTF8 byte arrays
+func RemoveErrorsAndBOMUTF8Byte(in []byte) []byte {
+	return []byte(RemoveErrorsAndBOMUTF8(string(in)))
+}


### PR DESCRIPTION
* Powershell outputs are now stripped of BOM(both out and error) as this was causing fmt.Print and seelog to crash.
* Replaced `Get-Service RemoteAccess | foreach { $_.StartType }` with `(Get-WmiObject Win32_Service -filter "Name='RemoteAccess'").StartMode` as the latter is compatible with older powershell versions(looking at you 2.0) as well as the current ones. 