### PR TITLE
OpenVPN not fail on empty consumer config

### DIFF
--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -142,12 +142,16 @@ func (m *Manager) ProvideConfig(config json.RawMessage) (session.ServiceConfigur
 		log.Info(logPrefix, "Config provider not initialized")
 		return nil, nil, errors.New("Config provider not initialized")
 	}
-	var c openvpn_service.ConsumerConfig
-	error := json.Unmarshal(config, &c)
-	if error != nil {
-		return nil, nil, errors.Wrap(error, "parsing consumer config failed")
+
+	if config != nil && len(config) > 0 { // Older clients do not send any config, but we should keep back compatibility and not fail in this case.
+		var c openvpn_service.ConsumerConfig
+		err := json.Unmarshal(config, &c)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "parsing consumer config failed")
+		}
+		m.consumerConfig = c
 	}
-	m.consumerConfig = c
+
 	return m.vpnServiceConfigProvider.ProvideConfig(config)
 }
 

--- a/services/openvpn/service/manager_test.go
+++ b/services/openvpn/service/manager_test.go
@@ -18,8 +18,10 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/mysteriumnetwork/node/session"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,4 +29,22 @@ func TestManager_StopNotPanic(t *testing.T) {
 	m := Manager{}
 	err := m.Stop()
 	assert.NoError(t, err)
+}
+
+func TestManager_ProvideConfigNotFailOnEmptyConfig(t *testing.T) {
+	m := Manager{vpnServiceConfigProvider: &mockConfigProvider{}}
+	_, _, err := m.ProvideConfig([]byte(""))
+	assert.NoError(t, err)
+}
+
+func TestManager_ProvideConfigNotFailOnNilConfig(t *testing.T) {
+	m := Manager{vpnServiceConfigProvider: &mockConfigProvider{}}
+	_, _, err := m.ProvideConfig(nil)
+	assert.NoError(t, err)
+}
+
+type mockConfigProvider struct{}
+
+func (cp *mockConfigProvider) ProvideConfig(consumerKey json.RawMessage) (session.ServiceConfiguration, session.DestroyCallback, error) {
+	return nil, nil, nil
 }


### PR DESCRIPTION
(cherry picked from commit c1bef8852752caced6449260178f8c7d48098e49)