### PR TITLE
Fix location cache

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -498,7 +498,7 @@ func (di *Dependencies) bootstrapLocationComponents(options node.OptionsLocation
 		return err
 	}
 
-	di.LocationResolver = location.NewProperCache(resolver, time.Minute*5)
+	di.LocationResolver = location.NewCache(resolver, time.Minute*5)
 	return nil
 }
 

--- a/consumer/statistics/reporter.go
+++ b/consumer/statistics/reporter.go
@@ -36,9 +36,6 @@ const statsSenderLogPrefix = "[session-stats-sender] "
 // ErrSessionNotStarted represents the error that occurs when the session has not been started yet
 var ErrSessionNotStarted = errors.New("session not started")
 
-// LocationDetector detects the country for session stats
-type LocationDetector func() location.Location
-
 // StatsTracker allows for retrieval and resetting of statistics
 type StatsTracker interface {
 	Retrieve() consumer.SessionStatistics
@@ -54,7 +51,7 @@ type Reporter interface {
 // SessionStatisticsReporter sends session stats to remote API server with a fixed sendInterval.
 // Extra one send will be done on session disconnect.
 type SessionStatisticsReporter struct {
-	locationDetector LocationDetector
+	locationDetector location.Resolver
 
 	signerFactory     identity.SignerFactory
 	statisticsTracker StatsTracker
@@ -68,7 +65,7 @@ type SessionStatisticsReporter struct {
 }
 
 // NewSessionStatisticsReporter function creates new session stats sender by given options
-func NewSessionStatisticsReporter(statisticsTracker StatsTracker, remoteReporter Reporter, signerFactory identity.SignerFactory, locationDetector LocationDetector, interval time.Duration) *SessionStatisticsReporter {
+func NewSessionStatisticsReporter(statisticsTracker StatsTracker, remoteReporter Reporter, signerFactory identity.SignerFactory, locationDetector location.Resolver, interval time.Duration) *SessionStatisticsReporter {
 	return &SessionStatisticsReporter{
 		locationDetector:  locationDetector,
 		signerFactory:     signerFactory,
@@ -90,14 +87,18 @@ func (sr *SessionStatisticsReporter) start(consumerID identity.Identity, service
 	}
 
 	signer := sr.signerFactory(consumerID)
-	country := sr.locationDetector().Country
+	loc, err := sr.locationDetector.DetectLocation()
+	if err != nil {
+		log.Error(statsSenderLogPrefix, "Failed to resolve location: ", err)
+	}
+
 	sr.done = make(chan struct{})
 
 	go func() {
 		for {
 			select {
 			case <-sr.done:
-				if err := sr.send(serviceType, providerID, country, sessionID, signer); err != nil {
+				if err := sr.send(serviceType, providerID, loc.Country, sessionID, signer); err != nil {
 					log.Error(statsSenderLogPrefix, "Failed to send session stats to the remote service: ", err)
 				} else {
 					log.Debug(statsSenderLogPrefix, "Final stats sent")
@@ -106,7 +107,7 @@ func (sr *SessionStatisticsReporter) start(consumerID identity.Identity, service
 				sr.statisticsTracker.Reset()
 				return
 			case <-time.After(sr.sendInterval):
-				if err := sr.send(serviceType, providerID, country, sessionID, signer); err != nil {
+				if err := sr.send(serviceType, providerID, loc.Country, sessionID, signer); err != nil {
 					log.Error(statsSenderLogPrefix, "Failed to send session stats to the remote service: ", err)
 				} else {
 					log.Debug(statsSenderLogPrefix, "Stats sent")

--- a/consumer/statistics/reporter_test.go
+++ b/consumer/statistics/reporter_test.go
@@ -46,16 +46,18 @@ func mockSignerFactory(_ identity.Identity) identity.Signer {
 	return &identity.SignerFake{}
 }
 
-func mockLocationDetector() location.Location {
+type mockLocationDetector struct{}
+
+func (mld *mockLocationDetector) DetectLocation() (location.Location, error) {
 	return location.Location{
 		Country: "KG",
-	}
+	}, nil
 }
 
 func TestStatisticsReporterStartsAndStops(t *testing.T) {
 	statisticsTracker := NewSessionStatisticsTracker(time.Now)
 	mockSender := newMockRemoteSender()
-	reporter := NewSessionStatisticsReporter(statisticsTracker, mockSender, mockSignerFactory, mockLocationDetector, time.Minute)
+	reporter := NewSessionStatisticsReporter(statisticsTracker, mockSender, mockSignerFactory, &mockLocationDetector{}, time.Minute)
 
 	reporter.ConsumeSessionEvent(mockSessionEvent)
 
@@ -69,7 +71,7 @@ func TestStatisticsReporterStartsAndStops(t *testing.T) {
 func TestStatisticsReporterInterval(t *testing.T) {
 	mockSender := newMockRemoteSender()
 	statisticsTracker := NewSessionStatisticsTracker(time.Now)
-	reporter := NewSessionStatisticsReporter(statisticsTracker, mockSender, mockSignerFactory, mockLocationDetector, time.Nanosecond)
+	reporter := NewSessionStatisticsReporter(statisticsTracker, mockSender, mockSignerFactory, &mockLocationDetector{}, time.Nanosecond)
 
 	reporter.ConsumeSessionEvent(mockSessionEvent)
 
@@ -82,7 +84,7 @@ func TestStatisticsReporterInterval(t *testing.T) {
 func TestStatisticsReporterConsumeSessionEvent(t *testing.T) {
 	mockSender := newMockRemoteSender()
 	statisticsTracker := NewSessionStatisticsTracker(time.Now)
-	reporter := NewSessionStatisticsReporter(statisticsTracker, mockSender, mockSignerFactory, mockLocationDetector, time.Nanosecond)
+	reporter := NewSessionStatisticsReporter(statisticsTracker, mockSender, mockSignerFactory, &mockLocationDetector{}, time.Nanosecond)
 	reporter.ConsumeSessionEvent(mockSessionEvent)
 	<-mockSender.called
 	assert.True(t, reporter.started)

--- a/core/location/cache.go
+++ b/core/location/cache.go
@@ -25,10 +25,10 @@ import (
 	"github.com/mysteriumnetwork/node/core/connection"
 )
 
-const locationCacheLogPrefix = "[location-cache]"
+const locationCacheLogPrefix = "[location-cache] "
 
-// ProperCache allows us to cache location resolution
-type ProperCache struct {
+// Cache allows us to cache location resolution
+type Cache struct {
 	lastFetched      time.Time
 	locationDetector Resolver
 	location         Location
@@ -36,19 +36,19 @@ type ProperCache struct {
 	lock             sync.Mutex
 }
 
-// NewProperCache returns a new instance of location cache
-func NewProperCache(resolver Resolver, expiry time.Duration) *ProperCache {
-	return &ProperCache{
+// NewCache returns a new instance of location cache
+func NewCache(resolver Resolver, expiry time.Duration) *Cache {
+	return &Cache{
 		locationDetector: resolver,
 		expiry:           expiry,
 	}
 }
 
-func (c *ProperCache) needsRefresh() bool {
+func (c *Cache) needsRefresh() bool {
 	return c.lastFetched.IsZero() || c.lastFetched.After(time.Now().Add(-c.expiry))
 }
 
-func (c *ProperCache) fetchAndSave() (Location, error) {
+func (c *Cache) fetchAndSave() (Location, error) {
 	loc, err := c.locationDetector.DetectLocation()
 
 	// on successful fetch save the values for further use
@@ -61,7 +61,7 @@ func (c *ProperCache) fetchAndSave() (Location, error) {
 }
 
 // DetectLocation returns location from cache, or fetches it if needed
-func (c *ProperCache) DetectLocation() (Location, error) {
+func (c *Cache) DetectLocation() (Location, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -74,7 +74,7 @@ func (c *ProperCache) DetectLocation() (Location, error) {
 
 // HandleConnectionEvent handles connection state change and fetches the location info accordingly.
 // On the consumer side, we'll need to re-fetch the location once the user is connected or disconnected from a service.
-func (c *ProperCache) HandleConnectionEvent(se connection.StateEvent) {
+func (c *Cache) HandleConnectionEvent(se connection.StateEvent) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if se.State != connection.Connected && se.State != connection.NotConnected {

--- a/core/location/cache.go
+++ b/core/location/cache.go
@@ -27,6 +27,7 @@ import (
 
 const locationCacheLogPrefix = "[location-cache]"
 
+// ProperCache allows us to cache location resolution
 type ProperCache struct {
 	lastFetched      time.Time
 	locationDetector Resolver
@@ -35,6 +36,7 @@ type ProperCache struct {
 	lock             sync.Mutex
 }
 
+// NewProperCache returns a new instance of location cache
 func NewProperCache(resolver Resolver, expiry time.Duration) *ProperCache {
 	return &ProperCache{
 		locationDetector: resolver,
@@ -68,19 +70,6 @@ func (c *ProperCache) DetectLocation() (Location, error) {
 	}
 
 	return c.fetchAndSave()
-}
-
-// DetectLocation returns location from cache, or fetches it if needed
-func (c *ProperCache) Get() Location {
-	loc, err := c.DetectLocation()
-	if err != nil {
-		log.Error(locationCacheLogPrefix, "location update failed", err)
-	}
-	return loc
-}
-
-func (c *ProperCache) RefreshAndGet() (Location, error) {
-	return c.DetectLocation()
 }
 
 // HandleConnectionEvent handles connection state change and fetches the location info accordingly.

--- a/core/location/cache_test.go
+++ b/core/location/cache_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/connection"
 )
 
-func TestProperCache_needsRefresh(t *testing.T) {
+func TestCache_needsRefresh(t *testing.T) {
 	type fields struct {
 		lastFetched time.Time
 		expiry      time.Duration
@@ -60,12 +60,12 @@ func TestProperCache_needsRefresh(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &ProperCache{
+			c := &Cache{
 				lastFetched: tt.fields.lastFetched,
 				expiry:      tt.fields.expiry,
 			}
 			if got := c.needsRefresh(); got != tt.want {
-				t.Errorf("ProperCache.needsRefresh() = %v, want %v", got, tt.want)
+				t.Errorf("Cache.needsRefresh() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -83,7 +83,7 @@ func (mr *mockResolver) DetectLocation() (Location, error) {
 
 func TestCacheHandlesConnection_Connected(t *testing.T) {
 	r := &mockResolver{}
-	c := &ProperCache{
+	c := &Cache{
 		expiry:           time.Second * 1,
 		locationDetector: r,
 	}
@@ -93,7 +93,7 @@ func TestCacheHandlesConnection_Connected(t *testing.T) {
 
 func TestCacheHandlesConnection_NotConnected(t *testing.T) {
 	r := &mockResolver{}
-	c := &ProperCache{
+	c := &Cache{
 		expiry:           time.Second * 1,
 		locationDetector: r,
 	}
@@ -103,7 +103,7 @@ func TestCacheHandlesConnection_NotConnected(t *testing.T) {
 
 func TestCacheIgnoresOther(t *testing.T) {
 	r := &mockResolver{}
-	c := &ProperCache{
+	c := &Cache{
 		expiry:           time.Second * 1,
 		locationDetector: r,
 	}

--- a/core/location/interface.go
+++ b/core/location/interface.go
@@ -21,9 +21,3 @@ package location
 type Resolver interface {
 	DetectLocation() (Location, error)
 }
-
-// Cache allows caching location
-type Cache interface {
-	Get() Location
-	RefreshAndGet() (Location, error)
-}

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -35,26 +35,26 @@ type NatPinger interface {
 func NewNode(
 	connectionManager connection.Manager,
 	tequilapiServer tequilapi.APIServer,
-	originalLocationCache location.Cache,
+	locationCache location.Resolver,
 	metricsSender *metrics.Sender,
 	natPinger NatPinger,
 ) *Node {
 	return &Node{
-		connectionManager:     connectionManager,
-		httpAPIServer:         tequilapiServer,
-		originalLocationCache: originalLocationCache,
-		metricsSender:         metricsSender,
-		natPinger:             natPinger,
+		connectionManager: connectionManager,
+		httpAPIServer:     tequilapiServer,
+		locationCache:     locationCache,
+		metricsSender:     metricsSender,
+		natPinger:         natPinger,
 	}
 }
 
 // Node represent entrypoint for Mysterium node with top level components
 type Node struct {
-	connectionManager     connection.Manager
-	httpAPIServer         tequilapi.APIServer
-	originalLocationCache location.Cache
-	metricsSender         *metrics.Sender
-	natPinger             NatPinger
+	connectionManager connection.Manager
+	httpAPIServer     tequilapi.APIServer
+	locationCache     location.Resolver
+	metricsSender     *metrics.Sender
+	natPinger         NatPinger
 }
 
 // Start starts Mysterium node (Tequilapi service, fetches location)
@@ -66,7 +66,7 @@ func (node *Node) Start() error {
 		}
 	}()
 
-	originalLocation, err := node.originalLocationCache.RefreshAndGet()
+	originalLocation, err := node.locationCache.DetectLocation()
 	if err != nil {
 		log.Warn("Failed to detect original country: ", err)
 	} else {

--- a/eventbus/event_bus.go
+++ b/eventbus/event_bus.go
@@ -22,6 +22,7 @@ import asaskevichEventBus "github.com/asaskevich/EventBus"
 // EventBus allows subscribing and publishing data by topic
 type EventBus interface {
 	Subscribe(topic string, fn interface{}) error
+	SubscribeAsync(topic string, fn interface{}) error
 	Publish(topic string, data interface{})
 }
 
@@ -31,6 +32,10 @@ type simplifiedEventBus struct {
 
 func (simplifiedBus simplifiedEventBus) Subscribe(topic string, fn interface{}) error {
 	return simplifiedBus.bus.Subscribe(topic, fn)
+}
+
+func (simplifiedBus simplifiedEventBus) SubscribeAsync(topic string, fn interface{}) error {
+	return simplifiedBus.bus.SubscribeAsync(topic, fn, false)
 }
 
 func (simplifiedBus simplifiedEventBus) Publish(topic string, data interface{}) {

--- a/services/openvpn/connection_factory.go
+++ b/services/openvpn/connection_factory.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/state"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/ip"
-	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/services/openvpn/middlewares/client/bytescount"
 	openvpn_session "github.com/mysteriumnetwork/node/services/openvpn/session"
@@ -36,31 +35,28 @@ import (
 
 // ProcessBasedConnectionFactory represents a factory for creating process-based openvpn connections
 type ProcessBasedConnectionFactory struct {
-	openvpnBinary         string
-	configDirectory       string
-	runtimeDirectory      string
-	originalLocationCache location.Cache
-	signerFactory         identity.SignerFactory
-	ipResolver            ip.Resolver
-	natPinger             NATPinger
+	openvpnBinary    string
+	configDirectory  string
+	runtimeDirectory string
+	signerFactory    identity.SignerFactory
+	ipResolver       ip.Resolver
+	natPinger        NATPinger
 }
 
 // NewProcessBasedConnectionFactory creates a new ProcessBasedConnectionFactory
 func NewProcessBasedConnectionFactory(
 	openvpnBinary, configDirectory, runtimeDirectory string,
-	originalLocationCache location.Cache,
 	signerFactory identity.SignerFactory,
 	resolver ip.Resolver,
 	natPinger NATPinger,
 ) *ProcessBasedConnectionFactory {
 	return &ProcessBasedConnectionFactory{
-		openvpnBinary:         openvpnBinary,
-		configDirectory:       configDirectory,
-		runtimeDirectory:      runtimeDirectory,
-		originalLocationCache: originalLocationCache,
-		signerFactory:         signerFactory,
-		ipResolver:            resolver,
-		natPinger:             natPinger,
+		openvpnBinary:    openvpnBinary,
+		configDirectory:  configDirectory,
+		runtimeDirectory: runtimeDirectory,
+		signerFactory:    signerFactory,
+		ipResolver:       resolver,
+		natPinger:        natPinger,
 	}
 }
 

--- a/services/openvpn/connection_factory_test.go
+++ b/services/openvpn/connection_factory_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/mysteriumnetwork/node/consumer"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/ip"
-	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,18 +35,6 @@ var fakeSessionConfig = []byte(`{
     "CACertificate": "\n-----BEGIN CERTIFICATE-----\nMIIByDCCAW6gAwIBAgICBFcwCgYIKoZIzj0EAwIwQzELMAkGA1UEBhMCR0IxGzAZ\nBgNVBAoTEk15c3Rlcm1pdW0ubmV0d29yazEXMBUGA1UECxMOTXlzdGVyaXVtIFRl\nYW0wHhcNMTgwNTA4MTIwMDU5WhcNMjgwNTA4MTIwMDU5WjBDMQswCQYDVQQGEwJH\nQjEbMBkGA1UEChMSTXlzdGVybWl1bS5uZXR3b3JrMRcwFQYDVQQLEw5NeXN0ZXJp\ndW0gVGVhbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABKvoBgL5PCWlUr4PSl2j\njSXtW8ohVESWVL6l0de+Sj6dWsjELxmLAKdnwep9CcYvGE0i3Q0M24C/ZSoCREpl\n8UOjUjBQMA4GA1UdDwEB/wQEAwIChDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYB\nBQUHAwEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ4EBwQFAQIDBAUwCgYIKoZIzj0E\nAwIDSAAwRQIhAKLOIPprhU7CCyFG52J8FmyzwBJjcwHu+ZzGFrdfwEKKAiB7xkYM\nYFcPCscvdnZ1U8hTUaREZmDB2w9eaGyCM4YXAg==\n-----END CERTIFICATE-----\n"
 }`)
 
-type cacheFake struct {
-	location location.Location
-	err      error
-}
-
-func (cf *cacheFake) Get() location.Location {
-	return cf.location
-}
-func (cf *cacheFake) RefreshAndGet() (location.Location, error) {
-	return cf.location, cf.err
-}
-
 var _ connection.Factory = &ProcessBasedConnectionFactory{}
 
 func fakeSignerFactory(_ identity.Identity) identity.Signer {
@@ -55,7 +42,7 @@ func fakeSignerFactory(_ identity.Identity) identity.Signer {
 }
 
 func TestConnectionFactory_ErrorsOnInvalidConfig(t *testing.T) {
-	factory := NewProcessBasedConnectionFactory("./", "./", "./", &cacheFake{}, fakeSignerFactory, ip.NewResolverMock("1.1.1.1"), &MockNATPinger{})
+	factory := NewProcessBasedConnectionFactory("./", "./", "./", fakeSignerFactory, ip.NewResolverMock("1.1.1.1"), &MockNATPinger{})
 	channel := make(chan connection.State)
 	statisticsChannel := make(chan consumer.SessionStatistics)
 	connectionOptions := connection.ConnectOptions{}
@@ -66,7 +53,7 @@ func TestConnectionFactory_ErrorsOnInvalidConfig(t *testing.T) {
 }
 
 func TestConnectionFactory_CreatesConnection(t *testing.T) {
-	factory := NewProcessBasedConnectionFactory("./", "./", "./", &cacheFake{}, fakeSignerFactory, ip.NewResolverMock("1.1.1.1"), &MockNATPinger{})
+	factory := NewProcessBasedConnectionFactory("./", "./", "./", fakeSignerFactory, ip.NewResolverMock("1.1.1.1"), &MockNATPinger{})
 	channel := make(chan connection.State)
 	statisticsChannel := make(chan consumer.SessionStatistics)
 	conn, err := factory.Create(channel, statisticsChannel)


### PR DESCRIPTION
This does two:
* Closes #653
* Fixes an unreported bug where location is being actually resolved for each and every ping on nat traversal attempts.

Reworked the old location cache, created a new one that caches location info for 5 minutes by default, and also is invalidated when connection state changes(consumer side). Switched all resolvers to use the cache instead. 