### PR TITLE
Switch default logging level to debug for debugging

### DIFF
--- a/logconfig/config.go
+++ b/logconfig/config.go
@@ -56,7 +56,7 @@ var cfg configParams
 
 func init() {
 	cfg = configParams{
-		LogLevel: "info",
+		LogLevel: "debug",
 	}
 	if metadata.VersionAsString() == "source.dev-build" {
 		cfg.LogLevel = "trace"


### PR DESCRIPTION
There's less context info in desktop app with default logging level set to `info`. Openvpn configs are missing, etc.
This shouldn't be too verbose as those are mostly one time events. And @vkuznecovas adjusted proposal polling message levels `info->trace` in https://github.com/mysteriumnetwork/node/pull/1025