### PR TITLE
Make mobile entrypoint use location oracle as well

### DIFF
--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -72,6 +72,8 @@ func NewNode(appPath string, optionsNetwork *MobileNetworkOptions) (*MobileNode,
 
 		Location: node.OptionsLocation{
 			IPDetectorURL: "https://api.ipify.org/?format=json",
+			Type:          node.LocationTypeOracle,
+			Address:       "https://testnet-location.mysterium.network/api/v1/location",
 		},
 
 		OptionsNetwork: node.OptionsNetwork(*optionsNetwork),


### PR DESCRIPTION
We weren't setting the proper options for location on mobile entrypoint. 

Closes #925