### PR TITLE
Mysterium API address flag '--api.address'

### DIFF
--- a/bin/localnet/docker-compose.yml
+++ b/bin/localnet/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       MYSQL_PASSWORD: myst_api
 
   mysterium-api:
-    image: mysteriumnetwork/mysterium-api:0.4.1
+    image: mysteriumnetwork/mysterium-api:0.5.9
     expose:
     - 80
     environment:

--- a/bin/localnet/docker-compose.yml
+++ b/bin/localnet/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       MYSQL_USER: myst_api
       MYSQL_PASSWORD: myst_api
 
-  discovery:
+  mysterium-api:
     image: mysteriumnetwork/mysterium-api:0.4.1
     expose:
     - 80

--- a/bin/localnet/functions.sh
+++ b/bin/localnet/functions.sh
@@ -50,16 +50,16 @@ setupInfra () {
     sleep 2 #even after successful TCP connection we still hit db not ready yet sometimes
     echo "Database is up"
 
-    ${dockerComposeCmd} run --entrypoint bin/db-upgrade discovery
+    ${dockerComposeCmd} run --entrypoint bin/db-upgrade mysterium-api
     if [ ! $? -eq 0 ]; then
         print_error "Db migration failed"
         cleanup "$@"
         exit 1
     fi
 
-    ${dockerComposeCmd} up -d discovery
+    ${dockerComposeCmd} up -d mysterium-api
     if [ ! $? -eq 0 ]; then
-        print_error "Error starting discovery services"
+        print_error "Error starting Mysterium API"
         cleanup "$@"
         exit 1
     fi

--- a/bin/localnet/publish-ports.yml
+++ b/bin/localnet/publish-ports.yml
@@ -6,7 +6,7 @@ services:
       - 4222:4222
       - 8222:4222
 
-  discovery:
+  mysterium-api:
     ports:
     - 80:80
 

--- a/ci/test/e2e.go
+++ b/ci/test/e2e.go
@@ -83,13 +83,13 @@ func (r *runner) setup() error {
 	}
 
 	log.Info("migrating DB")
-	if err := r.compose("run", "--entrypoint", "bin/db-upgrade", "discovery"); err != nil {
+	if err := r.compose("run", "--entrypoint", "bin/db-upgrade", "mysterium-api"); err != nil {
 		return errors.Wrap(err, "migrating DB failed!")
 	}
 
-	log.Info("starting discovery")
-	if err := r.compose("up", "-d", "discovery"); err != nil {
-		return errors.Wrap(err, "starting discovery failed!")
+	log.Info("starting mysterium-api")
+	if err := r.compose("up", "-d", "mysterium-api"); err != nil {
+		return errors.Wrap(err, "starting mysterium-api failed!")
 	}
 
 	file, err := os.Open("bin/localnet/deployer/local_acc_password.txt")

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -206,7 +206,7 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 		return err
 	}
 
-	if err := di.bootstrapNetworkComponents(nodeOptions); err != nil {
+	if err := di.bootstrapNetworkComponents(nodeOptions.OptionsNetwork); err != nil {
 		return err
 	}
 
@@ -459,7 +459,7 @@ func newSessionManagerFactory(
 }
 
 // function decides on network definition combined from testnet/localnet flags and possible overrides
-func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err error) {
+func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) (err error) {
 	network := metadata.DefaultNetwork
 
 	switch {
@@ -470,8 +470,8 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 	}
 
 	//override defined values one by one from options
-	if options.Discovery.Address != metadata.DefaultNetwork.MysteriumAPIAddress {
-		network.MysteriumAPIAddress = options.Discovery.Address
+	if options.MysteriumAPIAddress != metadata.DefaultNetwork.MysteriumAPIAddress {
+		network.MysteriumAPIAddress = options.MysteriumAPIAddress
 	}
 
 	if options.BrokerAddress != metadata.DefaultNetwork.BrokerAddress {

--- a/cmd/flags_discovery.go
+++ b/cmd/flags_discovery.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/mysteriumnetwork/node/core/node"
-	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/urfave/cli"
 )
 
@@ -37,7 +36,7 @@ var (
 			"Address of specific discovery provider given in '--%s'",
 			discoveryTypeFlag.Name,
 		),
-		Value: metadata.DefaultNetwork.MysteriumAPIAddress,
+		Value: apiAddressFlag.Value,
 	}
 )
 

--- a/cmd/flags_network.go
+++ b/cmd/flags_network.go
@@ -38,6 +38,12 @@ var (
 		Usage: "Enables experimental identity check",
 	}
 
+	apiAddressFlag = cli.StringFlag{
+		Name:  "discovery-address",
+		Usage: "`URL` of discovery service",
+		Value: metadata.DefaultNetwork.MysteriumAPIAddress,
+	}
+
 	accessPolicyAddressFlag = cli.StringFlag{
 		Name:  "access-policy-address",
 		Usage: "`URL` of trust oracle endpoint for retrieving lists of access policies",
@@ -80,7 +86,7 @@ func RegisterFlagsNetwork(flags *[]cli.Flag) {
 		testFlag, localnetFlag,
 		identityCheckFlag,
 		natPunchingFlag,
-		brokerAddressFlag,
+		apiAddressFlag, brokerAddressFlag,
 		etherRPCFlag, etherContractPaymentsFlag,
 		qualityOracleFlag, accessPolicyAddressFlag,
 	)
@@ -95,6 +101,7 @@ func ParseFlagsNetwork(ctx *cli.Context) node.OptionsNetwork {
 		ExperimentIdentityCheck: ctx.GlobalBool(identityCheckFlag.Name),
 		ExperimentNATPunching:   ctx.GlobalBool(natPunchingFlag.Name),
 
+		MysteriumAPIAddress:         ctx.GlobalString(apiAddressFlag.Name),
 		AccessPolicyEndpointAddress: ctx.GlobalString(accessPolicyAddressFlag.Name),
 		BrokerAddress:               ctx.GlobalString(brokerAddressFlag.Name),
 

--- a/cmd/flags_network.go
+++ b/cmd/flags_network.go
@@ -18,6 +18,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/urfave/cli"
@@ -39,20 +41,25 @@ var (
 	}
 
 	apiAddressFlag = cli.StringFlag{
-		Name:  "discovery-address",
-		Usage: "`URL` of discovery service",
+		Name:  "api.address",
+		Usage: "URL of Mysterium API",
 		Value: metadata.DefaultNetwork.MysteriumAPIAddress,
+	}
+	apiAddressFlagDepreciated = cli.StringFlag{
+		Name:  "discovery-address",
+		Usage: fmt.Sprintf("URL of Mysterium API (DEPRECIATED, start using '--%s')", apiAddressFlag.Name),
+		Value: apiAddressFlag.Value,
 	}
 
 	accessPolicyAddressFlag = cli.StringFlag{
 		Name:  "access-policy-address",
-		Usage: "`URL` of trust oracle endpoint for retrieving lists of access policies",
+		Usage: "URL of trust oracle endpoint for retrieving lists of access policies",
 		Value: metadata.DefaultNetwork.AccessPolicyOracleAddress,
 	}
 
 	brokerAddressFlag = cli.StringFlag{
 		Name:  "broker-address",
-		Usage: "`URI` of message broker",
+		Usage: "URI of message broker",
 		Value: metadata.DefaultNetwork.BrokerAddress,
 	}
 
@@ -86,7 +93,8 @@ func RegisterFlagsNetwork(flags *[]cli.Flag) {
 		testFlag, localnetFlag,
 		identityCheckFlag,
 		natPunchingFlag,
-		apiAddressFlag, brokerAddressFlag,
+		apiAddressFlag, apiAddressFlagDepreciated,
+		brokerAddressFlag,
 		etherRPCFlag, etherContractPaymentsFlag,
 		qualityOracleFlag, accessPolicyAddressFlag,
 	)

--- a/core/node/options_network.go
+++ b/core/node/options_network.go
@@ -25,6 +25,7 @@ type OptionsNetwork struct {
 	ExperimentIdentityCheck bool
 	ExperimentNATPunching   bool
 
+	MysteriumAPIAddress         string
 	AccessPolicyEndpointAddress string
 	BrokerAddress               string
 

--- a/e2e/compatibility-matrix/docker-compose.yml
+++ b/e2e/compatibility-matrix/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       --experiment-payments
       --localnet
       --broker-address=broker
-      --discovery.address=http://discovery/v1
+      --discovery-address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       service openvpn,noop,wireguard
       --agreed-terms-and-conditions
@@ -103,6 +103,6 @@ services:
       --experiment-identity-check
       --experiment-payments
       --localnet
-      --discovery.address=http://discovery/v1
+      --discovery-address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       daemon

--- a/e2e/compatibility-matrix/docker-compose.yml
+++ b/e2e/compatibility-matrix/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       --experiment-payments
       --localnet
       --broker-address=broker
-      --discovery-address=http://discovery/v1
+      --api.address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       service openvpn,noop,wireguard
       --agreed-terms-and-conditions
@@ -103,6 +103,6 @@ services:
       --experiment-identity-check
       --experiment-payments
       --localnet
-      --discovery-address=http://discovery/v1
+      --api.address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       daemon

--- a/e2e/compatibility-matrix/docker-compose.yml
+++ b/e2e/compatibility-matrix/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: mysteriumnetwork/myst:0.5
     depends_on:
       - broker
-      - discovery
+      - mysterium-api
       - ipify
     cap_add:
       - NET_ADMIN
@@ -28,7 +28,7 @@ services:
       --experiment-promise-check
       --localnet
       --broker-address=broker
-      --discovery-address=http://discovery/v1
+      --discovery-address=http://mysterium-api/v1
       --ether.client.rpc=http://geth:8545
       service openvpn,noop,wireguard
       --agreed-terms-and-conditions
@@ -40,7 +40,7 @@ services:
     image: mysteriumnetwork/myst:0.5
     depends_on:
       - broker
-      - discovery
+      - mysterium-api
       - ipify
     cap_add:
       - NET_ADMIN
@@ -51,7 +51,7 @@ services:
       --experiment-identity-check
       --experiment-promise-check
       --localnet
-      --discovery-address=http://discovery/v1
+      --discovery-address=http://mysterium-api/v1
       --ether.client.rpc=http://geth:8545
       daemon
 
@@ -61,7 +61,7 @@ services:
       dockerfile: bin/docker/alpine/Dockerfile
     depends_on:
       - broker
-      - discovery
+      - mysterium-api
       - ipify
     cap_add:
       - NET_ADMIN
@@ -78,7 +78,7 @@ services:
       --experiment-payments
       --localnet
       --broker-address=broker
-      --api.address=http://discovery/v1
+      --api.address=http://mysterium-api/v1
       --ether.client.rpc=http://geth:8545
       service openvpn,noop,wireguard
       --agreed-terms-and-conditions
@@ -92,7 +92,7 @@ services:
       dockerfile: bin/docker/alpine/Dockerfile
     depends_on:
       - broker
-      - discovery
+      - mysterium-api
       - ipify
     cap_add:
       - NET_ADMIN
@@ -103,6 +103,6 @@ services:
       --experiment-identity-check
       --experiment-payments
       --localnet
-      --api.address=http://discovery/v1
+      --api.address=http://mysterium-api/v1
       --ether.client.rpc=http://geth:8545
       daemon

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       --experiment-identity-check
       --localnet
       --broker-address=broker
-      --discovery-address=http://discovery/v1
+      --api.address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       --keystore.lightweight
       service openvpn,noop,wireguard
@@ -48,7 +48,7 @@ services:
       --ip-detector=http://ipify:3000/?format=json
       --experiment-identity-check
       --localnet
-      --discovery-address=http://discovery/v1
+      --api.address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       --keystore.lightweight
       daemon

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       --experiment-identity-check
       --localnet
       --broker-address=broker
-      --discovery.address=http://discovery/v1
+      --discovery-address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       --keystore.lightweight
       service openvpn,noop,wireguard
@@ -48,7 +48,7 @@ services:
       --ip-detector=http://ipify:3000/?format=json
       --experiment-identity-check
       --localnet
-      --discovery.address=http://discovery/v1
+      --discovery-address=http://discovery/v1
       --ether.client.rpc=http://geth:8545
       --keystore.lightweight
       daemon

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: bin/docker/alpine/Dockerfile
     depends_on:
       - broker
-      - discovery
+      - mysterium-api
       - ipify
     cap_add:
       - NET_ADMIN
@@ -23,7 +23,7 @@ services:
       --experiment-identity-check
       --localnet
       --broker-address=broker
-      --api.address=http://discovery/v1
+      --api.address=http://mysterium-api/v1
       --ether.client.rpc=http://geth:8545
       --keystore.lightweight
       service openvpn,noop,wireguard
@@ -38,7 +38,7 @@ services:
       dockerfile: bin/docker/alpine/Dockerfile
     depends_on:
       - broker
-      - discovery
+      - mysterium-api
       - ipify
     cap_add:
       - NET_ADMIN
@@ -48,7 +48,7 @@ services:
       --ip-detector=http://ipify:3000/?format=json
       --experiment-identity-check
       --localnet
-      --api.address=http://discovery/v1
+      --api.address=http://mysterium-api/v1
       --ether.client.rpc=http://geth:8545
       --keystore.lightweight
       daemon

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -76,11 +76,6 @@ func NewNode(appPath string, optionsNetwork *MobileNetworkOptions) (*MobileNode,
 			Address:       "https://testnet-location.mysterium.network/api/v1/location",
 		},
 
-		Discovery: node.OptionsDiscovery{
-			Type:    node.DiscoveryTypeAPI,
-			Address: metadata.TestnetDefinition.MysteriumAPIAddress,
-		},
-
 		OptionsNetwork: node.OptionsNetwork(*optionsNetwork),
 	})
 	if err != nil {
@@ -95,6 +90,7 @@ func DefaultNetworkOptions() *MobileNetworkOptions {
 	return &MobileNetworkOptions{
 		Testnet:                 true,
 		ExperimentIdentityCheck: false,
+		MysteriumAPIAddress:     metadata.TestnetDefinition.MysteriumAPIAddress,
 		BrokerAddress:           metadata.TestnetDefinition.BrokerAddress,
 		EtherClientRPC:          metadata.TestnetDefinition.EtherClientRPC,
 		EtherPaymentsAddress:    metadata.DefaultNetwork.PaymentsContractAddress.String(),


### PR DESCRIPTION
Yes, Mysterium API is not discovery anymore. So I rename it to "Mysterium API Service"

And we cannot drop flag `--api.address`, as we're are depending on this API not only for disovery purposes:
- sessions
- identity payout
- etc.