### PR TITLE
Use the unified way to print error logs

### DIFF
--- a/cmd/mysterium_node/mysterium_node.go
+++ b/cmd/mysterium_node/mysterium_node.go
@@ -18,9 +18,9 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/cmd"
 	command_cli "github.com/mysteriumnetwork/node/cmd/commands/cli"
 	"github.com/mysteriumnetwork/node/cmd/commands/daemon"
@@ -47,13 +47,15 @@ var (
 func main() {
 	app, err := NewCommand()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		log.Error("Failed to create command: ", err)
+		log.Flush()
 		os.Exit(1)
 	}
 
 	err = app.Run(os.Args)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		log.Error("Failed to execute command: ", err)
+		log.Flush()
 		os.Exit(1)
 	}
 }

--- a/utils/stopper.go
+++ b/utils/stopper.go
@@ -18,8 +18,9 @@
 package utils
 
 import (
-	"fmt"
 	"os"
+
+	log "github.com/cihub/seelog"
 )
 
 // Killer kills some resource and performs cleanup
@@ -49,12 +50,13 @@ func newStopper(kill Killer, exit exitter) func() {
 
 func stop(kill Killer, exit exitter) {
 	if err := kill(); err != nil {
-		msg := fmt.Sprintf("Error while killing process: %v\n", err.Error())
-		fmt.Fprintln(os.Stderr, msg)
+		log.Errorf("Error while killing process: %v\n", err.Error())
+		log.Flush()
 		exit(1)
 		return
 	}
 
-	fmt.Println("Good bye")
+	log.Info("Good bye")
+	log.Flush()
 	exit(0)
 }

--- a/utils/stopper.go
+++ b/utils/stopper.go
@@ -51,12 +51,10 @@ func newStopper(kill Killer, exit exitter) func() {
 func stop(kill Killer, exit exitter) {
 	if err := kill(); err != nil {
 		log.Errorf("Error while killing process: %v\n", err.Error())
-		log.Flush()
 		exit(1)
 		return
 	}
 
 	log.Info("Good bye")
-	log.Flush()
 	exit(0)
 }


### PR DESCRIPTION
Starting a myst service with an incorrect service type does not print logs, it just prints to the `stderr`. 
Running a myst service with systemd swallows these errors and it starting to be very hard to figure out the source of the problem

![image](https://user-images.githubusercontent.com/8612618/56941527-d7890d00-6b36-11e9-8db6-eed919baa1f0.png)

This PR changes formatted output to the unified logs, that we are using everywhere it allows to keep logs in the same form and able to read it. 


