### PR TITLE
Node master triggers desktop app master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,10 @@ jobs:
       - bin/release_goreport
       name: "Update Go Report Card"
 
+    - script:
+      - bin/travis_scripts/trigger_desktop_app_build
+      name: "Trigger Desktop APP build"
+
     # Official release (on tags only)
     - stage: release
       script: bin/s3 sync s3://travis-$TRAVIS_BUILD_NUMBER/build-artifacts build/package

--- a/bin/travis_scripts/trigger_desktop_app_build
+++ b/bin/travis_scripts/trigger_desktop_app_build
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+body='{
+"request": {
+"branch":"master"
+}}'
+
+ORG="mysteriumnetwork"
+REPO="mysterium-vpn"
+
+curl -s -X POST \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   -H "Travis-API-Version: 3" \
+   -H "Authorization: token $TRAVIS_API_KEY" \
+   -d "$body" \
+   https://api.travis-ci.com/repo/$ORG%2F$REPO/requests


### PR DESCRIPTION
Every commit into master will trigger a desktop app master build:) This is for having a bleeding edge version of the app.

Added TRAVIS_API_KEY env variable in Travis.