### PR TITLE
Fix access policy params when starting service

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -43,13 +43,13 @@ import (
 const cliCommandName = "cli"
 
 const serviceHelp = `service <action> [args]
-	start	<ProviderID> <ServiceType> [access-policies] [options]
+	start	<ProviderID> <ServiceType> [options]
 	stop	<ServiceID>
 	status	<ServiceID>
 	list
 	sessions
 
-	example: service start 0x7d5ee3557775aed0b85d691b036769c17349db23 openvpn --openvpn.port=1194 --openvpn.proto=UDP`
+	example: service start 0x7d5ee3557775aed0b85d691b036769c17349db23 openvpn --access-policy.list=mysterium --openvpn.port=1194 --openvpn.proto=UDP`
 
 // NewCommand constructs CLI based Mysterium UI with possibility to control quiting
 func NewCommand() *cli.Command {

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -49,13 +49,13 @@ type serviceRequest struct {
 
 	// access list which determines which identities will be able to receive the service
 	// required: false
-	AccessPolicy accessPolicyRequest `json:"accessPolicy"`
+	AccessPolicies accessPoliciesRequest `json:"accessPolicies"`
 }
 
 // accessPolicy represents the access controls
 // swagger:model AccessPolicyRequest
-type accessPolicyRequest struct {
-	Ids []string `json:"Ids"`
+type accessPoliciesRequest struct {
+	Ids []string `json:"ids"`
 }
 
 // swagger:model ServiceListDTO
@@ -225,15 +225,15 @@ func (se *ServiceEndpoint) ServiceStart(resp http.ResponseWriter, req *http.Requ
 }
 
 func getAccessPolicyData(sr serviceRequest, href string) *[]market.AccessPolicy {
-	if len(sr.AccessPolicy.Ids) == 0 {
+	if len(sr.AccessPolicies.Ids) == 0 {
 		return nil
 	}
 
-	result := make([]market.AccessPolicy, len(sr.AccessPolicy.Ids))
+	result := make([]market.AccessPolicy, len(sr.AccessPolicies.Ids))
 	for i := range result {
 		result[i] = market.AccessPolicy{
-			ID:     sr.AccessPolicy.Ids[i],
-			Source: fmt.Sprintf("%v%v", href, sr.AccessPolicy.Ids[i]),
+			ID:     sr.AccessPolicies.Ids[i],
+			Source: fmt.Sprintf("%v%v", href, sr.AccessPolicies.Ids[i]),
 		}
 	}
 
@@ -295,24 +295,24 @@ func AddRoutesForService(router *httprouter.Router, serviceManager ServiceManage
 
 func (se *ServiceEndpoint) toServiceRequest(req *http.Request) (serviceRequest, error) {
 	var jsonData struct {
-		ProviderID   string              `json:"providerId"`
-		Type         string              `json:"type"`
-		Options      *json.RawMessage    `json:"options"`
-		AccessPolicy accessPolicyRequest `json:"accessPolicy"`
+		ProviderID     string                `json:"providerId"`
+		Type           string                `json:"type"`
+		Options        *json.RawMessage      `json:"options"`
+		AccessPolicies accessPoliciesRequest `json:"accessPolicies"`
 	}
 	if err := json.NewDecoder(req.Body).Decode(&jsonData); err != nil {
 		return serviceRequest{}, err
 	}
 
-	if jsonData.AccessPolicy.Ids == nil {
-		jsonData.AccessPolicy.Ids = []string{}
+	if jsonData.AccessPolicies.Ids == nil {
+		jsonData.AccessPolicies.Ids = []string{}
 	}
 
 	sr := serviceRequest{
-		ProviderID:   jsonData.ProviderID,
-		Type:         se.toServiceType(jsonData.Type),
-		Options:      se.toServiceOptions(jsonData.Type, jsonData.Options),
-		AccessPolicy: jsonData.AccessPolicy,
+		ProviderID:     jsonData.ProviderID,
+		Type:           se.toServiceType(jsonData.Type),
+		Options:        se.toServiceOptions(jsonData.Type, jsonData.Options),
+		AccessPolicies: jsonData.AccessPolicies,
 	}
 	return sr, nil
 }


### PR DESCRIPTION
`POST /services` request body should look like this (https://github.com/mysteriumnetwork/internal-docs/tree/master/access-lists#node):
```
{
    "providerId": "id",
    "type": "openvpn",
    "access-policies": {
      "ids": ["verified-streaming", "dvpn-traffic", "12312312332132", "0x0000000000000001"]
    },
    "options": {}
}
```

