### PR TITLE
Protect session client ID map with lock while reading

### DIFF
--- a/nat/traversal/nat_proxy.go
+++ b/nat/traversal/nat_proxy.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 
 	log "github.com/cihub/seelog"
 
@@ -40,6 +41,7 @@ type NATProxy struct {
 }
 
 func (np *NATProxy) consumerHandOff(consumerPort int, remoteConn *net.UDPConn) chan struct{} {
+	time.Sleep(400 * time.Millisecond)
 	stop := make(chan struct{})
 	if np.socketProtect == nil {
 		// shutdown pinger session since openvpn client will connect directly (without NATProxy)

--- a/services/openvpn/session/client_map.go
+++ b/services/openvpn/session/client_map.go
@@ -41,6 +41,9 @@ type clientMap struct {
 
 // FindClientSession returns OpenVPN session instance by given session id
 func (cm *clientMap) FindClientSession(clientID int, id session.ID) (session.Session, bool, error) {
+	cm.sessionMapLock.Lock()
+	defer cm.sessionMapLock.Unlock()
+
 	sessionInstance, sessionExist := cm.sessions.Find(id)
 	if !sessionExist {
 		return session.Session{}, false, errors.New("no underlying session exists, possible break-in attempt")


### PR DESCRIPTION
  - fix session find race condition reproducible on win10
  - return consumer proxy delay as hack for slow providers