### PR TITLE
nat now tracks events properly

### DIFF
--- a/nat/status_tracker.go
+++ b/nat/status_tracker.go
@@ -56,6 +56,8 @@ func (t *StatusTracker) ConsumeNATEvent(event event.Event) {
 		t.status = Status{Status: statusSuccessful}
 		return
 	}
+
+	t.status = Status{Status: statusNotFinished}
 }
 
 // NewStatusTracker returns new instance of status tracker

--- a/nat/status_tracker_test.go
+++ b/nat/status_tracker_test.go
@@ -59,3 +59,16 @@ func Test_StatusTracker_Status_ReturnsNotFinished_WithPortMappingFailureEvent(t 
 	assert.Equal(t, "not_finished", status.Status)
 	assert.Nil(t, status.Error)
 }
+
+func Test_StatusTracker_Status_ReturnsNotFinished_AfterSuccess(t *testing.T) {
+	tracker := NewStatusTracker("last stage")
+	tracker.ConsumeNATEvent(event.Event{Successful: true, Stage: "any stage"})
+	status := tracker.Status()
+
+	assert.Equal(t, "successful", status.Status)
+	assert.Nil(t, status.Error)
+
+	tracker.ConsumeNATEvent(event.Event{Successful: false, Stage: "any stage"})
+	status = tracker.Status()
+	assert.Equal(t, "not_finished", status.Status)
+}


### PR DESCRIPTION
Closes #1031

Issue was caused by the nat status not being returned to initial state.