### PR TITLE
Add GET /access-lists endpoint

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -333,6 +333,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options) {
 	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, serviceTypesRequestParser)
 	tequilapi_endpoints.AddRoutesForServiceSessions(router, di.ServiceSessionStorage)
 	tequilapi_endpoints.AddRoutesForPayout(router, di.IdentityManager, di.SignerFactory, di.MysteriumAPI)
+	tequilapi_endpoints.AddRoutesForAccessLists(router)
 	identity_registry.AddIdentityRegistrationEndpoint(router, di.IdentityRegistration, di.IdentityRegistry)
 
 	corsPolicy := tequilapi.NewMysteriumCorsPolicy()

--- a/tequilapi/endpoints/access_lists.go
+++ b/tequilapi/endpoints/access_lists.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package endpoints
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/mysteriumnetwork/node/tequilapi/utils"
+)
+
+// swagger:model AccessLists
+type accessLists struct {
+	AccessLists []accessList `json:"accessLists"`
+}
+
+type accessList struct {
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Allow       []accessRule `json:"allow"`
+}
+
+type accessRule struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type accessListsEndpoint struct {
+}
+
+var staticAccessList = accessList{
+	Name:        "mysterium",
+	Description: "Mysterium Network approved identities",
+	Allow: []accessRule{
+		{
+			Type:  "identity",
+			Value: "0xf4d6ffba09d460ebe10d24667770437981ce3de9",
+		},
+	},
+}
+
+// NewAccessListsEndpoint creates and returns access lists endpoint
+func NewAccessListsEndpoint() *accessListsEndpoint {
+	return &accessListsEndpoint{}
+}
+
+// swagger:operation GET /access-lists AccessLists listAccessLists
+// ---
+// summary: Returns access lists
+// description: Returns list of access lists
+// responses:
+//   200:
+//     description: List of access lists
+//     schema:
+//       "$ref": "#/definitions/AccessLists"
+func (ale *accessListsEndpoint) List(resp http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	r := accessLists{AccessLists: []accessList{staticAccessList}}
+	utils.WriteAsJSON(r, resp)
+}
+
+// AddRoutesForAccessLists attaches access lists endpoints to router
+func AddRoutesForAccessLists(router *httprouter.Router) {
+	ale := NewAccessListsEndpoint()
+	router.GET("/access-lists", ale.List)
+}

--- a/tequilapi/endpoints/access_lists_test.go
+++ b/tequilapi/endpoints/access_lists_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package endpoints
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Get_AccessLists(t *testing.T) {
+	router := httprouter.New()
+	AddRoutesForAccessLists(router)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"/access-lists",
+		nil,
+	)
+	assert.Nil(t, err)
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.JSONEq(
+		t,
+		`{
+			"accessLists": [
+				{
+					"name": "mysterium",
+					"description": "Mysterium Network approved identities",
+					"allow": [
+						{
+							"type": "identity",
+							"value": "0xf4d6ffba09d460ebe10d24667770437981ce3de9"
+						}
+					]
+				}
+			]
+		}`,
+		resp.Body.String(),
+	)
+}


### PR DESCRIPTION
Closes https://github.com/mysteriumnetwork/node/issues/864
`GET /access-lists` returns hardcoded list:
```json
{
    "accessLists": [
        {
            "name": "mysterium",
            "description": "Mysterium Network approved identities",
            "allow": [
                {
                    "type": "identity",
                    "value": "0xf4d6ffba09d460ebe10d24667770437981ce3de9"
                }
            ]
        }
    ]
}
```
Later this list will be fetched from service using http (in https://github.com/mysteriumnetwork/node/issues/865)

Full feature description: https://github.com/mysteriumnetwork/internal-docs/tree/master/access-lists