### PR TITLE
Clean up NAT forwarding rule on OpenVPN service stop

### DIFF
--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -136,6 +136,14 @@ func (m *Manager) Stop() (err error) {
 	if m.vpnServer != nil {
 		m.vpnServer.Stop()
 	}
+
+	if m.natService != nil {
+		return m.natService.Del(nat.RuleForwarding{
+			SourceAddress: "10.8.0.0/24",
+			TargetIP:      m.outboundIP,
+		})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
For OpenVPN service, we are only adding new IP forwarding rules, without cleaning old on service stop. 

It prevents new service to start if the node network was changed. 

Updates: #926