### PR TITLE
Close NATS connection correctly.

### DIFF
--- a/communication/nats/dialog/dialog.go
+++ b/communication/nats/dialog/dialog.go
@@ -19,16 +19,21 @@ package dialog
 
 import (
 	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/communication/nats/discovery"
 	"github.com/mysteriumnetwork/node/identity"
 )
 
 type dialog struct {
 	communication.Sender
 	communication.Receiver
-	peerID identity.Identity
+	peerID      identity.Identity
+	peerAddress *discovery.AddressNATS
 }
 
 func (dialog *dialog) Close() error {
+	if dialog.peerAddress != nil {
+		dialog.peerAddress.Disconnect()
+	}
 	return nil
 }
 

--- a/communication/nats/dialog/dialog_establisher.go
+++ b/communication/nats/dialog/dialog_establisher.go
@@ -68,6 +68,7 @@ func (establisher *dialogEstablisher) EstablishDialog(
 	peerSender := establisher.newSenderToPeer(peerAddress, peerCodec)
 	topic, err := establisher.negotiateTopic(peerSender)
 	if err != nil {
+		peerAddress.Disconnect()
 		return nil, err
 	}
 
@@ -127,8 +128,9 @@ func (establisher *dialogEstablisher) newDialogToPeer(
 	}
 
 	return &dialog{
-		peerID:   peerID,
-		Sender:   nats.NewSender(peerAddress.GetConnection(), peerCodec, topic),
-		Receiver: nats.NewReceiver(peerAddress.GetConnection(), peerCodec, topic),
+		peerID:      peerID,
+		peerAddress: peerAddress,
+		Sender:      nats.NewSender(peerAddress.GetConnection(), peerCodec, topic),
+		Receiver:    nats.NewReceiver(peerAddress.GetConnection(), peerCodec, topic),
 	}
 }

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -199,7 +199,7 @@ func (manager *connectionManager) launchPayments(paymentInfo *promise.PaymentInf
 
 func (manager *connectionManager) cleanConnection() {
 	manager.cancel()
-	for i := len(manager.cleanup) - 1; i > 0; i-- {
+	for i := len(manager.cleanup) - 1; i >= 0; i-- {
 		err := manager.cleanup[i]()
 		if err != nil {
 			log.Warn(managerLogPrefix, "cleanup error:", err)


### PR DESCRIPTION
This commit fixes a memory leak on multiple reconnects to providers.
In normal behaviour memory leak is not really noticeable.
But when network changes for some reasons, all active nats connections tries to reconnect to the broker at the same time and memory usage become significant.