### PR TITLE
Fix Travis condition for 0.0.0-dev version of PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - if [ -z "$BUILD_VERSION" ]; then
       export BUILD_VERSION=$BUILD_DEV_RELEASE;
     fi
-  - if [ -z "$PPA_VERSION" ]; then
+  - if [ "$PPA_VERSION" == "$BUILD_DEV_RELEASE" ]; then
       export PPA_VERSION=$PPA_DEV_VERSION;
     fi
 


### PR DESCRIPTION
Build fails because we have `0.0.0-dev` as `$PPA_VERSION` but expected `0.0.0`. 