### PR TITLE
Cleaning ICS config only on Start and Stop of the service

### DIFF
--- a/cmd/service_bootstrap_desktop.go
+++ b/cmd/service_bootstrap_desktop.go
@@ -126,13 +126,12 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 		}
 
 		proposal := openvpn_discovery.NewServiceProposalWithLocation(currentLocation, transportOptions.Protocol)
-		natService := nat.NewService()
 		manager := openvpn_service.NewManager(
 			nodeOptions,
 			transportOptions,
 			locationInfo,
 			di.ServiceSessionStorage,
-			natService,
+			di.NATService,
 			di.NATPinger,
 			mapPort,
 			di.LastSessionShutdown,


### PR DESCRIPTION
Our Implementation of the ICS configuration was cleaning up ICS config for every interface on every action.
Adding public interface like `Ethernet` was cleaning up internet connection sharing for every interface.
The second step is adding `myst` interface as in private(internal) internet connection sharing device was cleaning up internet connection sharing for every interface as well, including `Ethernet`.

This fix doing total cleanup only on Enabling and Disabling ICS, i.e. service Start and Stop.