### PR TITLE
adjust logging levels for less flooding of end-user logs

### DIFF
--- a/core/ip/rest_resolver.go
+++ b/core/ip/rest_resolver.go
@@ -66,7 +66,7 @@ func (client *clientRest) GetPublicIP() (string, error) {
 		return "", err
 	}
 
-	log.Info(ipAPILogPrefix, "IP detected: ", ipResponse.IP)
+	log.Trace(ipAPILogPrefix, "IP detected: ", ipResponse.IP)
 	return ipResponse.IP, nil
 }
 
@@ -78,6 +78,6 @@ func (client *clientRest) GetOutboundIP() (string, error) {
 	defer conn.Close()
 
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
-	log.Info("[Detect Outbound IP] ", "IP detected: ", localAddr.IP.String())
+	log.Trace("[Detect Outbound IP] ", "IP detected: ", localAddr.IP.String())
 	return localAddr.IP.String(), nil
 }

--- a/market/mysterium/mysterium_api.go
+++ b/market/mysterium/mysterium_api.go
@@ -182,7 +182,7 @@ func (mApi *MysteriumAPI) FindProposals(providerID, serviceType, accessPolicyID,
 	}
 	total := len(proposalsResponse.Proposals)
 	supported := supportedProposalsOnly(proposalsResponse.Proposals)
-	log.Info(mysteriumAPILogPrefix, "Total proposals: ", total, " supported: ", len(supported))
+	log.Trace(mysteriumAPILogPrefix, "Total proposals: ", total, " supported: ", len(supported))
 	return supported, nil
 }
 


### PR DESCRIPTION
closes #1021

Currently we're adding a metric ton of repeating logs to end user log files this adjust the levels and traces by default on local builds, resorts to logging info and above on end-users.