### PR TITLE
Fix NAT events sending to ELK

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -96,7 +96,7 @@ type NatPinger interface {
 // NatEventTracker is responsible for tracking NAT events
 type NatEventTracker interface {
 	ConsumeNATEvent(event traversal.Event)
-	LastEvent() (traversal.Event, bool)
+	LastEvent() *traversal.Event
 	WaitForEvent() traversal.Event
 }
 

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -96,7 +96,7 @@ type NatPinger interface {
 // NatEventTracker is responsible for tracking NAT events
 type NatEventTracker interface {
 	ConsumeNATEvent(event traversal.Event)
-	LastEvent() traversal.Event
+	LastEvent() (traversal.Event, bool)
 	WaitForEvent() traversal.Event
 }
 

--- a/metrics/sender.go
+++ b/metrics/sender.go
@@ -50,9 +50,9 @@ type appInfo struct {
 }
 
 type natMappingContext struct {
-	stage        string
-	successful   bool
-	errorMessage *string
+	Stage        string  `json:"stage"`
+	Successful   bool    `json:"successful"`
+	ErrorMessage *string `json:"error_message"`
 }
 
 // SendStartupEvent sends startup event
@@ -62,14 +62,14 @@ func (sender *Sender) SendStartupEvent() error {
 
 // SendNATMappingSuccessEvent sends event about successful NAT mapping
 func (sender *Sender) SendNATMappingSuccessEvent(stage string) error {
-	context := natMappingContext{stage: stage, successful: true}
+	context := natMappingContext{Stage: stage, Successful: true}
 	return sender.sendEvent(natMappingEventName, context)
 }
 
 // SendNATMappingFailEvent sends event about failed NAT mapping
 func (sender *Sender) SendNATMappingFailEvent(stage string, err error) error {
 	errorMessage := err.Error()
-	context := natMappingContext{stage: stage, successful: false, errorMessage: &errorMessage}
+	context := natMappingContext{Stage: stage, Successful: false, ErrorMessage: &errorMessage}
 	return sender.sendEvent(natMappingEventName, context)
 }
 

--- a/metrics/sender_test.go
+++ b/metrics/sender_test.go
@@ -72,7 +72,7 @@ func TestSender_SendNATMappingSuccessEvent_SendsToTransport(t *testing.T) {
 	assert.Equal(t, "nat_mapping", sentEvent.EventName)
 	assert.Equal(t, appInfo{Name: "myst", Version: "test version"}, sentEvent.Application)
 	assert.NotZero(t, sentEvent.CreatedAt)
-	assert.Equal(t, natMappingContext{successful: true, stage: "port_mapping"}, sentEvent.Context)
+	assert.Equal(t, natMappingContext{Successful: true, Stage: "port_mapping"}, sentEvent.Context)
 }
 
 func TestSender_SendNATMappingSuccessEvent_ReturnsTransportErrors(t *testing.T) {
@@ -97,9 +97,9 @@ func TestSender_SendNATMappingFailEvent_SendsToTransport(t *testing.T) {
 	assert.Equal(t, appInfo{Name: "myst", Version: "test version"}, sentEvent.Application)
 	assert.NotZero(t, sentEvent.CreatedAt)
 	c := sentEvent.Context.(natMappingContext)
-	assert.False(t, c.successful)
-	assert.Equal(t, "mock nat mapping error", *c.errorMessage)
-	assert.Equal(t, "hole_punching", c.stage)
+	assert.False(t, c.Successful)
+	assert.Equal(t, "mock nat mapping error", *c.ErrorMessage)
+	assert.Equal(t, "hole_punching", c.Stage)
 }
 
 func TestSender_SendNATMappingFailEvent_ReturnsTransportErrors(t *testing.T) {

--- a/nat/traversal/events_sender.go
+++ b/nat/traversal/events_sender.go
@@ -80,6 +80,5 @@ func (es *EventsSender) isEventRelevant(event Event, ip string) bool {
 		return true
 	}
 
-	// TODO: add check for Stage or remove this optimisation
-	return event.Successful != es.lastEvent.Successful
+	return event.Successful != es.lastEvent.Successful || event.Stage != es.lastEvent.Stage
 }

--- a/nat/traversal/events_sender.go
+++ b/nat/traversal/events_sender.go
@@ -50,7 +50,7 @@ func (es *EventsSender) ConsumeNATEvent(event Event) {
 		log.Warnf(eventsSenderLogPrefix, "resolving public ip failed: ", err)
 		return
 	}
-	if !es.isEventRelevant(event, publicIP) {
+	if publicIP == es.lastIp && es.matchesLastEvent(event) {
 		return
 	}
 
@@ -71,14 +71,10 @@ func (es *EventsSender) sendNATEvent(event Event) error {
 	return es.metricsSender.SendNATMappingFailEvent(event.Stage, event.Error)
 }
 
-func (es *EventsSender) isEventRelevant(event Event, ip string) bool {
-	if ip != es.lastIp {
-		return true
-	}
-
+func (es *EventsSender) matchesLastEvent(event Event) bool {
 	if es.lastEvent == nil {
-		return true
+		return false
 	}
 
-	return event.Successful != es.lastEvent.Successful || event.Stage != es.lastEvent.Stage
+	return event.Successful == es.lastEvent.Successful && event.Stage == es.lastEvent.Stage
 }

--- a/nat/traversal/events_sender_test.go
+++ b/nat/traversal/events_sender_test.go
@@ -117,6 +117,19 @@ func Test_EventsSender_ConsumeNATEvent_SendsFailureEvent(t *testing.T) {
 	assert.Equal(t, "hole_punching", mockMetricsSender.stageSent)
 }
 
+func Test_EventsSender_ConsumeNATEvent_WithFailuresOfDifferentStages_SendsBothEvents(t *testing.T) {
+	mockMetricsSender := buildMockMetricsSender(nil)
+	mockIPResolver := &mockIPResolver{mockIp: "1st ip"}
+	sender := NewEventsSender(mockMetricsSender, mockIPResolver.GetPublicIP)
+
+	testErr1 := errors.New("test error 1")
+	sender.ConsumeNATEvent(Event{Successful: false, Error: testErr1, Stage: "test 1"})
+	testErr2 := errors.New("test error 2")
+	sender.ConsumeNATEvent(Event{Successful: false, Error: testErr2, Stage: "test 2"})
+
+	assert.Equal(t, testErr2, mockMetricsSender.failErrorSent)
+}
+
 func Test_EventsSender_ConsumeNATEvent_WithSuccessAndFailureOnSameIp_SendsBothEvents(t *testing.T) {
 	mockMetricsSender := buildMockMetricsSender(nil)
 	mockIPResolver := &mockIPResolver{mockIp: "1st ip"}

--- a/nat/traversal/events_sender_test.go
+++ b/nat/traversal/events_sender_test.go
@@ -62,7 +62,7 @@ func Test_EventsSender_ConsumeNATEvent_SendsSuccessEvent(t *testing.T) {
 	mockIPResolver := mockIPResolver{mockIp: "1st ip"}
 	sender := NewEventsSender(mockMetricsSender, mockIPResolver.GetPublicIP)
 
-	sender.ConsumeNATEvent(Event{Stage: "hole_punching", Type: SuccessEventType})
+	sender.ConsumeNATEvent(Event{Stage: "hole_punching", Successful: true})
 
 	assert.True(t, mockMetricsSender.successSent)
 	assert.Equal(t, "hole_punching", mockMetricsSender.stageSent)
@@ -73,11 +73,11 @@ func Test_EventsSender_ConsumeNATEvent_WithSameIp_DoesNotSendSuccessEventAgain(t
 	mockIPResolver := mockIPResolver{mockIp: "1st ip"}
 	sender := NewEventsSender(mockMetricsSender, mockIPResolver.GetPublicIP)
 
-	sender.ConsumeNATEvent(Event{Type: SuccessEventType})
+	sender.ConsumeNATEvent(Event{Successful: true})
 
 	mockMetricsSender.successSent = false
 
-	sender.ConsumeNATEvent(Event{Type: SuccessEventType})
+	sender.ConsumeNATEvent(Event{Successful: true})
 	assert.False(t, mockMetricsSender.successSent)
 }
 
@@ -86,12 +86,12 @@ func Test_EventsSender_ConsumeNATEvent_WithDifferentIP_SendsSuccessEventAgain(t 
 	mockIPResolver := &mockIPResolver{mockIp: "1st ip"}
 	sender := NewEventsSender(mockMetricsSender, mockIPResolver.GetPublicIP)
 
-	sender.ConsumeNATEvent(Event{Type: SuccessEventType})
+	sender.ConsumeNATEvent(Event{Successful: true})
 
 	mockMetricsSender.successSent = false
 
 	mockIPResolver.mockIp = "2nd ip"
-	sender.ConsumeNATEvent(Event{Type: SuccessEventType})
+	sender.ConsumeNATEvent(Event{Successful: true})
 	assert.True(t, mockMetricsSender.successSent)
 }
 
@@ -100,7 +100,7 @@ func Test_EventsSender_ConsumeNATEvent_WhenIPResolverFails_DoesNotSendEvent(t *t
 	mockIPResolver := &mockIPResolver{mockErr: errors.New("mock error")}
 	sender := NewEventsSender(mockMetricsSender, mockIPResolver.GetPublicIP)
 
-	sender.ConsumeNATEvent(Event{Type: SuccessEventType})
+	sender.ConsumeNATEvent(Event{Successful: true})
 
 	assert.False(t, mockMetricsSender.successSent)
 }
@@ -111,7 +111,7 @@ func Test_EventsSender_ConsumeNATEvent_SendsFailureEvent(t *testing.T) {
 	sender := NewEventsSender(mockMetricsSender, mockIPResolver.GetPublicIP)
 
 	testErr := errors.New("test error")
-	sender.ConsumeNATEvent(Event{Stage: "hole_punching", Type: FailureEventType, Error: testErr})
+	sender.ConsumeNATEvent(Event{Stage: "hole_punching", Successful: false, Error: testErr})
 
 	assert.Equal(t, testErr, mockMetricsSender.failErrorSent)
 	assert.Equal(t, "hole_punching", mockMetricsSender.stageSent)
@@ -122,9 +122,9 @@ func Test_EventsSender_ConsumeNATEvent_WithSuccessAndFailureOnSameIp_SendsBothEv
 	mockIPResolver := &mockIPResolver{mockIp: "1st ip"}
 	sender := NewEventsSender(mockMetricsSender, mockIPResolver.GetPublicIP)
 
-	sender.ConsumeNATEvent(Event{Type: SuccessEventType})
+	sender.ConsumeNATEvent(Event{Successful: true})
 	testErr := errors.New("test error")
-	sender.ConsumeNATEvent(Event{Type: FailureEventType, Error: testErr})
+	sender.ConsumeNATEvent(Event{Successful: false, Error: testErr})
 
 	assert.True(t, mockMetricsSender.successSent)
 	assert.Equal(t, mockMetricsSender.failErrorSent, testErr)

--- a/nat/traversal/events_tracker.go
+++ b/nat/traversal/events_tracker.go
@@ -61,12 +61,9 @@ func (et *EventsTracker) ConsumeNATEvent(event Event) {
 }
 
 // LastEvent returns the last known event and boolean flag, indicating if such event exists
-func (et *EventsTracker) LastEvent() (Event, bool) {
+func (et *EventsTracker) LastEvent() *Event {
 	log.Info(eventsTrackerLogPrefix, "getting last NAT event: ", et.lastEvent)
-	if et.lastEvent == nil {
-		return Event{}, false
-	}
-	return *et.lastEvent, true
+	return et.lastEvent
 }
 
 // WaitForEvent waits for event to occur

--- a/nat/traversal/events_tracker.go
+++ b/nat/traversal/events_tracker.go
@@ -28,13 +28,6 @@ const EventTopic = "Traversal"
 
 const eventsTrackerLogPrefix = "[traversal-events-tracker] "
 
-const (
-	// SuccessEventType is name of event for a successful NAT traversal
-	SuccessEventType = "success"
-	// FailureEventType is name of event for a failed NAT traversal
-	FailureEventType = "failure"
-)
-
 // EventsTracker is able to track NAT traversal events
 type EventsTracker struct {
 	lastEvent *Event
@@ -43,12 +36,12 @@ type EventsTracker struct {
 
 // BuildSuccessEvent returns new event for successful NAT traversal
 func BuildSuccessEvent(stage string) Event {
-	return Event{Stage: stage, Type: SuccessEventType}
+	return Event{Stage: stage, Successful: true}
 }
 
 // BuildFailureEvent returns new event for failed NAT traversal
 func BuildFailureEvent(stage string, err error) Event {
-	return Event{Stage: stage, Type: FailureEventType, Error: err}
+	return Event{Stage: stage, Successful: false, Error: err}
 }
 
 // NewEventsTracker returns a new instance of event tracker
@@ -88,7 +81,7 @@ func (et *EventsTracker) WaitForEvent() Event {
 
 // Event represents a NAT traversal related event
 type Event struct {
-	Stage string
-	Type  string
-	Error error
+	Stage      string
+	Successful bool
+	Error      error
 }

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -191,7 +191,7 @@ func (p *Pinger) waitForPreviousStageResult() bool {
 	for {
 		event := p.natEventWaiter.WaitForEvent()
 		if event.Stage == p.previousStage {
-			return event.Type == SuccessEventType
+			return event.Successful
 		}
 	}
 }

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -32,7 +32,6 @@ import (
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/nat"
 	"github.com/mysteriumnetwork/node/nat/mapping"
-	"github.com/mysteriumnetwork/node/nat/traversal"
 	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn"
 	openvpn_session "github.com/mysteriumnetwork/node/services/openvpn/session"
 	"github.com/mysteriumnetwork/node/session"
@@ -144,7 +143,7 @@ func (ocn *OpenvpnConfigNegotiator) portMappingFailed() bool {
 	if !found {
 		return false
 	}
-	return event.Stage == mapping.StageName && event.Type == traversal.FailureEventType
+	return event.Stage == mapping.StageName && !event.Successful
 }
 
 func vpnServerIP(serviceOptions Options, outboundIP, publicIP string, isLocalnet bool) string {

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -140,7 +140,10 @@ func (ocn *OpenvpnConfigNegotiator) determineClientPort(pingerPort int) int {
 }
 
 func (ocn *OpenvpnConfigNegotiator) portMappingFailed() bool {
-	event := ocn.natEventGetter.LastEvent()
+	event, found := ocn.natEventGetter.LastEvent()
+	if !found {
+		return false
+	}
 	return event.Stage == mapping.StageName && event.Type == traversal.FailureEventType
 }
 

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -139,8 +139,8 @@ func (ocn *OpenvpnConfigNegotiator) determineClientPort(pingerPort int) int {
 }
 
 func (ocn *OpenvpnConfigNegotiator) portMappingFailed() bool {
-	event, found := ocn.natEventGetter.LastEvent()
-	if !found {
+	event := ocn.natEventGetter.LastEvent()
+	if event == nil {
 		return false
 	}
 	return event.Stage == mapping.StageName && !event.Successful

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -180,7 +180,7 @@ func (m *Manager) portMappingFailed() bool {
 	if !found {
 		return false
 	}
-	return event.Stage == mapping.StageName && event.Type == traversal.FailureEventType
+	return event.Stage == mapping.StageName && !event.Successful
 }
 
 func vpnStateCallback(state openvpn.State) {

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -58,7 +58,7 @@ type NATPinger interface {
 
 // NATEventGetter allows us to fetch the last known NAT event
 type NATEventGetter interface {
-	LastEvent() traversal.Event
+	LastEvent() (traversal.Event, bool)
 }
 
 // Manager represents entrypoint for Openvpn service with top level components
@@ -176,7 +176,10 @@ func (m *Manager) isBehindNAT() bool {
 }
 
 func (m *Manager) portMappingFailed() bool {
-	event := m.natEventGetter.LastEvent()
+	event, found := m.natEventGetter.LastEvent()
+	if !found {
+		return false
+	}
 	return event.Stage == mapping.StageName && event.Type == traversal.FailureEventType
 }
 

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -58,7 +58,7 @@ type NATPinger interface {
 
 // NATEventGetter allows us to fetch the last known NAT event
 type NATEventGetter interface {
-	LastEvent() (traversal.Event, bool)
+	LastEvent() *traversal.Event
 }
 
 // Manager represents entrypoint for Openvpn service with top level components
@@ -176,8 +176,8 @@ func (m *Manager) isBehindNAT() bool {
 }
 
 func (m *Manager) portMappingFailed() bool {
-	event, found := m.natEventGetter.LastEvent()
-	if !found {
+	event := m.natEventGetter.LastEvent()
+	if event == nil {
 		return false
 	}
 	return event.Stage == mapping.StageName && !event.Successful

--- a/session/manager.go
+++ b/session/manager.go
@@ -74,7 +74,7 @@ type BalanceTrackerFactory func(consumer, provider, issuer identity.Identity) (B
 
 // NATEventGetter lets us access the last known traversal event
 type NATEventGetter interface {
-	LastEvent() (traversal.Event, bool)
+	LastEvent() *traversal.Event
 }
 
 // NewManager returns new session Manager

--- a/session/manager.go
+++ b/session/manager.go
@@ -74,7 +74,7 @@ type BalanceTrackerFactory func(consumer, provider, issuer identity.Identity) (B
 
 // NATEventGetter lets us access the last known traversal event
 type NATEventGetter interface {
-	LastEvent() traversal.Event
+	LastEvent() (traversal.Event, bool)
 }
 
 // NewManager returns new session Manager

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -98,6 +98,6 @@ func TestManager_Create_RejectsUnknownProposal(t *testing.T) {
 type MockNatEventTracker struct {
 }
 
-func (mnet *MockNatEventTracker) LastEvent() (traversal.Event, bool) {
-	return traversal.Event{}, true
+func (mnet *MockNatEventTracker) LastEvent() *traversal.Event {
+	return &traversal.Event{}
 }

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -98,6 +98,6 @@ func TestManager_Create_RejectsUnknownProposal(t *testing.T) {
 type MockNatEventTracker struct {
 }
 
-func (mnet *MockNatEventTracker) LastEvent() traversal.Event {
-	return traversal.Event{}
+func (mnet *MockNatEventTracker) LastEvent() (traversal.Event, bool) {
+	return traversal.Event{}, true
 }


### PR DESCRIPTION
I have to admit, I haven't actually tested that proper events are sent in https://github.com/mysteriumnetwork/node/pull/900. And they aren't - no new fields were sent, because they all were private :D

This fixed events sending and improves internal NAT events structure to be similar to ELK events structure - it simplifies stuff.