### PR TITLE
Measuring bandwidth on consumer side

### DIFF
--- a/consumer/bandwidth/tracker.go
+++ b/consumer/bandwidth/tracker.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bandwidth
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/node/consumer"
+	"github.com/mysteriumnetwork/node/core/connection"
+)
+
+const trackerLogPrefix = "[bandwidth-tracker] "
+const bitsInByte = 8
+
+// Throughput represents the throughput
+type Throughput struct {
+	BitsPerSecond float64
+}
+
+// String returns human readable form of the throughput
+func (t Throughput) String() string {
+	return bitCountDecimal(int64(t.BitsPerSecond))
+}
+
+// CurrentSpeed represents the current(moment) download and upload speeds in bits per second
+type CurrentSpeed struct {
+	Up, Down Throughput
+}
+
+// Tracker keeps track of current speed
+type Tracker struct {
+	previous     consumer.SessionStatistics
+	previousTime time.Time
+	currentSpeed CurrentSpeed
+	lock         sync.RWMutex
+}
+
+// Get returns the current upload and download speeds in bits per second
+func (t *Tracker) Get() CurrentSpeed {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.currentSpeed
+}
+
+// ConsumeStatisticsEvent handles the connection statistics changes
+func (t *Tracker) ConsumeStatisticsEvent(stats consumer.SessionStatistics) {
+	t.lock.Lock()
+	defer func() {
+		t.previous = stats
+		t.lock.Unlock()
+	}()
+
+	if t.previousTime.IsZero() {
+		t.previousTime = time.Now()
+		return
+	}
+
+	currentTime := time.Now()
+	secondsSince := currentTime.Sub(t.previousTime).Seconds()
+	t.previousTime = currentTime
+
+	byteDownDiff := stats.BytesReceived - t.previous.BytesReceived
+	byteUpDiff := stats.BytesSent - t.previous.BytesSent
+
+	t.currentSpeed = CurrentSpeed{
+		Up:   Throughput{BitsPerSecond: float64(byteUpDiff) / secondsSince * bitsInByte},
+		Down: Throughput{BitsPerSecond: float64(byteDownDiff) / secondsSince * bitsInByte},
+	}
+
+	log.Tracef("%sDownload speed: %s", trackerLogPrefix, t.currentSpeed.Down)
+	log.Tracef("%sUpload speed: %s", trackerLogPrefix, t.currentSpeed.Up)
+}
+
+// ConsumeSessionEvent handles the session state changes
+func (t *Tracker) ConsumeSessionEvent(sessionEvent connection.SessionEvent) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	switch sessionEvent.Status {
+	case connection.SessionEndedStatus, connection.SessionCreatedStatus:
+		t.previous = consumer.SessionStatistics{}
+		t.previousTime = time.Time{}
+		t.currentSpeed = CurrentSpeed{}
+	}
+}
+
+// bitCountDecimal returns a human readable representation of speed in bits per second
+// Taken from: https://programming.guide/go/formatting-byte-size-to-human-readable-format.html
+func bitCountDecimal(b int64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d bps", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cbps", float64(b)/float64(div), "kMGTPE"[exp])
+}

--- a/consumer/bandwidth/tracker_test.go
+++ b/consumer/bandwidth/tracker_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package bandwidth allows us to keep track of the consumer side connection speed.
+package bandwidth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mysteriumnetwork/node/consumer"
+	"github.com/mysteriumnetwork/node/core/connection"
+)
+
+func Test_ThroughputStringOutput(t *testing.T) {
+
+}
+
+func Test_bitCountDecimal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int64
+		want  string
+	}{
+		{
+			name:  "tests",
+			input: 1000,
+			want:  "1.0 kbps",
+		},
+		{
+			name:  "tests",
+			input: 1500,
+			want:  "1.5 kbps",
+		},
+		{
+			name:  "tests",
+			input: 100 * 0.5,
+			want:  "50 bps",
+		},
+		{
+			name:  "tests",
+			input: 1000 * 1000,
+			want:  "1.0 Mbps",
+		},
+		{
+			name:  "tests",
+			input: 1000 * 1000 * 1000,
+			want:  "1.0 Gbps",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bitCountDecimal(tt.input); got != tt.want {
+				t.Errorf("bitCountDecimal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_ConsumeSessionEvent_ResetsOnConnect(t *testing.T) {
+	tracker := Tracker{
+		previousTime: time.Now(),
+		previous: consumer.SessionStatistics{
+			BytesReceived: 1,
+			BytesSent:     1,
+		},
+	}
+	tracker.ConsumeSessionEvent(connection.SessionEvent{
+		Status: connection.SessionCreatedStatus,
+	})
+
+	assert.True(t, tracker.previousTime.IsZero())
+	assert.Zero(t, tracker.previous.BytesReceived)
+	assert.Zero(t, tracker.previous.BytesSent)
+}
+
+func Test_ConsumeSessionEvent_ResetsOnDisconnect(t *testing.T) {
+	tracker := Tracker{
+		previousTime: time.Now(),
+		previous: consumer.SessionStatistics{
+			BytesReceived: 1,
+			BytesSent:     1,
+		},
+	}
+	tracker.ConsumeSessionEvent(connection.SessionEvent{
+		Status: connection.SessionEndedStatus,
+	})
+
+	assert.True(t, tracker.previousTime.IsZero())
+	assert.Zero(t, tracker.previous.BytesReceived)
+	assert.Zero(t, tracker.previous.BytesSent)
+}
+
+func Test_ConsumeStatisticsEvent_CalculatesCorrectly(t *testing.T) {
+	startTime := time.Now()
+	var bytesTransfered uint64 = 10000
+	tracker := Tracker{
+		previousTime: startTime,
+	}
+
+	tracker.ConsumeStatisticsEvent(consumer.SessionStatistics{
+		BytesReceived: bytesTransfered,
+		BytesSent:     bytesTransfered,
+	})
+
+	assert.NotEqual(t, tracker.previousTime, startTime)
+	speed := tracker.Get()
+	expected := float64(bytesTransfered) / tracker.previousTime.Sub(startTime).Seconds() * bitsInByte
+	assert.Equal(t, expected, speed.Down.BitsPerSecond)
+	assert.Equal(t, expected, speed.Up.BitsPerSecond)
+}
+
+func Test_ConsumeStatisticsEvent_SkipsOnZero(t *testing.T) {
+	tracker := Tracker{}
+	input := consumer.SessionStatistics{
+		BytesReceived: 1,
+		BytesSent:     2,
+	}
+	tracker.ConsumeStatisticsEvent(input)
+	assert.False(t, tracker.previousTime.IsZero())
+	assert.Equal(t, input.BytesReceived, tracker.previous.BytesReceived)
+	assert.Equal(t, input.BytesSent, tracker.previous.BytesSent)
+	assert.Zero(t, tracker.Get().Down.BitsPerSecond)
+}


### PR DESCRIPTION
Consumer will now be able to determine the connection speed from the statistics reported by the various services. The speed is measured and provided as is and may not be the most accurate. It should be good enough for our applications though.


It seems to be accurate enough. Here's an actual speedtest measurement:

<img width="743" alt="Screen Shot 2019-05-22 at 3 01 54 PM" src="https://user-images.githubusercontent.com/18392269/58176941-10d31980-7cac-11e9-8405-a6be316308ca.png">

Here's the output log for the download part of the test:
```
2019-05-22T12:01:01.002221 [Trace] Download speed: 18.8 Mbps
2019-05-22T12:01:01.002232 [Trace] Upload speed: 153.0 kbps
2019-05-22T12:01:02.010846 [Debug] [client-management] Line received: >BYTECOUNT:8569022,588142
2019-05-22T12:01:02.0109 [Trace] [client-management] Line delivering: >BYTECOUNT:8569022,588142
2019-05-22T12:01:02.011023 [Trace] Download speed: 24.8 Mbps
2019-05-22T12:01:02.011045 [Trace] Upload speed: 551.5 kbps
2019-05-22T12:01:02.656432 [Warn] [NATS] Disconnected
2019-05-22T12:01:03.015221 [Debug] [client-management] Line received: >BYTECOUNT:11599654,614617
2019-05-22T12:01:03.015271 [Trace] [client-management] Line delivering: >BYTECOUNT:11599654,614617
2019-05-22T12:01:03.015366 [Trace] Download speed: 24.1 Mbps
2019-05-22T12:01:03.015377 [Trace] Upload speed: 210.9 kbps
2019-05-22T12:01:03.050734 [Warn] [NATS] Reconnected
2019-05-22T12:01:04.000267 [Debug] [client-management] Line received: >BYTECOUNT:15129222,642006
2019-05-22T12:01:04.000303 [Trace] [client-management] Line delivering: >BYTECOUNT:15129222,642006
2019-05-22T12:01:04.000377 [Trace] Download speed: 28.7 Mbps
2019-05-22T12:01:04.000388 [Trace] Upload speed: 222.5 kbps
2019-05-22T12:01:05.000786 [Debug] [client-management] Line received: >BYTECOUNT:18792567,670434
2019-05-22T12:01:05.000842 [Trace] [client-management] Line delivering: >BYTECOUNT:18792567,670434
2019-05-22T12:01:05.00095 [Trace] Download speed: 29.3 Mbps
2019-05-22T12:01:05.000974 [Trace] Upload speed: 227.3 kbps
2019-05-22T12:01:06.000165 [Debug] [client-management] Line received: >BYTECOUNT:21514209,711332
2019-05-22T12:01:06.000196 [Trace] [client-management] Line delivering: >BYTECOUNT:21514209,711332
2019-05-22T12:01:06.000256 [Trace] Download speed: 21.8 Mbps
2019-05-22T12:01:06.000265 [Trace] Upload speed: 327.4 kbps
2019-05-22T12:01:07.005939 [Debug] [client-management] Line received: >BYTECOUNT:25213338,750551
2019-05-22T12:01:07.00605 [Trace] [client-management] Line delivering: >BYTECOUNT:25213338,750551
2019-05-22T12:01:07.006141 [Trace] Download speed: 29.4 Mbps
2019-05-22T12:01:07.00616 [Trace] Upload speed: 311.9 kbps
2019-05-22T12:01:08.000276 [Debug] [client-management] Line received: >BYTECOUNT:28081643,816550
2019-05-22T12:01:08.000315 [Trace] [client-management] Line delivering: >BYTECOUNT:28081643,816550
2019-05-22T12:01:08.000396 [Trace] Download speed: 23.1 Mbps
2019-05-22T12:01:08.000412 [Trace] Upload speed: 531.1 kbps
2019-05-22T12:01:09.007798 [Debug] [client-management] Line received: >BYTECOUNT:31006710,839198
2019-05-22T12:01:09.00784 [Trace] [client-management] Line delivering: >BYTECOUNT:31006710,839198
2019-05-22T12:01:09.007937 [Trace] Download speed: 23.2 Mbps
2019-05-22T12:01:09.007951 [Trace] Upload speed: 179.8 kbps
2019-05-22T12:01:10.01002 [Debug] [client-management] Line received: >BYTECOUNT:32035910,870404
2019-05-22T12:01:10.010066 [Trace] [client-management] Line delivering: >BYTECOUNT:32035910,870404
```

Here's the output log for the upload part of the test:
```
2019-05-22T12:01:24.031315 [Debug] [client-management] Line received: >BYTECOUNT:38061700,2906521
2019-05-22T12:01:24.031355 [Trace] [client-management] Line delivering: >BYTECOUNT:38061700,2906521
2019-05-22T12:01:24.03143 [Trace] Download speed: 122.9 kbps
2019-05-22T12:01:24.031441 [Trace] Upload speed: 2.6 Mbps
2019-05-22T12:01:25.006143 [Debug] [client-management] Line received: >BYTECOUNT:38073220,3336911
2019-05-22T12:01:25.006205 [Trace] [client-management] Line delivering: >BYTECOUNT:38073220,3336911
2019-05-22T12:01:25.006281 [Trace] Download speed: 94.5 kbps
2019-05-22T12:01:25.006296 [Trace] Upload speed: 3.5 Mbps
2019-05-22T12:01:26.005964 [Debug] [client-management] Line received: >BYTECOUNT:38087739,3661054
2019-05-22T12:01:26.006002 [Trace] [client-management] Line delivering: >BYTECOUNT:38087739,3661054
2019-05-22T12:01:26.006085 [Trace] Download speed: 116.2 kbps
2019-05-22T12:01:26.006099 [Trace] Upload speed: 2.6 Mbps
2019-05-22T12:01:27.073026 [Debug] [client-management] Line received: >BYTECOUNT:38097587,3960136
2019-05-22T12:01:27.073067 [Trace] [client-management] Line delivering: >BYTECOUNT:38097587,3960136
2019-05-22T12:01:27.073164 [Trace] Download speed: 73.8 kbps
2019-05-22T12:01:27.073205 [Trace] Upload speed: 2.2 Mbps
2019-05-22T12:01:28.010911 [Debug] [client-management] Line received: >BYTECOUNT:38109983,4310020
2019-05-22T12:01:28.010981 [Trace] [client-management] Line delivering: >BYTECOUNT:38109983,4310020
2019-05-22T12:01:28.011111 [Trace] Download speed: 105.7 kbps
2019-05-22T12:01:28.011137 [Trace] Upload speed: 3.0 Mbps
2019-05-22T12:01:29.051735 [Debug] [client-management] Line received: >BYTECOUNT:38123381,4634122
2019-05-22T12:01:29.051833 [Trace] [client-management] Line delivering: >BYTECOUNT:38123381,4634122
2019-05-22T12:01:29.051954 [Trace] Download speed: 103.0 kbps
2019-05-22T12:01:29.051981 [Trace] Upload speed: 2.5 Mbps
2019-05-22T12:01:30.02681 [Debug] [client-management] Line received: >BYTECOUNT:38144119,4857368
2019-05-22T12:01:30.026868 [Trace] [client-management] Line delivering: >BYTECOUNT:38144119,4857368
2019-05-22T12:01:30.026977 [Trace] Download speed: 170.2 kbps
2019-05-22T12:01:30.027011 [Trace] Upload speed: 1.8 Mbps
2019-05-22T12:01:31.019073 [Debug] [client-management] Line received: >BYTECOUNT:38211698,4877627
2019-05-22T12:01:31.019117 [Trace] [client-management] Line delivering: >BYTECOUNT:38211698,4877627
2019-05-22T12:01:31.019251 [Trace] Download speed: 544.9 kbps
2019-05-22T12:01:31.019268 [Trace] Upload speed: 163.3 kbps
2019-05-22T12:01:32.04597 [Debug] [client-management] Line received: >BYTECOUNT:38626634,4970175
2019-05-22T12:01:32.046033 [Trace] [client-management] Line delivering: >BYTECOUNT:38626634,4970175
2019-05-22T12:01:32.046302 [Trace] Download speed: 3.2 Mbps
2019-05-22T12:01:32.046347 [Trace] Upload speed: 720.9 kbps
2019-05-22T12:01:33.003574 [Debug] [client-management] Line received: >BYTECOUNT:39004460,5013532
2019-05-22T12:01:33.003618 [Trace] [client-management] Line delivering: >BYTECOUNT:39004460,5013532
2019-05-22T12:01:33.003683 [Trace] Download speed: 3.2 Mbps
2019-05-22T12:01:33.003693 [Trace] Upload speed: 362.3 kbps
```