### PR TITLE
Fail service start endpoint with unknown params

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -707,8 +707,8 @@ func newAutocompleter(tequilapi *tequilapi_client.Client, proposals []tequilapi_
 	)
 }
 
-func parseStartFlags(serviceType string, args ...string) (service.Options, tequilapi_client.AccessPolicy, error) {
-	var ap tequilapi_client.AccessPolicy
+func parseStartFlags(serviceType string, args ...string) (service.Options, tequilapi_client.AccessPoliciesRequest, error) {
+	var ap tequilapi_client.AccessPoliciesRequest
 	var flags []cli.Flag
 	openvpn_service.RegisterFlags(&flags)
 	wireguard_service.RegisterFlags(&flags)
@@ -728,7 +728,7 @@ func parseStartFlags(serviceType string, args ...string) (service.Options, tequi
 	apFlagValue := ctx.String(accessPolicyFlag.Name)
 	if len(apFlagValue) > 0 {
 		splits := strings.Split(ctx.String(accessPolicyFlag.Name), ",")
-		ap = tequilapi_client.AccessPolicy{
+		ap = tequilapi_client.AccessPoliciesRequest{
 			IDs: splits,
 		}
 	}

--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -53,7 +53,7 @@ var (
 		Usage: "Agree with terms & conditions",
 	}
 
-	accessPolicyFlag = cli.StringFlag{
+	accessPolicyListFlag = cli.StringFlag{
 		Name:  "access-policy.list",
 		Usage: "Comma separated list that determines the allowed identities on our service.",
 		Value: "",
@@ -114,7 +114,7 @@ type serviceCommand struct {
 	identityHandler identity_selector.Handler
 	tequilapi       *client.Client
 	errorChannel    chan error
-	ap              client.AccessPolicy
+	ap              client.AccessPoliciesRequest
 }
 
 // Run runs a command
@@ -165,7 +165,7 @@ func registerFlags(flags *[]cli.Flag) {
 	*flags = append(*flags,
 		agreedTermsConditionsFlag,
 		identityFlag, identityPassphraseFlag,
-		accessPolicyFlag,
+		accessPolicyListFlag,
 	)
 	openvpn_service.RegisterFlags(flags)
 	wireguard_service.RegisterFlags(flags)
@@ -180,13 +180,13 @@ func parseIdentityFlags(ctx *cli.Context) service.OptionsIdentity {
 }
 
 // parseAccessPolicyFlag fetches the access policy data from CLI context
-func parseAccessPolicyFlag(ctx *cli.Context) client.AccessPolicy {
-	policies := ctx.String(accessPolicyFlag.Name)
+func parseAccessPolicyFlag(ctx *cli.Context) client.AccessPoliciesRequest {
+	policies := ctx.String(accessPolicyListFlag.Name)
 	if policies == "" {
-		return client.AccessPolicy{}
+		return client.AccessPoliciesRequest{}
 	}
 	splits := strings.Split(policies, ",")
-	return client.AccessPolicy{
+	return client.AccessPoliciesRequest{
 		IDs: splits,
 	}
 }

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -296,17 +296,17 @@ func (client *Client) Service(id string) (service ServiceInfoDTO, err error) {
 }
 
 // ServiceStart starts an instance of the service.
-func (client *Client) ServiceStart(providerID, serviceType string, options interface{}, ap AccessPolicy) (service ServiceInfoDTO, err error) {
+func (client *Client) ServiceStart(providerID, serviceType string, options interface{}, ap AccessPoliciesRequest) (service ServiceInfoDTO, err error) {
 	opts, err := json.Marshal(options)
 	if err != nil {
 		return service, err
 	}
 
 	payload := struct {
-		ProviderID   string          `json:"providerID"`
-		Type         string          `json:"type"`
-		Options      json.RawMessage `json:"options"`
-		AccessPolicy AccessPolicy    `json:"accessPolicy"`
+		ProviderID     string                `json:"providerID"`
+		Type           string                `json:"type"`
+		Options        json.RawMessage       `json:"options"`
+		AccessPolicies AccessPoliciesRequest `json:"accessPolicies"`
 	}{
 		providerID,
 		serviceType,

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -155,7 +155,7 @@ type ServiceSessionDTO struct {
 	ConsumerID string `json:"consumerId"`
 }
 
-// AccessPolicy represents the access controls for service start
-type AccessPolicy struct {
+// AccessPoliciesRequest represents the access controls for service start
+type AccessPoliciesRequest struct {
 	IDs []string `json:"ids"`
 }

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -300,7 +300,9 @@ func (se *ServiceEndpoint) toServiceRequest(req *http.Request) (serviceRequest, 
 		Options        *json.RawMessage      `json:"options"`
 		AccessPolicies accessPoliciesRequest `json:"accessPolicies"`
 	}
-	if err := json.NewDecoder(req.Body).Decode(&jsonData); err != nil {
+	decoder := json.NewDecoder(req.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&jsonData); err != nil {
 		return serviceRequest{}, err
 	}
 

--- a/tequilapi/endpoints/service_test.go
+++ b/tequilapi/endpoints/service_test.go
@@ -419,7 +419,7 @@ func Test_ServiceStart_WithAccessPolicy(t *testing.T) {
 		strings.NewReader(`{
 			"type": "mockAccessPolicyService",
 			"providerId": "0x9edf75f870d87d2d1a69f0d950a99984ae955ee0",
-			"accessPolicy": {
+			"accessPolicies": {
 				"ids": ["verified-traffic", "dvpn-traffic", "12312312332132", "0x0000000000000001"]
 			}
 		}`),

--- a/tequilapi/endpoints/service_test.go
+++ b/tequilapi/endpoints/service_test.go
@@ -467,3 +467,29 @@ func Test_ServiceStart_WithAccessPolicy(t *testing.T) {
 		resp.Body.String(),
 	)
 }
+
+func Test_ServiceStart_ReturnsBadRequest_WithUnknownParams(t *testing.T) {
+	serviceEndpoint := NewServiceEndpoint(&mockServiceManager{}, fakeOptionsParser, mockAccessPolicyEndpoint)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/irrelevant",
+		strings.NewReader(`{
+			"type": "mockAccessPolicyService",
+			"providerId": "0x9edf75f870d87d2d1a69f0d950a99984ae955ee0",
+			"accessPolicy": {
+				"ids": ["verified-traffic", "dvpn-traffic", "12312312332132", "0x0000000000000001"]
+			}
+		}`),
+	)
+	resp := httptest.NewRecorder()
+
+	serviceEndpoint.ServiceStart(resp, req, httprouter.Params{})
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.JSONEq(
+		t,
+		`{"message": "json: unknown field \"accessPolicy\""}`,
+		resp.Body.String(),
+	)
+}


### PR DESCRIPTION
Not sure about other tequilapi requests, but starting service with misinterpreted params is dangerous - i.e. we can expose user to all traffic without his consent, as we did in https://github.com/mysteriumnetwork/node/pull/899.

If we get some params which we don't know, it's likely that request has a mistake, and we shouldn't start service.