### PR TITLE
Trigger desktop app build and raspberry image build only for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
     - script:
       - bin/build_xgo linux/arm
       - bin/builder_run BINARY=build/myst/myst_linux_arm bin/package_debian $BUILD_VERSION armhf
-      - bin/package_raspberry
+      - if [[ -nz $TRAVIS_TAG ]]; then bin/package_raspberry; fi
       - bin/s3 sync build/package s3://travis-$TRAVIS_BUILD_NUMBER/build-artifacts
       name: "DEB ARM package and Raspberry image"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,10 +160,6 @@ jobs:
       - bin/release_goreport
       name: "Update Go Report Card"
 
-    - script:
-      - bin/travis_scripts/trigger_desktop_app_build
-      name: "Trigger Desktop APP build"
-
     # Official release (on tags only)
     - stage: release
       script: bin/s3 sync s3://travis-$TRAVIS_BUILD_NUMBER/build-artifacts build/package
@@ -192,6 +188,10 @@ jobs:
       - gpg --list-keys
       - bin/release_android "$TRAVIS_TAG"
       name: "Publish Android SDK to the Sonatype and Maven Central"
+    - script:
+      - bin/travis_scripts/trigger_desktop_app_build
+      name: "Trigger Desktop APP build"
+      if: tag = env(BUILD_DEV_RELEASE)
 
     - stage: cleanup
       script:


### PR DESCRIPTION
We should trigger a desktop app build only on tag 0.0.0-dev. Commits to master do not update artifacts in the releases, it just tags new 0.0.0-dev. 

And we don't really need to build Raspberry Pi image twice to push it to releases.  