### PR TITLE
Remove redundant protocol requirement for acquiring a port

### DIFF
--- a/core/port/availability.go
+++ b/core/port/availability.go
@@ -25,29 +25,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-func available(protocol string, port int) (bool, error) {
-	addr := ":" + strconv.Itoa(port)
-
-	switch protocol {
-	case "udp", "udp4", "udp6":
-		udpAddr, err := net.ResolveUDPAddr(protocol, addr)
-		if err != nil {
-			return false, errors.Wrap(err, "unable to resolve UDP address")
-		}
-		conn, err := net.ListenUDP(protocol, udpAddr)
-		if err != nil {
-			log.Infof("%s cannot listen on UDP port %v: %v", logPrefix, port, err)
-			return false, nil
-		}
-		defer conn.Close()
-	default:
-		listener, err := net.Listen(protocol, addr)
-		if err != nil {
-			log.Infof("%s cannot listen on TCP port %v: %v", logPrefix, port, err)
-			return false, nil
-		}
-		defer listener.Close()
+// Tests port by opening a UDP listener on given port number
+func available(port int) (bool, error) {
+	addr, err := net.ResolveUDPAddr("udp", ":"+strconv.Itoa(port))
+	if err != nil {
+		return false, errors.Wrap(err, "unable to resolve UDP address")
 	}
+
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		log.Infof("%s cannot listen on UDP port %v: %v", logPrefix, port, err)
+		return false, nil
+	}
+	defer conn.Close()
 
 	return true, nil
 }

--- a/core/port/fixed.go
+++ b/core/port/fixed.go
@@ -28,6 +28,6 @@ func NewFixed(port int) *FixedPortSupplier {
 }
 
 // Acquire returns the fixed port
-func (fixed *FixedPortSupplier) Acquire(protocol string) (Port, error) {
+func (fixed *FixedPortSupplier) Acquire() (Port, error) {
 	return Port(fixed.number), nil
 }

--- a/core/port/pool.go
+++ b/core/port/pool.go
@@ -41,16 +41,16 @@ func NewPool() *Pool {
 }
 
 // Acquire returns an unused port in pool's range
-func (pool *Pool) Acquire(protocol string) (Port, error) {
+func (pool *Pool) Acquire() (port Port, err error) {
 	p := pool.randomPort()
-	available, err := available(protocol, p)
+	available, err := available(p)
 	if err != nil {
 		return 0, errors.Wrap(err, "could not acquire port")
 	}
 	if !available {
-		p, err = pool.seekAvailablePort(protocol)
+		p, err = pool.seekAvailablePort()
 	}
-	log.Debugf("%s supplying %v port %v, err %v", logPrefix, protocol, p, err)
+	log.Debugf("%s supplying port %v, err %v", logPrefix, p, err)
 	return Port(p), errors.Wrap(err, "could not acquire port")
 }
 
@@ -58,10 +58,10 @@ func (pool *Pool) randomPort() int {
 	return pool.start + pool.rand.Intn(pool.capacity)
 }
 
-func (pool *Pool) seekAvailablePort(protocol string) (int, error) {
+func (pool *Pool) seekAvailablePort() (int, error) {
 	for i := 0; i < pool.capacity; i++ {
 		p := pool.start + i
-		available, err := available(protocol, p)
+		available, err := available(p)
 		if available || err != nil {
 			return p, err
 		}

--- a/core/port/pool_test.go
+++ b/core/port/pool_test.go
@@ -26,29 +26,12 @@ import (
 )
 
 func TestAcquiredPortsAreUsable(t *testing.T) {
-	// given
 	pool := NewPool()
 
-	// when
-	tcpPort, _ := pool.Acquire("tcp")
-	// then
-	err := listenTcp(tcpPort.Num())
-	assert.NoError(t, err)
+	port, _ := pool.Acquire()
+	err := listenUdp(port.Num())
 
-	// when
-	udpPort, _ := pool.Acquire("udp")
-	// then
-	err = listenUdp(udpPort.Num())
 	assert.NoError(t, err)
-}
-
-func listenTcp(port int) error {
-	listener, err := net.Listen("tcp", ":"+strconv.Itoa(port))
-	if err != nil {
-		return err
-	}
-	defer listener.Close()
-	return nil
 }
 
 func listenUdp(port int) error {

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -61,7 +61,7 @@ type NATEventGetter interface {
 }
 
 type portSupplier interface {
-	Acquire(protocol string) (port.Port, error)
+	Acquire() (port.Port, error)
 }
 
 // Manager represents entrypoint for Openvpn service with top level components
@@ -96,7 +96,7 @@ func (m *Manager) Serve(providerID identity.Identity) (err error) {
 		return errors.Wrap(err, "failed to add NAT forwarding rule")
 	}
 
-	servicePort, err := m.ports.Acquire(m.serviceOptions.Protocol)
+	servicePort, err := m.ports.Acquire()
 	if err != nil {
 		return errors.Wrap(err, "failed to acquire an unused port")
 	}


### PR DESCRIPTION
Port can be tested using any protocol (in this case, I'm using TCP)