### PR TITLE
disable auto port generation while with noop pinger

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -99,6 +99,7 @@ type NatPinger interface {
 	Stop()
 	SetProtectSocketCallback(SocketProtect func(socket int) bool)
 	StopNATProxy()
+	Valid() bool
 }
 
 // NatEventTracker is responsible for tracking NAT events

--- a/mobile/mysterium/openvpn_connection_setup.go
+++ b/mobile/mysterium/openvpn_connection_setup.go
@@ -53,8 +53,8 @@ func (wrapper *sessionWrapper) Start(options connection.ConnectOptions) error {
 	}
 
 	log.Info("client config after session create: ", clientConfig)
-	wrapper.natPinger.BindConsumerPort(clientConfig.LocalPort)
 	if clientConfig.LocalPort > 0 {
+		wrapper.natPinger.BindConsumerPort(clientConfig.LocalPort)
 		err := wrapper.natPinger.PingProvider(
 			clientConfig.OriginalRemoteIP,
 			clientConfig.OriginalRemotePort,
@@ -202,11 +202,10 @@ type OpenvpnConnectionFactory struct {
 // Create creates a new openvpn connection
 func (ocf *OpenvpnConnectionFactory) Create(stateChannel connection.StateChannel, statisticsChannel connection.StatisticsChannel) (con connection.Connection, err error) {
 	sessionFactory := func(options connection.ConnectOptions) (*openvpn3.Session, *openvpn.ClientConfig, error) {
-		outIP, err := ocf.ipResolver.GetOutboundIP()
 		if err != nil {
 			return nil, nil, err
 		}
-		vpnClientConfig, err := openvpn.NewClientConfigFromSession(options.SessionConfig, "", "", outIP)
+		vpnClientConfig, err := openvpn.NewClientConfigFromSession(options.SessionConfig, "", "")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/nat/traversal/noop.go
+++ b/nat/traversal/noop.go
@@ -24,6 +24,11 @@ import (
 // NoopPinger does nothing
 type NoopPinger struct{}
 
+// Valid returns that noop pinger is not a valid pinger
+func (np *NoopPinger) Valid() bool {
+	return false
+}
+
 // StopNATProxy does nothing
 func (np *NoopPinger) StopNATProxy() {}
 

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -357,3 +357,8 @@ func (p *Pinger) SetProtectSocketCallback(socketProtect func(socket int) bool) {
 func (p *Pinger) StopNATProxy() {
 	close(p.stopNATProxy)
 }
+
+// Valid returns that this pinger is a valid pinger
+func (p *Pinger) Valid() bool {
+	return true
+}

--- a/services/openvpn/client.go
+++ b/services/openvpn/client.go
@@ -64,9 +64,8 @@ func (c *Client) Start(options connection.ConnectOptions) error {
 	c.process = proc
 	log.Infof("client config: %v", clientConfig)
 
-	c.natPinger.BindConsumerPort(clientConfig.LocalPort)
-
 	if clientConfig.VpnConfig.LocalPort > 0 {
+		c.natPinger.BindConsumerPort(clientConfig.LocalPort)
 		err = c.natPinger.PingProvider(clientConfig.OriginalRemoteIP, clientConfig.OriginalRemotePort, c.pingerStop)
 		if err != nil {
 			return err

--- a/services/openvpn/client_config.go
+++ b/services/openvpn/client_config.go
@@ -81,7 +81,7 @@ func defaultClientConfig(runtimeDir string, scriptSearchPath string) *ClientConf
 // NewClientConfigFromSession creates client configuration structure for given VPNConfig, configuration dir to store serialized file args, and
 // configuration filename to store other args
 // TODO this will become the part of openvpn service consumer separate package
-func NewClientConfigFromSession(sessionConfig []byte, configDir string, runtimeDir string, outboundIP string) (*ClientConfig, error) {
+func NewClientConfigFromSession(sessionConfig []byte, configDir string, runtimeDir string) (*ClientConfig, error) {
 	vpnConfig := &VPNConfig{}
 	err := json.Unmarshal(sessionConfig, vpnConfig)
 	if err != nil {

--- a/services/openvpn/connection_factory.go
+++ b/services/openvpn/connection_factory.go
@@ -78,7 +78,7 @@ func (op *ProcessBasedConnectionFactory) newStateMiddleware(session session.ID, 
 // Create creates a new openvpn connection
 func (op *ProcessBasedConnectionFactory) Create(stateChannel connection.StateChannel, statisticsChannel connection.StatisticsChannel) (connection.Connection, error) {
 	procFactory := func(options connection.ConnectOptions) (openvpn.Process, *ClientConfig, error) {
-		vpnClientConfig, err := NewClientConfigFromSession(options.SessionConfig, op.configDirectory, op.runtimeDirectory, "")
+		vpnClientConfig, err := NewClientConfigFromSession(options.SessionConfig, op.configDirectory, op.runtimeDirectory)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -55,6 +55,7 @@ type SessionConfigNegotiatorFactory func(secPrimitives *tls.Primitives, outbound
 type NATPinger interface {
 	BindServicePort(serviceType services.ServiceType, port int)
 	Stop()
+	Valid() bool
 }
 
 // NATEventGetter allows us to fetch the last known NAT event
@@ -162,7 +163,7 @@ func (m *Manager) ProvideConfig(sessionConfig json.RawMessage, traversalParams *
 	traversalParams = &traversal.Params{ProviderPort: op.Num()}
 
 	// Older clients do not send any sessionConfig, but we should keep back compatibility and not fail in this case.
-	if sessionConfig != nil && len(sessionConfig) > 0 {
+	if sessionConfig != nil && len(sessionConfig) > 0 && m.natPinger.Valid() {
 		var c openvpn_service.ConsumerConfig
 		err := json.Unmarshal(sessionConfig, &c)
 		if err != nil {


### PR DESCRIPTION
if `experiment-natpunch` is disabled, do not generate any auto ports.
If provider does manual port forwarding he needs to disable `experiment-natpunch`