### PR TITLE
bootstrap now checks for presence of node before starting

### DIFF
--- a/core/node/node.go
+++ b/core/node/node.go
@@ -71,10 +71,7 @@ func (node *Node) Start() error {
 		}
 	}()
 
-	err := node.httpAPIServer.StartServing()
-	if err != nil {
-		return err
-	}
+	node.httpAPIServer.StartServing()
 
 	address, err := node.httpAPIServer.Address()
 	if err != nil {

--- a/tequilapi/api_test.go
+++ b/tequilapi/api_test.go
@@ -18,6 +18,7 @@
 package tequilapi
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,9 +32,11 @@ type tequilapiTestSuite struct {
 }
 
 func (testSuite *tequilapiTestSuite) SetupSuite() {
-	testSuite.server = NewServer("localhost", 0, NewAPIRouter(), RegexpCorsPolicy{})
+	listener, err := net.Listen("tcp", "localhost:0")
+	assert.Nil(testSuite.T(), err)
+	testSuite.server = NewServer(listener, NewAPIRouter(), RegexpCorsPolicy{})
 
-	assert.NoError(testSuite.T(), testSuite.server.StartServing())
+	testSuite.server.StartServing()
 	address, err := testSuite.server.Address()
 	assert.NoError(testSuite.T(), err)
 	testSuite.client = NewTestClient(testSuite.T(), address)

--- a/tequilapi/http_api_server_test.go
+++ b/tequilapi/http_api_server_test.go
@@ -18,6 +18,7 @@
 package tequilapi
 
 import (
+	"net"
 	"strings"
 	"testing"
 
@@ -25,9 +26,12 @@ import (
 )
 
 func TestLocalAPIServerPortIsAsExpected(t *testing.T) {
-	server := NewServer("localhost", 31337, nil, RegexpCorsPolicy{})
+	listener, err := net.Listen("tcp", "localhost:31337")
+	assert.Nil(t, err)
 
-	assert.NoError(t, server.StartServing())
+	server := NewServer(listener, nil, RegexpCorsPolicy{})
+
+	server.StartServing()
 
 	address, err := server.Address()
 	assert.NoError(t, err)
@@ -40,6 +44,8 @@ func TestLocalAPIServerPortIsAsExpected(t *testing.T) {
 }
 
 func TestStopBeforeStartingListeningDoesNotCausePanic(t *testing.T) {
-	server := NewServer("", 12345, nil, RegexpCorsPolicy{})
+	listener, err := net.Listen("tcp", "localhost:31337")
+	assert.Nil(t, err)
+	server := NewServer(listener, nil, RegexpCorsPolicy{})
 	server.Stop()
 }


### PR DESCRIPTION
We're running into an issue where the node is being started multiple times. This causes various issues, namely boltdb lock races. To fix it, introducing an early attempt to bind to the tequilapi port. If the bind suceeds, we'll now that a node isn't running. Well, at least on the same port.