### PR TITLE
initialize commands on demand for mac ipforward

### DIFF
--- a/nat/factory_darwin.go
+++ b/nat/factory_darwin.go
@@ -17,15 +17,14 @@
 
 package nat
 
-import "os/exec"
-
 // NewService returns fake nat service since there are no iptables on darwin
 func NewService() NATService {
 	return &servicePFCtl{
 		ipForward: serviceIPForward{
-			CommandEnable:  exec.Command("/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=1"),
-			CommandDisable: exec.Command("/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=0"),
-			CommandRead:    exec.Command("/usr/sbin/sysctl", "-n", "net.inet.ip.forwarding"),
+			CommandName:        "/usr/sbin/sysctl",
+			CommandEnableArgs:  []string{"-w", "net.inet.ip.forwarding=1"},
+			CommandDisableArgs: []string{"-w", "net.inet.ip.forwarding=0"},
+			CommandReadArgs:    []string{"-n", "net.inet.ip.forwarding"},
 		},
 		rules: make(map[RuleForwarding]struct{}),
 	}

--- a/nat/service_ipforward.go
+++ b/nat/service_ipforward.go
@@ -25,10 +25,11 @@ import (
 )
 
 type serviceIPForward struct {
-	CommandEnable  *exec.Cmd
-	CommandDisable *exec.Cmd
-	CommandRead    *exec.Cmd
-	forward        bool
+	CommandName        string
+	CommandEnableArgs  []string
+	CommandDisableArgs []string
+	CommandReadArgs    []string
+	forward            bool
 }
 
 func (service *serviceIPForward) Enable() error {
@@ -38,8 +39,8 @@ func (service *serviceIPForward) Enable() error {
 		return nil
 	}
 
-	if output, err := service.CommandEnable.CombinedOutput(); err != nil {
-		log.Warn("Failed to enable IP forwarding: ", service.CommandEnable.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+	if output, err := exec.Command(service.CommandName, service.CommandEnableArgs...).CombinedOutput(); err != nil {
+		log.Warn("Failed to enable IP forwarding: ", service.CommandEnableArgs, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
 		return err
 	}
 
@@ -52,17 +53,17 @@ func (service *serviceIPForward) Disable() {
 		return
 	}
 
-	if output, err := service.CommandDisable.CombinedOutput(); err != nil {
-		log.Warn("Failed to disable IP forwarding: ", service.CommandDisable.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+	if output, err := exec.Command(service.CommandName, service.CommandDisableArgs...).CombinedOutput(); err != nil {
+		log.Warn("Failed to disable IP forwarding: ", service.CommandDisableArgs, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
 	}
 
 	log.Info(natLogPrefix, "IP forwarding disabled")
 }
 
 func (service *serviceIPForward) Enabled() bool {
-	output, err := service.CommandEnable.Output()
+	output, err := exec.Command(service.CommandName, service.CommandReadArgs...).Output()
 	if err != nil {
-		log.Warn("Failed to check IP forwarding status: ", service.CommandRead.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+		log.Warn("Failed to check IP forwarding status: ", service.CommandReadArgs, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
 	}
 
 	return strings.TrimSpace(string(output)) == "1"


### PR DESCRIPTION
We were reusing exec.Command instances in the IPforward, resulting in the following errors:

```
2019-05-09T16:32:00.753637 [Warn] Failed to enable IP forwarding: [/usr/sbin/sysctl -w net.inet.ip.forwarding=1] Returned exit error: exec: Stdout already set Cmd output: 
2019-05-09T16:32:00.776118 [Warn] [nat] Failed to enable IP forwarding: exec: Stdout already set
2019-05-09T16:32:00.776259 [Warn] [service bootstrap] Failed to enable NAT forwarding: exec: Stdout already set
```

We were also using "CommandEnable" for lookup of ip forward flag. Fixed that as well.