### PR TITLE
Refactor event bus

### DIFF
--- a/bus/event_bus.go
+++ b/bus/event_bus.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bus
+
+import asaskevichEventBus "github.com/asaskevich/EventBus"
+
+// EventBus allows subscribing and publishing data by topic
+type EventBus interface {
+	Subscribe(topic string, fn interface{}) error
+	Publish(topic string, args ...interface{})
+}
+
+// NewEventBus returns implementation of EventBus
+func NewEventBus() EventBus {
+	return asaskevichEventBus.New()
+}

--- a/bus/event_bus.go
+++ b/bus/event_bus.go
@@ -26,19 +26,19 @@ type EventBus interface {
 }
 
 type simplifiedEventBus struct {
-	bus *asaskevichEventBus.Bus
+	bus asaskevichEventBus.Bus
 }
 
 func (bus simplifiedEventBus) Subscribe(topic string, fn interface{}) error {
-	return bus.Subscribe(topic, fn)
+	return bus.bus.Subscribe(topic, fn)
 }
 
 func (bus simplifiedEventBus) Publish(topic string, data interface{}) {
-	bus.Publish(topic, data)
+	bus.bus.Publish(topic, data)
 }
 
 // NewEventBus returns implementation of EventBus
 func NewEventBus() EventBus {
 	bus := asaskevichEventBus.New()
-	return simplifiedEventBus{bus: &bus}
+	return simplifiedEventBus{bus: bus}
 }

--- a/bus/event_bus.go
+++ b/bus/event_bus.go
@@ -22,10 +22,23 @@ import asaskevichEventBus "github.com/asaskevich/EventBus"
 // EventBus allows subscribing and publishing data by topic
 type EventBus interface {
 	Subscribe(topic string, fn interface{}) error
-	Publish(topic string, args ...interface{})
+	Publish(topic string, arg interface{})
+}
+
+type simplifiedEventBus struct {
+	bus *asaskevichEventBus.Bus
+}
+
+func (bus simplifiedEventBus) Subscribe(topic string, fn interface{}) error {
+	return bus.Subscribe(topic, fn)
+}
+
+func (bus simplifiedEventBus) Publish(topic string, arg interface{}) {
+	bus.Publish(topic, arg)
 }
 
 // NewEventBus returns implementation of EventBus
 func NewEventBus() EventBus {
-	return asaskevichEventBus.New()
+	bus := asaskevichEventBus.New()
+	return simplifiedEventBus{bus: &bus}
 }

--- a/bus/event_bus.go
+++ b/bus/event_bus.go
@@ -22,7 +22,7 @@ import asaskevichEventBus "github.com/asaskevich/EventBus"
 // EventBus allows subscribing and publishing data by topic
 type EventBus interface {
 	Subscribe(topic string, fn interface{}) error
-	Publish(topic string, arg interface{})
+	Publish(topic string, data interface{})
 }
 
 type simplifiedEventBus struct {
@@ -33,8 +33,8 @@ func (bus simplifiedEventBus) Subscribe(topic string, fn interface{}) error {
 	return bus.Subscribe(topic, fn)
 }
 
-func (bus simplifiedEventBus) Publish(topic string, arg interface{}) {
-	bus.Publish(topic, arg)
+func (bus simplifiedEventBus) Publish(topic string, data interface{}) {
+	bus.Publish(topic, data)
 }
 
 // NewEventBus returns implementation of EventBus

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -456,7 +456,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 }
 
 func (di *Dependencies) bootstrapEventBus() {
-	di.EventBus = eventbus.NewEventBus()
+	di.EventBus = eventbus.New()
 }
 
 func (di *Dependencies) bootstrapIdentityComponents(options node.Options) {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -20,12 +20,12 @@ package cmd
 import (
 	"time"
 
-	"github.com/asaskevich/EventBus"
 	log "github.com/cihub/seelog"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/mysteriumnetwork/node/blockchain"
+	"github.com/mysteriumnetwork/node/bus"
 	"github.com/mysteriumnetwork/node/communication"
 	nats_dialog "github.com/mysteriumnetwork/node/communication/nats/dialog"
 	nats_discovery "github.com/mysteriumnetwork/node/communication/nats/discovery"
@@ -131,7 +131,7 @@ type Dependencies struct {
 	StatisticsReporter *statistics.SessionStatisticsReporter
 	SessionStorage     *consumer_session.Storage
 
-	EventBus EventBus.Bus
+	EventBus bus.EventBus
 
 	ConnectionManager  connection.Manager
 	ConnectionRegistry *connection.Registry
@@ -456,7 +456,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 }
 
 func (di *Dependencies) bootstrapEventBus() {
-	di.EventBus = EventBus.New()
+	di.EventBus = bus.NewEventBus()
 }
 
 func (di *Dependencies) bootstrapIdentityComponents(options node.Options) {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/mysteriumnetwork/node/blockchain"
-	"github.com/mysteriumnetwork/node/bus"
 	"github.com/mysteriumnetwork/node/communication"
 	nats_dialog "github.com/mysteriumnetwork/node/communication/nats/dialog"
 	nats_discovery "github.com/mysteriumnetwork/node/communication/nats/discovery"
@@ -39,6 +38,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb/migrations/history"
+	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
 	identity_registry "github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/node/logconfig"
@@ -131,7 +131,7 @@ type Dependencies struct {
 	StatisticsReporter *statistics.SessionStatisticsReporter
 	SessionStorage     *consumer_session.Storage
 
-	EventBus bus.EventBus
+	EventBus eventbus.EventBus
 
 	ConnectionManager  connection.Manager
 	ConnectionRegistry *connection.Registry
@@ -456,7 +456,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 }
 
 func (di *Dependencies) bootstrapEventBus() {
-	di.EventBus = bus.NewEventBus()
+	di.EventBus = eventbus.NewEventBus()
 }
 
 func (di *Dependencies) bootstrapIdentityComponents(options node.Options) {

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -64,7 +64,7 @@ type SessionInfo struct {
 
 // Publisher is responsible for publishing given events
 type Publisher interface {
-	Publish(topic string, args ...interface{})
+	Publish(topic string, arg interface{})
 }
 
 // PaymentIssuer handles the payments for service

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -64,7 +64,7 @@ type SessionInfo struct {
 
 // Publisher is responsible for publishing given events
 type Publisher interface {
-	Publish(topic string, arg interface{})
+	Publish(topic string, data interface{})
 }
 
 // PaymentIssuer handles the payments for service

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -301,7 +301,7 @@ func (tc *testContext) Test_SessionEndPublished_OnConnectError() {
 
 	for _, v := range history {
 		if v.calledWithTopic == SessionEventTopic {
-			event := v.calledWithArg.(SessionEvent)
+			event := v.calledWithData.(SessionEvent)
 			if event.Status == SessionEndedStatus {
 				found = true
 
@@ -350,12 +350,12 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 
 	for _, v := range history {
 		if v.calledWithTopic == StatisticsEventTopic {
-			event := v.calledWithArg.(consumer.SessionStatistics)
+			event := v.calledWithData.(consumer.SessionStatistics)
 			assert.True(tc.T(), event.BytesReceived == tc.mockStatistics.BytesReceived)
 			assert.True(tc.T(), event.BytesSent == tc.mockStatistics.BytesSent)
 		}
 		if v.calledWithTopic == StateEventTopic {
-			event := v.calledWithArg.(StateEvent)
+			event := v.calledWithData.(StateEvent)
 			assert.Equal(tc.T(), Connected, event.State)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
 			assert.Equal(tc.T(), establishedSessionID, event.SessionInfo.SessionID)
@@ -363,7 +363,7 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 			assert.Equal(tc.T(), activeProposal.ServiceType, event.SessionInfo.Proposal.ServiceType)
 		}
 		if v.calledWithTopic == SessionEventTopic {
-			event := v.calledWithArg.(SessionEvent)
+			event := v.calledWithData.(SessionEvent)
 			assert.Equal(tc.T(), SessionCreatedStatus, event.Status)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
 			assert.Equal(tc.T(), establishedSessionID, event.SessionInfo.SessionID)

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -301,7 +301,7 @@ func (tc *testContext) Test_SessionEndPublished_OnConnectError() {
 
 	for _, v := range history {
 		if v.calledWithTopic == SessionEventTopic {
-			event := v.calledWithArgs[0].(SessionEvent)
+			event := v.calledWithArg.(SessionEvent)
 			if event.Status == SessionEndedStatus {
 				found = true
 
@@ -350,12 +350,12 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 
 	for _, v := range history {
 		if v.calledWithTopic == StatisticsEventTopic {
-			event := v.calledWithArgs[0].(consumer.SessionStatistics)
+			event := v.calledWithArg.(consumer.SessionStatistics)
 			assert.True(tc.T(), event.BytesReceived == tc.mockStatistics.BytesReceived)
 			assert.True(tc.T(), event.BytesSent == tc.mockStatistics.BytesSent)
 		}
 		if v.calledWithTopic == StateEventTopic {
-			event := v.calledWithArgs[0].(StateEvent)
+			event := v.calledWithArg.(StateEvent)
 			assert.Equal(tc.T(), Connected, event.State)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
 			assert.Equal(tc.T(), establishedSessionID, event.SessionInfo.SessionID)
@@ -363,7 +363,7 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 			assert.Equal(tc.T(), activeProposal.ServiceType, event.SessionInfo.Proposal.ServiceType)
 		}
 		if v.calledWithTopic == SessionEventTopic {
-			event := v.calledWithArgs[0].(SessionEvent)
+			event := v.calledWithArg.(SessionEvent)
 			assert.Equal(tc.T(), SessionCreatedStatus, event.Status)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
 			assert.Equal(tc.T(), establishedSessionID, event.SessionInfo.SessionID)

--- a/core/connection/stubs_test.go
+++ b/core/connection/stubs_test.go
@@ -32,7 +32,7 @@ import (
 // StubPublisherEvent represents the event in publishers history
 type StubPublisherEvent struct {
 	calledWithTopic string
-	calledWithArg   interface{}
+	calledWithData  interface{}
 }
 
 // StubPublisher acts as a publisher
@@ -49,12 +49,12 @@ func NewStubPublisher() *StubPublisher {
 }
 
 // Publish adds the given event to the publish history
-func (sp *StubPublisher) Publish(topic string, arg interface{}) {
+func (sp *StubPublisher) Publish(topic string, data interface{}) {
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 	event := StubPublisherEvent{
 		calledWithTopic: topic,
-		calledWithArg:   arg,
+		calledWithData:  data,
 	}
 	sp.publishHistory = append(sp.publishHistory, event)
 }

--- a/core/connection/stubs_test.go
+++ b/core/connection/stubs_test.go
@@ -32,7 +32,7 @@ import (
 // StubPublisherEvent represents the event in publishers history
 type StubPublisherEvent struct {
 	calledWithTopic string
-	calledWithArgs  []interface{}
+	calledWithArg   interface{}
 }
 
 // StubPublisher acts as a publisher
@@ -49,12 +49,12 @@ func NewStubPublisher() *StubPublisher {
 }
 
 // Publish adds the given event to the publish history
-func (sp *StubPublisher) Publish(topic string, args ...interface{}) {
+func (sp *StubPublisher) Publish(topic string, arg interface{}) {
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 	event := StubPublisherEvent{
 		calledWithTopic: topic,
-		calledWithArgs:  args,
+		calledWithArg:   arg,
 	}
 	sp.publishHistory = append(sp.publishHistory, event)
 }

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -105,5 +105,5 @@ func TestManager_StopSendsEvent_SucceedsAndPublishesEvent(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, StopTopic, eventBus.publishedTopic)
-	assert.Equal(t, &mockCopy, eventBus.publishedArg.(*Instance).service)
+	assert.Equal(t, &mockCopy, eventBus.publishedData.(*Instance).service)
 }

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -105,6 +105,5 @@ func TestManager_StopSendsEvent_SucceedsAndPublishesEvent(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, StopTopic, eventBus.publishedTopic)
-	assert.Len(t, eventBus.publishedArgs, 1)
-	assert.Equal(t, &mockCopy, eventBus.publishedArgs[0].(*Instance).service)
+	assert.Equal(t, &mockCopy, eventBus.publishedArg.(*Instance).service)
 }

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -44,7 +44,7 @@ type Pool struct {
 
 // Publisher is responsible for publishing given events
 type Publisher interface {
-	Publish(topic string, arg interface{})
+	Publish(topic string, data interface{})
 }
 
 // NewPool returns a empty service pool

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -44,7 +44,7 @@ type Pool struct {
 
 // Publisher is responsible for publishing given events
 type Publisher interface {
-	Publish(topic string, args ...interface{})
+	Publish(topic string, arg interface{})
 }
 
 // NewPool returns a empty service pool

--- a/core/service/pool_test.go
+++ b/core/service/pool_test.go
@@ -33,9 +33,9 @@ type mockPublisher struct {
 	publishedArg   interface{}
 }
 
-func (mockPublisher *mockPublisher) Publish(topic string, arg interface{}) {
+func (mockPublisher *mockPublisher) Publish(topic string, data interface{}) {
 	mockPublisher.publishedTopic = topic
-	mockPublisher.publishedArg = arg
+	mockPublisher.publishedArg = data
 }
 
 func (mr *mockService) Stop() error {

--- a/core/service/pool_test.go
+++ b/core/service/pool_test.go
@@ -30,12 +30,12 @@ type mockService struct {
 
 type mockPublisher struct {
 	publishedTopic string
-	publishedArgs  []interface{}
+	publishedArg   interface{}
 }
 
-func (mockPublisher *mockPublisher) Publish(topic string, args ...interface{}) {
+func (mockPublisher *mockPublisher) Publish(topic string, arg interface{}) {
 	mockPublisher.publishedTopic = topic
-	mockPublisher.publishedArgs = args
+	mockPublisher.publishedArg = arg
 }
 
 func (mr *mockService) Stop() error {

--- a/core/service/pool_test.go
+++ b/core/service/pool_test.go
@@ -30,12 +30,12 @@ type mockService struct {
 
 type mockPublisher struct {
 	publishedTopic string
-	publishedArg   interface{}
+	publishedData  interface{}
 }
 
 func (mockPublisher *mockPublisher) Publish(topic string, data interface{}) {
 	mockPublisher.publishedTopic = topic
-	mockPublisher.publishedArg = data
+	mockPublisher.publishedData = data
 }
 
 func (mr *mockService) Stop() error {

--- a/eventbus/event_bus.go
+++ b/eventbus/event_bus.go
@@ -29,12 +29,12 @@ type simplifiedEventBus struct {
 	bus asaskevichEventBus.Bus
 }
 
-func (bus simplifiedEventBus) Subscribe(topic string, fn interface{}) error {
-	return bus.bus.Subscribe(topic, fn)
+func (simplifiedBus simplifiedEventBus) Subscribe(topic string, fn interface{}) error {
+	return simplifiedBus.bus.Subscribe(topic, fn)
 }
 
-func (bus simplifiedEventBus) Publish(topic string, data interface{}) {
-	bus.bus.Publish(topic, data)
+func (simplifiedBus simplifiedEventBus) Publish(topic string, data interface{}) {
+	simplifiedBus.bus.Publish(topic, data)
 }
 
 // New returns implementation of EventBus

--- a/eventbus/event_bus.go
+++ b/eventbus/event_bus.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bus
+package eventbus
 
 import asaskevichEventBus "github.com/asaskevich/EventBus"
 

--- a/eventbus/event_bus_test.go
+++ b/eventbus/event_bus_test.go
@@ -17,28 +17,20 @@
 
 package eventbus
 
-import asaskevichEventBus "github.com/asaskevich/EventBus"
+import (
+	"testing"
 
-// EventBus allows subscribing and publishing data by topic
-type EventBus interface {
-	Subscribe(topic string, fn interface{}) error
-	Publish(topic string, data interface{})
-}
+	"github.com/stretchr/testify/assert"
+)
 
-type simplifiedEventBus struct {
-	bus asaskevichEventBus.Bus
-}
+func Test_simplifiedEventBus_Publish_InvokesSubscribers(t *testing.T) {
+	eventBus := New()
+	var received string
+	eventBus.Subscribe("test topic", func(data string) {
+		received = data
+	})
 
-func (bus simplifiedEventBus) Subscribe(topic string, fn interface{}) error {
-	return bus.bus.Subscribe(topic, fn)
-}
+	eventBus.Publish("test topic", "test data")
 
-func (bus simplifiedEventBus) Publish(topic string, data interface{}) {
-	bus.bus.Publish(topic, data)
-}
-
-// New returns implementation of EventBus
-func New() EventBus {
-	bus := asaskevichEventBus.New()
-	return simplifiedEventBus{bus: bus}
+	assert.Equal(t, "test data", received)
 }

--- a/nat/mapping/port_mapping.go
+++ b/nat/mapping/port_mapping.go
@@ -37,7 +37,7 @@ const StageName = "port_mapping"
 
 // Publisher is responsible for publishing given events
 type Publisher interface {
-	Publish(topic string, arg interface{})
+	Publish(topic string, data interface{})
 }
 
 // GetPortMappingFunc returns PortMapping function if service is behind NAT

--- a/nat/mapping/port_mapping.go
+++ b/nat/mapping/port_mapping.go
@@ -37,7 +37,7 @@ const StageName = "port_mapping"
 
 // Publisher is responsible for publishing given events
 type Publisher interface {
-	Publish(topic string, args ...interface{})
+	Publish(topic string, arg interface{})
 }
 
 // GetPortMappingFunc returns PortMapping function if service is behind NAT


### PR DESCRIPTION
- Decouple from external event bus implementation (github.com/asaskevich/EventBus)
- Simplify interface
- Unify naming