### PR TITLE
Configure raspberrypi image using existing raspbian-stretch-lite

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,39 @@
   version = "v2.2.1"
 
 [[projects]]
+  digest = "1:43f99b9aa2ac54938ff8bc617488a802d738340a168c0f9501a37644750c33d7"
+  name = "github.com/aws/aws-sdk-go-v2"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/ec2rolecreds",
+    "aws/endpointcreds",
+    "aws/endpoints",
+    "aws/external",
+    "aws/signer/v4",
+    "aws/stscreds",
+    "internal/awsutil",
+    "internal/ini",
+    "internal/sdk",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
+    "service/sts",
+  ]
+  pruneopts = "UT"
+  revision = "098e15df3044cf1b04a222c1c33c3e6135ac89f3"
+  version = "v0.9.0"
+
+[[projects]]
   digest = "1:2c00f064ba355903866cbfbf3f7f4c0fe64af6638cc7d1b8bdcf3181bc67f1d8"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
@@ -299,6 +332,13 @@
   packages = ["io"]
   pruneopts = "UT"
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
+
+[[projects]]
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2b33e84"
 
 [[projects]]
   digest = "1:f5a2051c55d05548d2d4fd23d244027b59fbd943217df8aa3b5e170ac2fd6e1b"
@@ -987,6 +1027,11 @@
   input-imports = [
     "github.com/asaskevich/EventBus",
     "github.com/asdine/storm",
+    "github.com/aws/aws-sdk-go-v2/aws",
+    "github.com/aws/aws-sdk-go-v2/aws/endpoints",
+    "github.com/aws/aws-sdk-go-v2/aws/external",
+    "github.com/aws/aws-sdk-go-v2/service/s3",
+    "github.com/aws/aws-sdk-go-v2/service/s3/s3manager",
     "github.com/chzyer/readline",
     "github.com/cihub/seelog",
     "github.com/ethereum/go-ethereum",
@@ -1013,6 +1058,7 @@
     "github.com/julienschmidt/httprouter",
     "github.com/magefile/mage/mage",
     "github.com/magefile/mage/sh",
+    "github.com/mholt/archiver",
     "github.com/mitchellh/go-homedir",
     "github.com/mysteriumnetwork/go-dvpn-web",
     "github.com/mysteriumnetwork/go-openvpn/openvpn",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -141,3 +141,11 @@
 [[constraint]]
   name = "gopkg.in/src-d/go-git.v4"
   version = "4.11.0"
+
+[[constraint]]
+  name = "github.com/aws/aws-sdk-go-v2"
+  version = "0.9.0"
+
+[[constraint]]
+  name = "github.com/mholt/archiver"
+  version = "3.1.1"

--- a/bin/package/raspberry/files/default-myst-conf
+++ b/bin/package/raspberry/files/default-myst-conf
@@ -1,0 +1,6 @@
+# Define additional args for `myst` service (see `myst --help` for full list)
+CONF_DIR="--config-dir=/etc/mysterium-node"
+RUN_DIR="--runtime-dir=/var/run/mysterium-node"
+DATA_DIR="--data-dir=/var/lib/mysterium-node"
+DAEMON_OPTS="--tequilapi.address=0.0.0.0"
+SERVICE_OPTS="openvpn --access-policy.list mysterium"

--- a/bin/package/raspberry/files/setup.sh
+++ b/bin/package/raspberry/files/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ev
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export DEBIAN_FRONTEND="noninteractive"
+
+install -m 644 default-myst-conf /etc/default/mysterium-node
+
+if [[ "${RELEASE_BUILD}" == "true" ]]; then
+  echo "Release build, setting up auto-update"
+  install -m 644 unattended-upgrades /etc/apt/apt.conf.d/51unattended-upgrades-myst
+fi
+
+echo "deb http://deb.debian.org/debian/ unstable main" | tee --append /etc/apt/sources.list.d/unstable.list
+echo "deb http://ppa.launchpad.net/mysteriumnetwork/node/ubuntu bionic main " | tee --append /etc/apt/sources.list.d/mysterium.list
+printf 'Package: *\nPin: release a=unstable\nPin-Priority: 150\n' | tee --append /etc/apt/preferences.d/limit-unstable
+
+apt-get -y install raspberrypi-kernel-headers dirmngr
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B48AD6246925553 7638D0442B90D010 04EE7237B7D453EC ECCB6A56B22C536D
+apt-get update
+apt-get -y install wireguard openvpn
+
+chmod 755 myst_linux_armhf.deb
+yes | dpkg -i myst_linux_armhf.deb

--- a/bin/package/raspberry/files/unattended-upgrades
+++ b/bin/package/raspberry/files/unattended-upgrades
@@ -1,0 +1,3 @@
+Unattended-Upgrade::Allowed-Origins {
+  "LP-PPA-mysteriumnetwork-node:bionic";
+};

--- a/ci/packages/package.go
+++ b/ci/packages/package.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/magefile/mage/sh"
+
 	"github.com/mysteriumnetwork/node/ci/env"
 	"github.com/mysteriumnetwork/node/ci/storage"
 	"github.com/mysteriumnetwork/node/logconfig"
@@ -79,27 +80,6 @@ func PackageLinuxDebianArm() error {
 		return err
 	}
 	return env.IfRelease(storage.UploadArtifacts)
-}
-
-// PackageLinuxRaspberryImage builds and stores raspberry image
-func PackageLinuxRaspberryImage() error {
-	logconfig.Bootstrap()
-	defer log.Flush()
-	if err := goGet("github.com/debber/debber-v0.3/cmd/debber"); err != nil {
-		return err
-	}
-	if err := sh.RunV("bin/build_xgo", "linux/arm"); err != nil {
-		return err
-	}
-	if err := packageDebian("build/myst/myst_linux_arm", "armhf"); err != nil {
-		return err
-	}
-	return env.IfRelease(func() error {
-		if err := sh.RunV("bin/package_raspberry"); err != nil {
-			return err
-		}
-		return storage.UploadArtifacts()
-	})
 }
 
 // PackageOsxAmd64 builds and stores OSX amd64 package

--- a/ci/packages/raspberry.go
+++ b/ci/packages/raspberry.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package packages
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	log "github.com/cihub/seelog"
+	"github.com/mholt/archiver"
+	"github.com/mysteriumnetwork/node/ci/env"
+	"github.com/mysteriumnetwork/node/ci/storage"
+	"github.com/mysteriumnetwork/node/ci/util/device"
+	"github.com/mysteriumnetwork/node/ci/util/shell"
+	"github.com/mysteriumnetwork/node/logconfig"
+	"github.com/pkg/errors"
+)
+
+const raspbianMountPoint = "/mnt/rpi"
+
+// PackageLinuxRaspberryImage builds and stores raspberry image
+func PackageLinuxRaspberryImage() error {
+	logconfig.Bootstrap()
+	defer log.Flush()
+	if err := goGet("github.com/debber/debber-v0.3/cmd/debber"); err != nil {
+		return err
+	}
+	if err := shell.NewCmd("bin/build_xgo linux/arm").Run(); err != nil {
+		return err
+	}
+	if err := packageDebian("build/myst/myst_linux_arm", "armhf"); err != nil {
+		return err
+	}
+	return env.IfRelease(func() error {
+		err := buildMystRaspbianImage()
+		if err != nil {
+			return err
+		}
+		return storage.UploadArtifacts()
+	})
+}
+
+func buildMystRaspbianImage() error {
+	logconfig.Bootstrap()
+	defer log.Flush()
+
+	imagePath, err := fetchRaspbianImage()
+	if err != nil {
+		return err
+	}
+	if err := configureRaspbianImage(imagePath); err != nil {
+		return err
+	}
+	if err := archiver.DefaultZip.Archive([]string{imagePath}, "build/package/mystberry.zip"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// configureRaspbianImage mounts given raspbian image, spawns a lightweight container via systemd-nspawn and configures it
+// see `setup.sh` for setup script executed in container
+func configureRaspbianImage(raspbianImagePath string) error {
+	envs := map[string]string{
+		"PATH":            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"DEBIAN_FRONTEND": "noninteractive",
+	}
+
+	if err := shell.NewCmd("sudo apt-get install -y qemu qemu-user-static binfmt-support systemd-container").RunWith(envs); err != nil {
+		return err
+	}
+	loopDevice, err := device.AttachLoop(raspbianImagePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := device.DetachLoop(loopDevice); err != nil {
+			log.Warn(err)
+		}
+	}()
+
+	_ = os.MkdirAll(raspbianMountPoint, 0755)
+	if err := shell.NewCmdf("sudo mount --options rw %s %s", loopDevice+"p2", raspbianMountPoint).Run(); err != nil {
+		return err
+	}
+	_ = os.MkdirAll(raspbianMountPoint+"/boot", 0755)
+	if err := shell.NewCmdf("sudo mount --options rw %s %s", loopDevice+"p1", raspbianMountPoint+"/boot").Run(); err != nil {
+		return err
+	}
+	defer func() {
+		if err := shell.NewCmdf("sudo umount --recursive %s", raspbianMountPoint).Run(); err != nil {
+			log.Warn(err)
+		}
+	}()
+	if err := shell.NewCmdf("sudo cp /usr/bin/qemu-arm-static %s", raspbianMountPoint+"/usr/bin").Run(); err != nil {
+		return err
+	}
+
+	setupDir := "/home/pi/myst-setup"
+	mountedSetupDir := raspbianMountPoint + setupDir
+	if err := shell.NewCmdf("sudo mkdir -p %s", mountedSetupDir).Run(); err != nil {
+		return err
+	}
+	if err := shell.NewCmdf("sudo cp build/package/myst_linux_armhf.deb %s", mountedSetupDir).Run(); err != nil {
+		return err
+	}
+	if err := shell.NewCmdf("sudo cp -r bin/package/raspberry/files/. %s", mountedSetupDir).Run(); err != nil {
+		return err
+	}
+	if err := shell.NewCmdf("sudo systemd-nspawn --directory=%s --chdir=%s bash -ev setup.sh", raspbianMountPoint, setupDir).Run(); err != nil {
+		return err
+	}
+	if err := shell.NewCmdf("sudo rm -r %s", mountedSetupDir).Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func fetchRaspbianImage() (filename string, err error) {
+	storageClient, err := storage.NewClient()
+	if err != nil {
+		return "", err
+	}
+
+	log.Infof("looking up raspbian image file")
+	localRaspbianZip, err := storageClient.GetCacheableFile("raspbian", func(object s3.Object) bool {
+		return strings.Contains(aws.StringValue(object.Key), "-raspbian-stretch-lite")
+	})
+	if err != nil {
+		return "", err
+	}
+
+	localRaspbianZipDir, localRaspbianZipFilename := filepath.Split(localRaspbianZip)
+	localRaspbianImgDir := filepath.Join(localRaspbianZipDir, localRaspbianZipFilename[0:len(localRaspbianZipFilename)-4])
+
+	log.Infof("extracting raspbian image to %s", localRaspbianImgDir)
+	err = os.RemoveAll(localRaspbianImgDir)
+	if err != nil {
+		return "", err
+	}
+
+	zip := archiver.NewZip()
+	zip.OverwriteExisting = true
+	err = zip.Unarchive(localRaspbianZip, localRaspbianImgDir)
+	if err != nil {
+		return "", err
+	}
+
+	extractedFiles, err := ioutil.ReadDir(localRaspbianImgDir)
+	if err != nil {
+		return "", err
+	}
+
+	var localRaspbianImg string
+	for _, f := range extractedFiles {
+		if strings.Contains(f.Name(), ".img") {
+			localRaspbianImg = filepath.Join(localRaspbianImgDir, f.Name())
+			break
+		}
+	}
+	if localRaspbianImg == "" {
+		return "", errors.New("could not find img file in raspbian archive")
+	}
+	return localRaspbianImg, nil
+}

--- a/ci/storage/s3.go
+++ b/ci/storage/s3.go
@@ -18,12 +18,141 @@
 package storage
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
+	awsExternal "github.com/aws/aws-sdk-go-v2/aws/external"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/s3manager"
 	log "github.com/cihub/seelog"
 	"github.com/magefile/mage/sh"
+	"github.com/mitchellh/go-homedir"
 	"github.com/mysteriumnetwork/node/ci/env"
 	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/pkg/errors"
 )
+
+// Storage wraps AWS S3 client, configures for s3.mysterium.network
+// and provides convenience methods
+type Storage struct {
+	*s3.Client
+}
+
+var cacheDir string
+
+const cacheDirPermissions = 0700
+
+func init() {
+	var err error
+	cacheDir, err = homedir.Expand("~/.myst-build-cache")
+	if err != nil {
+		_, _ = os.Stderr.WriteString("failed to determine cache directory")
+		os.Exit(1)
+	}
+	err = os.Mkdir(cacheDir, cacheDirPermissions)
+	if err != nil && !os.IsExist(err) {
+		_, _ = os.Stderr.WriteString("failed to create storage cache directory")
+		os.Exit(1)
+	}
+}
+
+// NewClient returns *s3.Client, configured to work with https://s3.mysterium.network storage
+func NewClient() (*Storage, error) {
+	cfg, err := awsExternal.LoadDefaultAWSConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg.EndpointResolver = aws.ResolveWithEndpointURL("https://s3.mysterium.network")
+	cfg.Region = endpoints.EuCentral1RegionID
+	client := s3.New(cfg)
+	client.ForcePathStyle = true
+	return &Storage{client}, nil
+}
+
+// ListObjects lists objects in storage bucket
+func (s *Storage) ListObjects(bucket string) ([]s3.Object, error) {
+	req := s.ListObjectsV2Request(&s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+	})
+	if err := req.Build(); err != nil {
+		return nil, err
+	}
+	res, err := req.Send(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return res.Contents, nil
+}
+
+// FindObject finds an object in storage bucket satisfying given predicate
+func (s *Storage) FindObject(bucket string, predicate func(s3.Object) bool) (*s3.Object, error) {
+	objects, err := s.ListObjects(bucket)
+	if err != nil {
+		return nil, err
+	}
+	for _, obj := range objects {
+		if predicate(obj) {
+			return &obj, nil
+		}
+	}
+	return nil, nil
+}
+
+// GetCacheableFile finds a file in a storage bucket satisfying given predicate. If a local copy with the same size
+// does not exist, downloads the file. Otherwise, returns a cached copy.
+func (s *Storage) GetCacheableFile(bucket string, predicate func(s3.Object) bool) (string, error) {
+	object, err := s.FindObject(bucket, predicate)
+	if err != nil {
+		return "", errors.Wrap(err, "could not find file in bucket")
+	}
+	remoteFilename := aws.StringValue(object.Key)
+	remoteFileSize := aws.Int64Value(object.Size)
+
+	localFilename := filepath.Join(cacheDir, remoteFilename)
+	localFileInfo, err := os.Stat(localFilename)
+
+	var download bool
+	switch {
+	case err == nil && localFileInfo.Size() != remoteFileSize:
+		log.Infof(
+			"cached copy found: %s, but size mismatched, expected: %d, found: %d",
+			localFilename, remoteFileSize, localFileInfo.Size(),
+		)
+		download = true
+	case err != nil && os.IsNotExist(err):
+		log.Infof("cached copy not found: %s", localFilename)
+		download = true
+	case err != nil:
+		return "", errors.Wrap(err, "error looking up cached copy")
+	}
+
+	if download {
+		log.Infof("downloading file from the bucket")
+		file, err := os.OpenFile(localFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, cacheDirPermissions)
+		if err != nil {
+			return "", err
+		}
+		defer file.Close()
+
+		downloader := s3manager.NewDownloaderWithClient(s)
+
+		numBytes, err := downloader.Download(file, &s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(remoteFilename),
+		})
+		if err != nil {
+			return "", err
+		}
+		log.Infof("downloaded file: %s (%dMB)", localFilename, numBytes/1024/1024)
+	} else {
+		log.Infof("returning cached copy")
+	}
+
+	return localFilename, nil
+}
 
 // MakeBucket creates a bucket in s3 for the build (env.BuildNumber)
 func MakeBucket() error {

--- a/ci/util/device/loop.go
+++ b/ci/util/device/loop.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package device
+
+import (
+	"strings"
+
+	"github.com/mysteriumnetwork/node/ci/util/shell"
+	"github.com/pkg/errors"
+)
+
+// AttachLoop attaches system image to the first available loop device and returns its name
+func AttachLoop(imageFilename string) (loopDevice string, err error) {
+	output, err := shell.NewCmdf("sudo /sbin/losetup --show --find --partscan %s", imageFilename).Output()
+	if err != nil {
+		return "", errors.Wrapf(err, "could not attach image to loop loopDevice, image: %s", imageFilename)
+	}
+	devices := strings.Split(output, "\n")
+	if len(devices) > 0 {
+		loopDevice = devices[0]
+	}
+	if loopDevice == "" {
+		return "", errors.New("loop loopDevice not found")
+	}
+	return loopDevice, nil
+}
+
+// DetachLoop detaches given loop device
+func DetachLoop(loopDevice string) error {
+	err := shell.NewCmdf("sudo /sbin/losetup -d %s", loopDevice).Run()
+	return errors.Wrapf(err, "could not detach image from loop loopDevice %s", loopDevice)
+}

--- a/ci/util/shell/cmd.go
+++ b/ci/util/shell/cmd.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package shell
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/magefile/mage/sh"
+)
+
+// Cmd represents a shell command
+type Cmd struct {
+	cmd  string
+	args []string
+}
+
+// NewCmd shell command from a string
+func NewCmd(cmd string) *Cmd {
+	split := strings.Split(cmd, " ")
+	return &Cmd{
+		cmd:  split[0],
+		args: split[1:],
+	}
+}
+
+// NewCmdf creates a shell command from a format string
+func NewCmdf(cmdf string, args ...interface{}) *Cmd {
+	return NewCmd(fmt.Sprintf(cmdf, args...))
+}
+
+// Run runs shell command
+func (c *Cmd) Run() error {
+	return sh.Run(c.cmd, c.args...)
+}
+
+// RunWith runs shell command with environment variables
+func (c *Cmd) RunWith(env map[string]string) error {
+	return sh.RunWith(env, c.cmd, c.args...)
+}
+
+// Output runs the command and returns text from stdout
+func (c *Cmd) Output() (string, error) {
+	return sh.Output(c.cmd, c.args...)
+}


### PR DESCRIPTION
Fixes: #1113 
Ref: #1061

Use an existing raspbian image and install package onto it instead of rebuilding raspbian from scratch with https://github.com/RPi-Distro/pi-gen

## Design notes

- Raspbian image is fetched from `raspbian` bucket and cache is size-based
- `systemd-nspawn` is used to create a lightweight container without booting it, then `bin/package/raspberry/files/setup.sh` is executed inside the container to set it up. Also tried https://github.com/proot-me/proot which didn't work.
- `ci/util/shell/cmd.go` small wrapper around mage's `sh` created to be able to pass the whole command string instead of splitting it. This is much easier to troubleshoot with shell: just copy cmd and execute (and replace `%s` with actual value in case of `Cmdf`)
- added a dependency on `aws-sdk-go-v2`, should still refactor the rest of build scripts to use it. For now it's just raspberry task that utilizes it.

## TODO

- pass env vars to systemd container
- change default username to `mystberry`