### PR TITLE
Log build information

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -173,6 +173,7 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	nats_discovery.Bootstrap()
 
 	log.Infof("Starting Mysterium Node (%s)", metadata.VersionAsString())
+	log.Infof("Build information (%s)", metadata.BuildAsString())
 
 	if err := nodeOptions.Directories.Check(); err != nil {
 		return err


### PR DESCRIPTION
This is very useful for 0.0.0-dev builds, we'll instantly know which commit was used to build this version.