### PR TITLE
Fix panic on session payments second stop

### DIFF
--- a/session/payment/session_payments.go
+++ b/session/payment/session_payments.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/session/balance"
@@ -46,6 +47,7 @@ type SessionPayments struct {
 	peerPromiseSender PeerPromiseSender
 	promiseTracker    PromiseTracker
 	balanceTracker    BalanceTracker
+	once              sync.Once
 }
 
 // NewSessionPayments returns a new instance of consumer payment orchestrator
@@ -139,5 +141,7 @@ func calculateBalanceDifference(yourBalance, myBalance uint64) uint64 {
 
 // Stop stops the payment orchestrator
 func (cpo *SessionPayments) Stop() {
-	close(cpo.stop)
+	cpo.once.Do(func() {
+		close(cpo.stop)
+	})
 }

--- a/session/payment/session_payments_test.go
+++ b/session/payment/session_payments_test.go
@@ -22,11 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/mysteriumnetwork/node/session/balance"
 	"github.com/mysteriumnetwork/node/session/promise"
 	"github.com/mysteriumnetwork/payments/promises"
+	"github.com/stretchr/testify/assert"
 )
 
 type MockPeerPromiseSender struct {
@@ -133,4 +132,13 @@ func Test_SessionPayments_ErrsOnBalanceMissmatch(t *testing.T) {
 
 	balanceChannel <- balance.Message{Balance: 100, SequenceID: 1}
 	<-testDone
+}
+
+func Test_SessionPayments_NoPanicOnSecondStop(t *testing.T) {
+	balanceChannel := make(chan balance.Message, 1)
+	promiseSender := newPromiseSender()
+	cpo := NewTestSessionPayments(balanceChannel, promiseSender, promiseTracker, balanceTracker)
+	go cpo.Start()
+	cpo.Stop()
+	cpo.Stop()
 }


### PR DESCRIPTION
```
2019-05-13T16:47:25.5986333 [Debug] [session-stats-sender] stopping
2019-05-13T16:47:25.5994902 [Info] [connection-manager] Connection exited
2019-05-13T16:47:25.6113664 [Debug] [connection-manager] State updater stopCalled
panic: close of closed channel

goroutine 131 [running]:
github.com/mysteriumnetwork/node/session/payment.(*SessionPayments).Stop(0xc4202dab40)
        /c/Users/Jey/go/src/github.com/mysteriumnetwork/node/session/payment/session_payments.go:142 +0x2e
github.com/mysteriumnetwork/node/core/connection.(*connectionManager).launchPayments.func1(0x0, 0x0)
        /c/Users/Jey/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:192 +0x2f
github.com/mysteriumnetwork/node/core/connection.(*connectionManager).cleanConnection(0xc420342000)
        /c/Users/Jey/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:203 +0x90
github.com/mysteriumnetwork/node/core/connection.(*connectionManager).Disconnect(0xc420342000, 0x0, 0x0)
        /c/Users/Jey/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:334 +0x1b9
github.com/mysteriumnetwork/node/core/connection.(*connectionManager).consumeConnectionStates(0xc420342000, 0xc4201b08a0)
        /c/Users/Jey/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:397 +0xf8
created by github.com/mysteriumnetwork/node/core/connection.(*connectionManager).startConnection
        /c/Users/Jey/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:307 +0x339
```