### PR TITLE
added context for nat events

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -200,8 +200,6 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 
 	di.PortPool = port.NewPool()
 
-	go upnp.ReportNetworkGateways()
-
 	di.bootstrapNATComponents(nodeOptions)
 	di.bootstrapServices(nodeOptions)
 	di.bootstrapNodeComponents(nodeOptions)
@@ -525,8 +523,13 @@ func (di *Dependencies) bootstrapLocationComponents(options node.OptionsLocation
 }
 
 func (di *Dependencies) bootstrapMetrics(options node.Options) {
+	loader := &upnp.GatewayLoader{}
+
+	// warm up the loader as the load takes up to a couple of secs
+	go loader.Get()
+
 	appVersion := metadata.VersionAsString()
-	di.MetricsSender = metrics.NewSender(options.DisableMetrics, options.MetricsAddress, appVersion)
+	di.MetricsSender = metrics.NewSender(options.DisableMetrics, options.MetricsAddress, appVersion, loader.HumanReadable)
 }
 
 func (di *Dependencies) bootstrapNATComponents(options node.Options) {

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -22,7 +22,7 @@ import (
 )
 
 // NewSender creates metrics sender with appropriate transport
-func NewSender(disableMetrics bool, metricsAddress, appVersion string) *Sender {
+func NewSender(disableMetrics bool, metricsAddress, appVersion string, gatewayLoader func() []map[string]string) *Sender {
 	var transport Transport
 	if disableMetrics {
 		transport = NewNoopTransport()
@@ -30,5 +30,5 @@ func NewSender(disableMetrics bool, metricsAddress, appVersion string) *Sender {
 		transport = NewElasticSearchTransport(metricsAddress, 10*time.Second)
 	}
 
-	return &Sender{Transport: transport, AppVersion: appVersion}
+	return &Sender{Transport: transport, AppVersion: appVersion, GatewayLoader: gatewayLoader}
 }

--- a/metrics/sender.go
+++ b/metrics/sender.go
@@ -27,8 +27,9 @@ const natMappingEventName = "nat_mapping"
 
 // Sender builds events and sends them using given transport
 type Sender struct {
-	Transport  Transport
-	AppVersion string
+	Transport     Transport
+	AppVersion    string
+	GatewayLoader func() []map[string]string
 }
 
 // Transport allows sending events
@@ -50,9 +51,10 @@ type appInfo struct {
 }
 
 type natMappingContext struct {
-	Stage        string  `json:"stage"`
-	Successful   bool    `json:"successful"`
-	ErrorMessage *string `json:"error_message"`
+	Stage        string              `json:"stage"`
+	Successful   bool                `json:"successful"`
+	ErrorMessage *string             `json:"error_message"`
+	Gateways     []map[string]string `json:"gateways,omitempty"`
 }
 
 // SendStartupEvent sends startup event
@@ -62,14 +64,14 @@ func (sender *Sender) SendStartupEvent() error {
 
 // SendNATMappingSuccessEvent sends event about successful NAT mapping
 func (sender *Sender) SendNATMappingSuccessEvent(stage string) error {
-	context := natMappingContext{Stage: stage, Successful: true}
+	context := natMappingContext{Stage: stage, Successful: true, Gateways: sender.GatewayLoader()}
 	return sender.sendEvent(natMappingEventName, context)
 }
 
 // SendNATMappingFailEvent sends event about failed NAT mapping
 func (sender *Sender) SendNATMappingFailEvent(stage string, err error) error {
 	errorMessage := err.Error()
-	context := natMappingContext{Stage: stage, Successful: false, ErrorMessage: &errorMessage}
+	context := natMappingContext{Stage: stage, Successful: false, ErrorMessage: &errorMessage, Gateways: sender.GatewayLoader()}
 	return sender.sendEvent(natMappingEventName, context)
 }
 

--- a/nat/upnp/loader.go
+++ b/nat/upnp/loader.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package upnp
+
+import (
+	"sync"
+
+	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+// GatewayLoader fetches the gateways once and keeps them stored for further use
+type GatewayLoader struct {
+	gateways []GatewayDevice
+	once     sync.Once
+}
+
+// HumanReadable returns a human readable representation of the devices
+func (gl *GatewayLoader) HumanReadable() []map[string]string {
+	gl.once.Do(gl.load)
+	res := make([]map[string]string, 0)
+
+	for _, v := range gl.gateways {
+		res = append(res, v.ToMap())
+	}
+
+	return res
+}
+
+// Get returns the gateway devices
+func (gl *GatewayLoader) Get() []GatewayDevice {
+	gl.once.Do(gl.load)
+	return gl.gateways
+}
+
+func (gl *GatewayLoader) load() {
+	gateways, err := discoverGateways()
+	if err != nil {
+		_ = log.Error(logPrefix, errors.Wrap(err, "error discovering UPnP devices"))
+		return
+	}
+	gl.gateways = gateways
+	printGatewayInfo(gateways)
+}


### PR DESCRIPTION
Wanted to add context to nat events. Issue is that the loader takes around 2sec to complete, so wrapped it in a component to only load it once. The sender is getting a getter instead of the plain value due to the fact that it takes a few seconds to load the gateway info - don't want to block in bootstrap for that.

![Screen Shot 2019-05-09 at 11 22 48 AM](https://user-images.githubusercontent.com/18392269/57438535-d188df80-724c-11e9-9aea-74b269d1098e.png)

Closes #693 