### PR TITLE
Fix Travis condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
     - script:
       - bin/build_xgo linux/arm
       - bin/builder_run BINARY=build/myst/myst_linux_arm bin/package_debian $BUILD_VERSION armhf
-      - if [[ -nz $TRAVIS_TAG ]]; then bin/package_raspberry; fi
+      - if [[ "$TRAVIS_TAG" != "" ]]; then bin/package_raspberry; fi
       - bin/s3 sync build/package s3://travis-$TRAVIS_BUILD_NUMBER/build-artifacts
       name: "DEB ARM package and Raspberry image"
 


### PR DESCRIPTION
Travis failed to parse it :(

```
$ if [[ -nz $TRAVIS_TAG ]]; then bin/package_raspberry; fi
/home/travis/.travis/functions: eval: line 104: conditional binary operator expected
/home/travis/.travis/functions: eval: line 104: syntax error near `$TRAVIS_TAG'
/home/travis/.travis/functions: eval: line 104: `if [[ -nz $TRAVIS_TAG ]]; then bin/package_raspberry; fi '
The command "if [[ -nz $TRAVIS_TAG ]]; then bin/package_raspberry; fi" exited with 1.
```