### PR TITLE
initialize commands on demand for mac/linux ipforward

### DIFF
--- a/nat/factory_darwin.go
+++ b/nat/factory_darwin.go
@@ -17,10 +17,15 @@
 
 package nat
 
+import "os/exec"
+
 // NewService returns fake nat service since there are no iptables on darwin
 func NewService() NATService {
 	return &servicePFCtl{
 		ipForward: serviceIPForward{
+			CommandFactory: func(name string, arg ...string) Command {
+				return exec.Command(name, arg...)
+			},
 			CommandEnable:  []string{"/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=1"},
 			CommandDisable: []string{"/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=0"},
 			CommandRead:    []string{"/usr/sbin/sysctl", "-n", "net.inet.ip.forwarding"},

--- a/nat/factory_darwin.go
+++ b/nat/factory_darwin.go
@@ -17,15 +17,13 @@
 
 package nat
 
-import "os/exec"
-
 // NewService returns fake nat service since there are no iptables on darwin
 func NewService() NATService {
 	return &servicePFCtl{
 		ipForward: serviceIPForward{
-			CommandEnable:  exec.Command("/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=1"),
-			CommandDisable: exec.Command("/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=0"),
-			CommandRead:    exec.Command("/usr/sbin/sysctl", "-n", "net.inet.ip.forwarding"),
+			CommandEnable:  []string{"/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=1"},
+			CommandDisable: []string{"/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=0"},
+			CommandRead:    []string{"/usr/sbin/sysctl", "-n", "net.inet.ip.forwarding"},
 		},
 		rules: make(map[RuleForwarding]struct{}),
 	}

--- a/nat/factory_linux.go
+++ b/nat/factory_linux.go
@@ -17,15 +17,13 @@
 
 package nat
 
-import "os/exec"
-
 // NewService returns linux os specific nat service based on ip tables
 func NewService() NATService {
 	return &serviceIPTables{
 		ipForward: serviceIPForward{
-			CommandEnable:  exec.Command("sudo", "/sbin/sysctl", "-w", "net.ipv4.ip_forward=1"),
-			CommandDisable: exec.Command("sudo", "/sbin/sysctl", "-w", "net.ipv4.ip_forward=0"),
-			CommandRead:    exec.Command("/sbin/sysctl", "-n", "net.ipv4.ip_forward"),
+			CommandEnable:  []string{"sudo", "/sbin/sysctl", "-w", "net.ipv4.ip_forward=1"},
+			CommandDisable: []string{"sudo", "/sbin/sysctl", "-w", "net.ipv4.ip_forward=0"},
+			CommandRead:    []string{"/sbin/sysctl", "-n", "net.ipv4.ip_forward"},
 		},
 		rules: make(map[RuleForwarding]struct{}),
 	}

--- a/nat/factory_linux.go
+++ b/nat/factory_linux.go
@@ -17,10 +17,15 @@
 
 package nat
 
+import "os/exec"
+
 // NewService returns linux os specific nat service based on ip tables
 func NewService() NATService {
 	return &serviceIPTables{
 		ipForward: serviceIPForward{
+			CommandFactory: func(name string, arg ...string) Command {
+				return exec.Command(name, arg...)
+			},
 			CommandEnable:  []string{"sudo", "/sbin/sysctl", "-w", "net.ipv4.ip_forward=1"},
 			CommandDisable: []string{"sudo", "/sbin/sysctl", "-w", "net.ipv4.ip_forward=0"},
 			CommandRead:    []string{"/sbin/sysctl", "-n", "net.ipv4.ip_forward"},

--- a/nat/service_ipforward.go
+++ b/nat/service_ipforward.go
@@ -25,9 +25,9 @@ import (
 )
 
 type serviceIPForward struct {
-	CommandEnable  *exec.Cmd
-	CommandDisable *exec.Cmd
-	CommandRead    *exec.Cmd
+	CommandEnable  []string
+	CommandDisable []string
+	CommandRead    []string
 	forward        bool
 }
 
@@ -38,8 +38,8 @@ func (service *serviceIPForward) Enable() error {
 		return nil
 	}
 
-	if output, err := service.CommandEnable.CombinedOutput(); err != nil {
-		log.Warn("Failed to enable IP forwarding: ", service.CommandEnable.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+	if output, err := exec.Command(service.CommandEnable[0], service.CommandEnable[1:]...).CombinedOutput(); err != nil {
+		log.Warn("Failed to enable IP forwarding: ", service.CommandEnable[1:], " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
 		return err
 	}
 
@@ -52,17 +52,17 @@ func (service *serviceIPForward) Disable() {
 		return
 	}
 
-	if output, err := service.CommandDisable.CombinedOutput(); err != nil {
-		log.Warn("Failed to disable IP forwarding: ", service.CommandDisable.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+	if output, err := exec.Command(service.CommandDisable[0], service.CommandDisable[1:]...).CombinedOutput(); err != nil {
+		log.Warn("Failed to disable IP forwarding: ", service.CommandDisable[1:], " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
 	}
 
 	log.Info(natLogPrefix, "IP forwarding disabled")
 }
 
 func (service *serviceIPForward) Enabled() bool {
-	output, err := service.CommandEnable.Output()
+	output, err := exec.Command(service.CommandRead[0], service.CommandRead[1:]...).Output()
 	if err != nil {
-		log.Warn("Failed to check IP forwarding status: ", service.CommandRead.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+		log.Warn("Failed to check IP forwarding status: ", service.CommandRead[1:], " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
 	}
 
 	return strings.TrimSpace(string(output)) == "1"

--- a/nat/service_ipforward_test.go
+++ b/nat/service_ipforward_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2018 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nat
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCommand struct {
+	CombinedOutputRes   []byte
+	CombinedOutputError error
+	OutputRes           []byte
+	OutputError         error
+}
+
+func (mc *mockCommand) CombinedOutput() ([]byte, error) {
+	return mc.CombinedOutputRes, mc.CombinedOutputError
+}
+
+func (mc *mockCommand) Output() ([]byte, error) {
+	return mc.OutputRes, mc.OutputError
+}
+
+type mockCommandFactory struct {
+	MockCommand Command
+}
+
+func (mcf *mockCommandFactory) Create(name string, arg ...string) Command {
+	return mcf.MockCommand
+}
+
+func Test_ServiceIPForward_Enabled(t *testing.T) {
+	mc := &mockCommand{
+		OutputRes: []byte("1"),
+	}
+	mf := &mockCommandFactory{
+		MockCommand: mc,
+	}
+	service := &serviceIPForward{
+		CommandFactory: mf.Create,
+		CommandRead:    []string{"doesnt", "matter"},
+	}
+
+	assert.True(t, service.Enabled())
+
+	mc.OutputRes = []byte("calm waters")
+	assert.False(t, service.Enabled())
+
+	mc.OutputError = errors.New("mass panic")
+	mc.OutputRes = []byte("1")
+	assert.True(t, service.Enabled())
+}
+
+func Test_ServiceIPForward_Enable(t *testing.T) {
+	mc := &mockCommand{
+		CombinedOutputRes: []byte("1"),
+		OutputRes:         []byte("1"),
+	}
+	mf := &mockCommandFactory{
+		MockCommand: mc,
+	}
+	service := &serviceIPForward{
+		CommandFactory: mf.Create,
+		CommandRead:    []string{"doesnt", "matter"},
+		CommandEnable:  []string{"doesnt", "matter"},
+	}
+
+	assert.Nil(t, service.Enable())
+	assert.True(t, service.forward)
+	service.forward = false
+
+	mc.OutputRes = []byte("people screaming")
+	mc.CombinedOutputError = errors.New("explosions everywhere")
+
+	assert.Equal(t, mc.CombinedOutputError, service.Enable())
+
+	mc.CombinedOutputError = nil
+
+	assert.Nil(t, mc.CombinedOutputError, service.Enable())
+}
+
+func Test_ServiceIPForward_Disable(t *testing.T) {
+	mc := &mockCommand{
+		CombinedOutputRes:   []byte("1"),
+		CombinedOutputError: errors.New("explosions everywhere"),
+	}
+	mf := &mockCommandFactory{
+		MockCommand: mc,
+	}
+	service := &serviceIPForward{
+		CommandFactory: mf.Create,
+		CommandDisable: []string{"doesnt", "matter"},
+	}
+	service.Disable()
+
+	service.forward = true
+	service.Disable()
+}


### PR DESCRIPTION
We were reusing exec.Command instances in the IPforward, resulting in the following errors:

```
2019-05-09T16:32:00.753637 [Warn] Failed to enable IP forwarding: [/usr/sbin/sysctl -w net.inet.ip.forwarding=1] Returned exit error: exec: Stdout already set Cmd output: 
2019-05-09T16:32:00.776118 [Warn] [nat] Failed to enable IP forwarding: exec: Stdout already set
2019-05-09T16:32:00.776259 [Warn] [service bootstrap] Failed to enable NAT forwarding: exec: Stdout already set
```

We were also using "CommandEnable" for lookup of ip forward flag. Fixed that as well.