### PR TITLE
Sync consumer / provider stream copy buffers

### DIFF
--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -276,6 +276,7 @@ func (p *Pinger) BindServicePort(serviceType services.ServiceType, port int) {
 
 func (p *Pinger) pingReceiver(conn *net.UDPConn, stop <-chan struct{}) error {
 	timeout := time.After(pingTimeout * time.Millisecond)
+	buf := make([]byte, bufferLen)
 	for {
 		select {
 		case <-timeout:
@@ -287,8 +288,7 @@ func (p *Pinger) pingReceiver(conn *net.UDPConn, stop <-chan struct{}) error {
 		default:
 		}
 
-		var buf [bufferLen]byte
-		n, err := conn.Read(buf[0:])
+		n, err := conn.Read(buf)
 		if err != nil {
 			log.Errorf("%sFailed to read remote peer: %s cause: %s - attempting to continue", prefix, conn.RemoteAddr().String(), err)
 			continue

--- a/services/openvpn/client_config.go
+++ b/services/openvpn/client_config.go
@@ -66,6 +66,8 @@ func defaultClientConfig(runtimeDir string, scriptSearchPath string) *ClientConf
 	clientConfig.SetPingTimerRemote()
 	clientConfig.SetPersistKey()
 
+	clientConfig.SetParam("auth", "none")
+
 	clientConfig.SetParam("reneg-sec", "60")
 	clientConfig.SetParam("resolv-retry", "infinite")
 	clientConfig.SetParam("redirect-gateway", "def1", "bypass-dhcp")

--- a/services/openvpn/server_config.go
+++ b/services/openvpn/server_config.go
@@ -80,5 +80,7 @@ func NewServerConfig(
 	serverConfig.SetPingTimerRemote()
 	serverConfig.SetPersistKey()
 
+	serverConfig.SetParam("auth", "none")
+
 	return &serverConfig
 }


### PR DESCRIPTION
 - fix go routine leak by properly checking if socket address has changed
 - improve nat proxy performance with larger buffers
 - auth mode set to none, not used by GCM cipher