### PR TITLE
Fix docker version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently node supports OpenVPN as its underlying VPN transport.
 
 To run a node as docker container You will need [docker](https://www.docker.com/).
 You should be able to run a node on any OS that supports docker.
-Tested on these OSes so far: _Dabian 9_, _Ubuntu 16.04_ and _Centos 7_.
+Tested on these OSes so far: _Debian 9_, _Ubuntu 16.04_ and _Centos 7_.
 
 You can check latest docker node versions here: https://hub.docker.com/r/mysteriumnetwork/myst/
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mysterium Node - decentralized VPN built on blockchain
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/mysteriumnetwork/node)](https://goreportcard.com/report/github.com/mysteriumnetwork/node)
-[![Build Status](https://travis-ci.com/mysteriumnetwork/node.svg?branch=master)](https://travis-ci.com/mysteriumnetwork/node)
+[![pipeline status](https://gitlab.com/mysteriumnetwork/node/badges/master/pipeline.svg)](https://gitlab.com/mysteriumnetwork/node/pipelines)
 [![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)
 
 Cross-platform software to run a node in Mysterium Network. It contains Mysterium server (node),

--- a/ci/env/generate.go
+++ b/ci/env/generate.go
@@ -35,6 +35,8 @@ type envVar struct {
 	val string
 }
 
+var buildTime = time.Now().UTC()
+
 // GenerateEnvFile for sourcing in other stages
 func GenerateEnvFile() error {
 	version, err := buildVersion()
@@ -111,9 +113,9 @@ func snapshotVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s+1snapshot+%s+%s",
+	return fmt.Sprintf("%s-1snapshot-%s-%s",
 		latestRelease.TagName,
-		time.Now().UTC().Format("20060102T1504"),
+		buildTime.Format("20060102T1504"),
 		gitHead.Hash().String()[:8]), nil
 }
 


### PR DESCRIPTION
Apparently, problems with pluses in version strings. Docker tags don't support them.
Let's use dashes...
Ref #1061 