### PR TITLE
Add support of the LAN node discovery

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -365,6 +365,13 @@
   version = "0.5"
 
 [[projects]]
+  digest = "1:8f57afa9ef1d9205094e9d89b9cb4ecb3123f342c4eb0053d7631181b511e6e4"
+  name = "github.com/koron/go-ssdp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4a0ed625a78b6858dc8d3a55fb7728968b712122"
+
+[[projects]]
   digest = "1:f4e64bb62274202b95403b8ae001d0601cee01afadf60767fb0e1d239f8f1413"
   name = "github.com/magefile/mage"
   packages = [
@@ -428,6 +435,14 @@
   pruneopts = "UT"
   revision = "1a8911d1ed007260465c3bfbbc785ac6915a0bb8"
   version = "v0.4.12"
+
+[[projects]]
+  digest = "1:fc5013a7a6f9600051ad48b059fef4a3035e8692d1c54ffd8dccfaa8ebe0b505"
+  name = "github.com/miekg/dns"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ba6747e8a94115e9dc7738afb87850687611df1b"
+  version = "v1.0.12"
 
 [[projects]]
   digest = "1:c7354463195544b1ab3c1f1fadb41430947f5d28dfbf2cdbd38268c5717a5a03"
@@ -540,6 +555,13 @@
   pruneopts = "UT"
   revision = "cc3e4b2381762c56dbcdf9f93be03349a1dc1c14"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:1a0539f293ad62dd34cce1c5cc11b0aa2c1c322b2352682e22ecf5aecaf4a8bd"
+  name = "github.com/oleksandr/bonjour"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5dcf00d8b228be86307f952f550f2191d956b9e2"
 
 [[projects]]
   digest = "1:e88d6836f8adbe7e9c08e08527ec4a5337436a63e06718e023fbd9c63cda976b"
@@ -1056,6 +1078,7 @@
     "github.com/huin/goupnp/ssdp",
     "github.com/jackpal/gateway",
     "github.com/julienschmidt/httprouter",
+    "github.com/koron/go-ssdp",
     "github.com/magefile/mage/mage",
     "github.com/magefile/mage/sh",
     "github.com/mholt/archiver",
@@ -1080,6 +1103,7 @@
     "github.com/mysteriumnetwork/wireguard-go/device",
     "github.com/mysteriumnetwork/wireguard-go/tun",
     "github.com/nats-io/go-nats",
+    "github.com/oleksandr/bonjour",
     "github.com/oschwald/geoip2-golang",
     "github.com/pkg/errors",
     "github.com/songgao/water",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -149,3 +149,11 @@
 [[constraint]]
   name = "github.com/mholt/archiver"
   version = "3.1.1"
+
+[[constraint]]
+  name = "github.com/oleksandr/bonjour"
+  revision = "5dcf00d8b228be86307f952f550f2191d956b9e2"
+
+[[constraint]]
+  name = "github.com/koron/go-ssdp"
+  revision = "4a0ed625a78b6858dc8d3a55fb7728968b712122"

--- a/bin/package/installation/systemd.service
+++ b/bin/package/installation/systemd.service
@@ -14,7 +14,7 @@ RuntimeDirectoryMode=0750
 LogsDirectory=mysterium-node
 
 EnvironmentFile=-/etc/default/mysterium-node
-ExecStart=/usr/bin/myst $CONF_DIR $DATA_DIR $RUN_DIR $DAEMON_OPTS service $SERVICE_OPTS --agreed-terms-and-conditions
+ExecStart=/usr/bin/myst $CONF_DIR $DATA_DIR $RUN_DIR $BUILTIN_UI $DAEMON_OPTS service $SERVICE_OPTS --agreed-terms-and-conditions
 KillMode=process
 TimeoutStopSec=10
 SendSIGKILL=yes

--- a/bin/package/installation/systemd.service
+++ b/bin/package/installation/systemd.service
@@ -14,7 +14,7 @@ RuntimeDirectoryMode=0750
 LogsDirectory=mysterium-node
 
 EnvironmentFile=-/etc/default/mysterium-node
-ExecStart=/usr/bin/myst $CONF_DIR $DATA_DIR $RUN_DIR $BUILTIN_UI $DAEMON_OPTS service $SERVICE_OPTS --agreed-terms-and-conditions
+ExecStart=/usr/bin/myst $CONF_DIR $DATA_DIR $RUN_DIR $DAEMON_OPTS service $SERVICE_OPTS --agreed-terms-and-conditions
 KillMode=process
 TimeoutStopSec=10
 SendSIGKILL=yes

--- a/bin/package/raspberry/stagemyst/00-install-deb/files/default-myst-conf
+++ b/bin/package/raspberry/stagemyst/00-install-deb/files/default-myst-conf
@@ -2,5 +2,6 @@
 CONF_DIR="--config-dir=/etc/mysterium-node"
 RUN_DIR="--runtime-dir=/var/run/mysterium-node"
 DATA_DIR="--data-dir=/var/lib/mysterium-node"
+BUILTIN_UI="--ui.enable"
 DAEMON_OPTS="--tequilapi.address=0.0.0.0"
 SERVICE_OPTS="openvpn --access-policy.list mysterium"

--- a/bin/package/raspberry/stagemyst/00-install-deb/files/default-myst-conf
+++ b/bin/package/raspberry/stagemyst/00-install-deb/files/default-myst-conf
@@ -2,6 +2,5 @@
 CONF_DIR="--config-dir=/etc/mysterium-node"
 RUN_DIR="--runtime-dir=/var/run/mysterium-node"
 DATA_DIR="--data-dir=/var/lib/mysterium-node"
-BUILTIN_UI="--ui.enable"
 DAEMON_OPTS="--tequilapi.address=0.0.0.0"
 SERVICE_OPTS="openvpn --access-policy.list mysterium"

--- a/core/ip/resolver.go
+++ b/core/ip/resolver.go
@@ -17,8 +17,21 @@
 
 package ip
 
+import "net"
+
 // Resolver allows resolving current IP
 type Resolver interface {
 	GetPublicIP() (string, error)
 	GetOutboundIP() (string, error)
+}
+
+// GetOutbound provides an outbound IP address of the current system.
+func GetOutbound() (net.IP, error) {
+	conn, err := net.Dial("udp", "8.8.8.8:53")
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	return conn.LocalAddr().(*net.UDPAddr).IP, nil
 }

--- a/core/ip/rest_resolver.go
+++ b/core/ip/rest_resolver.go
@@ -18,7 +18,6 @@
 package ip
 
 import (
-	"net"
 	"time"
 
 	log "github.com/cihub/seelog"
@@ -71,13 +70,6 @@ func (client *clientRest) GetPublicIP() (string, error) {
 }
 
 func (client *clientRest) GetOutboundIP() (string, error) {
-	conn, err := net.Dial("udp", "8.8.8.8:53")
-	if err != nil {
-		return "", err
-	}
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
-	log.Trace("[Detect Outbound IP] ", "IP detected: ", localAddr.IP.String())
-	return localAddr.IP.String(), nil
+	ip, err := GetOutbound()
+	return ip.String(), err
 }

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       --api.address=http://mysterium-api/v1
       --ether.client.rpc=http://geth:8545
       --keystore.lightweight
+      --ui.enable
       service openvpn,noop,wireguard
       --agreed-terms-and-conditions
       --identity=0xd1a23227bd5ad77f36ba62badcb78a410a1db6c5

--- a/e2e/traversal/docker-compose.yml
+++ b/e2e/traversal/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - net.ipv4.conf.eth1.rp_filter=0
     dns: 172.30.0.254
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.10
-      public2:
+      public1:
         ipv4_address: 172.31.0.10
 
   broker:
@@ -33,9 +33,9 @@ services:
       - net.ipv4.conf.eth1.rp_filter=0
     dns: 172.30.0.254
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.30
-      public2:
+      public1:
         ipv4_address: 172.31.0.30
 
   db:
@@ -52,9 +52,9 @@ services:
       MYSQL_PASSWORD: myst_api
     dns: 172.30.0.254
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.201
-      public2:
+      public1:
         ipv4_address: 172.31.0.201
 
   geth:
@@ -90,9 +90,9 @@ services:
       - net.ipv4.conf.eth1.rp_filter=0
     dns: 172.30.0.254
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.202
-      public2:
+      public1:
         ipv4_address: 172.31.0.202
 
   mysterium-api:
@@ -121,9 +121,9 @@ services:
       - geth
     dns: 172.30.0.254
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.200
-      public2:
+      public1:
         ipv4_address: 172.31.0.200
 
   router:
@@ -135,9 +135,9 @@ services:
     environment:
       - EXT_NAT=172.30.0.1
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.254
-      public2:
+      public1:
         ipv4_address: 172.31.0.254
 
   forwarder:
@@ -151,10 +151,10 @@ services:
     environment:
       - GATEWAY=172.30.0.254
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.2
       priv1:
-        ipv4_address: 10.100.0.2
+        ipv4_address: 10.100.1.2
 
   forwarder2:
     build:
@@ -168,17 +168,17 @@ services:
       - GATEWAY=172.31.0.254
     dns: 172.31.0.254
     networks:
-      public2:
+      public1:
         ipv4_address: 172.31.0.2
-      priv2:
-        ipv4_address: 10.100.1.2
+      priv0:
+        ipv4_address: 10.100.0.2
 
   myst-consumer:
     build:
       context: ../..
       dockerfile: bin/docker/alpine/Dockerfile
     environment:
-      - DEFAULT_ROUTE=10.100.0.2
+      - DEFAULT_ROUTE=10.100.1.2
     depends_on:
       - forwarder
     cap_add:
@@ -196,14 +196,14 @@ services:
     dns: 172.30.0.254
     networks:
       priv1:
-        ipv4_address: 10.100.0.101
+        ipv4_address: 10.100.1.101
 
   myst-provider:
     build:
       context: ../..
       dockerfile: bin/docker/alpine/Dockerfile
     environment:
-      - DEFAULT_ROUTE=10.100.1.2
+      - DEFAULT_ROUTE=10.100.0.2
     depends_on:
       - forwarder2
     cap_add:
@@ -231,8 +231,8 @@ services:
       --openvpn.port=3000
     dns: 172.31.0.254
     networks:
-      priv2:
-        ipv4_address: 10.100.1.102
+      priv0:
+        ipv4_address: 10.100.0.102
 
   go-runner:
     image: golang:1.11
@@ -241,33 +241,33 @@ services:
     working_dir: /go/src/github.com/mysteriumnetwork/node
     dns: 172.30.0.254
     networks:
-      public:
+      public0:
         ipv4_address: 172.30.0.222
-      public2:
+      public1:
         ipv4_address: 172.31.0.222
-      priv1:
+      priv0:
         ipv4_address: 10.100.0.222
-      priv2:
+      priv1:
         ipv4_address: 10.100.1.222
 
 networks:
-  public:
+  public0:
     driver: "bridge"
     ipam:
       driver: default
       config:
         - subnet: 172.30.0.0/24
-  public2:
+  public1:
     driver: "bridge"
     ipam:
       config:
         - subnet: 172.31.0.0/24
-  priv1:
+  priv0:
     driver: "bridge"
     ipam:
       config:
         - subnet: 10.100.0.0/24
-  priv2:
+  priv1:
     driver: "bridge"
     ipam:
       config:

--- a/e2e/traversal/docker-compose.yml
+++ b/e2e/traversal/docker-compose.yml
@@ -223,6 +223,7 @@ services:
       --ether.client.rpc=http://geth:8545
       --ether.contract.payments=0x1955141ba8e77a5B56efBa8522034352c94f77Ea
       --keystore.lightweight
+      --ui.enable
       service openvpn
       --agreed-terms-and-conditions
       --identity=0xd1a23227bd5ad77f36ba62badcb78a410a1db6c5

--- a/e2e/ui_test.go
+++ b/e2e/ui_test.go
@@ -18,9 +18,7 @@
 package e2e
 
 import (
-	"log"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -47,10 +45,7 @@ func TestLANDiscoverySSDP(t *testing.T) {
 
 func TestLANDiscoveryBonjour(t *testing.T) {
 	resolver, err := bonjour.NewResolver(nil)
-	if err != nil {
-		log.Println("Failed to initialize resolver:", err.Error())
-		os.Exit(1)
-	}
+	assert.NoError(t, err)
 	defer func() { resolver.Exit <- true }()
 
 	results := make(chan *bonjour.ServiceEntry)

--- a/e2e/ui_test.go
+++ b/e2e/ui_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package e2e
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	ssdp "github.com/koron/go-ssdp"
+	"github.com/oleksandr/bonjour"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLANDiscoverySSDP(t *testing.T) {
+	services, err := ssdp.Search(ssdp.All, 1, "")
+	assert.NoError(t, err)
+	for _, service := range services {
+		if service.Type == "upnp:rootdevice" && strings.Contains(service.Server, "UPnP/1.1 node/") {
+			resp, err := http.Get(service.Location)
+			assert.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			return
+		}
+	}
+
+	assert.Fail(t, "No SSDP service found")
+}
+
+func TestLANDiscoveryBonjour(t *testing.T) {
+	resolver, err := bonjour.NewResolver(nil)
+	if err != nil {
+		log.Println("Failed to initialize resolver:", err.Error())
+		os.Exit(1)
+	}
+	defer func() { resolver.Exit <- true }()
+
+	results := make(chan *bonjour.ServiceEntry)
+	go resolver.Browse("_mysterium-node._tcp", "", results)
+
+	for {
+		select {
+		case <-time.After(3 * time.Second):
+			assert.Fail(t, "No Bonjour service found")
+			return
+		case <-results:
+			return
+		}
+	}
+}
+
+func TestBuiltinUIAccassable(t *testing.T) {
+	resp, err := http.Get("http://" + *providerTequilapiHost + ":4449")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/ui/discovery/discovery.go
+++ b/ui/discovery/discovery.go
@@ -18,7 +18,6 @@
 package discovery
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -36,10 +35,8 @@ type multiDiscovery struct {
 
 // NewLANDiscoveryService creates SSDP and Bonjour services for LAN discovery.
 func NewLANDiscoveryService(uiPort int) *multiDiscovery {
-	outIP := getOutboundIP()
-	url := fmt.Sprintf("http://%s:%d/", outIP, uiPort)
 	return &multiDiscovery{
-		ssdp:    newSSDPServer(url),
+		ssdp:    newSSDPServer(uiPort),
 		bonjour: newBonjourServer(uiPort),
 	}
 }

--- a/ui/discovery/discovery.go
+++ b/ui/discovery/discovery.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"fmt"
+	"sync"
+)
+
+// LANDiscovery provides local network discovery service for Mysterium Node UI.
+type LANDiscovery interface {
+	Start() error
+	Stop() error
+}
+
+type multiDiscovery struct {
+	ssdp    LANDiscovery
+	bonjour LANDiscovery
+	lock    sync.Mutex
+}
+
+// NewLANDiscoveryService creates SSDP and Bonjour services for LAN discovery.
+func NewLANDiscoveryService(uiPort int) *multiDiscovery {
+	outIP := getOutboundIP()
+	url := fmt.Sprintf("http://%s:%d/", outIP, uiPort)
+	return &multiDiscovery{
+		ssdp:    newSSDPServer(url),
+		bonjour: newBonjourServer(uiPort),
+	}
+}
+
+func (md *multiDiscovery) Start() error {
+	if err := md.bonjour.Start(); err != nil {
+		return err
+	}
+
+	return md.ssdp.Start()
+}
+
+func (md *multiDiscovery) Stop() error {
+	// bonjour Stop does not return any error, nothing to check
+	_ = md.bonjour.Stop()
+	return md.ssdp.Stop()
+}

--- a/ui/discovery/discovery_test.go
+++ b/ui/discovery/discovery_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDiscovery struct {
+	err     error
+	started bool
+	stopped bool
+}
+
+func (md *mockDiscovery) Start() error {
+	md.started = true
+	return md.err
+}
+
+func (md *mockDiscovery) Stop() error {
+	md.stopped = true
+	return md.err
+}
+
+func Test_multiDiscovery_StartsAll(t *testing.T) {
+	d1 := &mockDiscovery{}
+	d2 := &mockDiscovery{}
+
+	md := multiDiscovery{
+		bonjour: d1,
+		ssdp:    d2,
+	}
+
+	err := md.Start()
+	assert.NoError(t, err)
+
+	assert.True(t, d1.started)
+	assert.True(t, d2.started)
+}
+
+func Test_multiDiscovery_StartsWithError(t *testing.T) {
+	d1 := &mockDiscovery{err: errors.New("error1")}
+	d2 := &mockDiscovery{err: errors.New("error2")}
+
+	md := multiDiscovery{
+		bonjour: d1,
+		ssdp:    d2,
+	}
+
+	err := md.Start()
+	assert.EqualError(t, err, "error1")
+
+	assert.True(t, d1.started)
+	assert.False(t, d2.started)
+}
+
+func Test_multiDiscovery_StopsAll(t *testing.T) {
+	d1 := &mockDiscovery{}
+	d2 := &mockDiscovery{}
+
+	md := multiDiscovery{
+		bonjour: d1,
+		ssdp:    d2,
+	}
+
+	err := md.Stop()
+	assert.NoError(t, err)
+
+	assert.True(t, d1.stopped)
+	assert.True(t, d2.stopped)
+}
+
+func Test_multiDiscovery_StopsWithError(t *testing.T) {
+	d1 := &mockDiscovery{err: errors.New("error1")}
+	d2 := &mockDiscovery{err: errors.New("error2")}
+
+	md := multiDiscovery{
+		bonjour: d1,
+		ssdp:    d2,
+	}
+
+	err := md.Stop()
+	assert.EqualError(t, err, "error2")
+
+	assert.True(t, d1.stopped)
+	assert.True(t, d2.stopped)
+}

--- a/ui/discovery/ssdp.go
+++ b/ui/discovery/ssdp.go
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"runtime"
+	"sync"
+	"text/template"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/gofrs/uuid"
+	"github.com/koron/go-ssdp"
+	"github.com/mysteriumnetwork/node/metadata"
+	"github.com/pkg/errors"
+)
+
+const ssdpLogPrefix = "[SSDP] "
+
+const deviceDescriptionTemplate = `<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0" configId="1">
+	<specVersion>
+		<major>1</major>
+		<minor>1</minor>
+	</specVersion>
+	<device>
+		<deviceType>urn:schemas-upnp-org:device:node:1</deviceType>
+		<friendlyName>Mysterium Node</friendlyName>
+
+		<manufacturer>Mysterium Network</manufacturer>
+		<manufacturerURL>https://mysterium.network/</manufacturerURL>
+
+		<modelName>Raspberry Node</modelName>
+		<modelNumber>{{.Version}}</modelNumber>
+		<modelURL>https://mysterium.network/node/</modelURL>
+
+		<serialNumber>1234</serialNumber>
+		<UDN>uuid:{{.UUID}}</UDN>
+		<presentationURL>{{.URL}}</presentationURL>
+	</device>
+</root>`
+
+type ssdpServer struct {
+	url  string
+	uuid string
+	ssdp *ssdp.Advertiser
+	quit chan struct{}
+	once sync.Once
+}
+
+func newSSDPServer(url string) *ssdpServer {
+	return &ssdpServer{
+		url:  url,
+		quit: make(chan struct{}),
+	}
+}
+
+func (ss *ssdpServer) Start() (err error) {
+	ss.uuid, err = generateUUID()
+	if err != nil {
+		return errors.Wrap(err, "failed to generate new UUID")
+	}
+
+	url, err := ss.serveDeviceDescriptionDocument()
+	if err != nil {
+		return errors.Wrap(err, "failed to serve device description document")
+	}
+
+	ss.ssdp, err = ssdp.Advertise(
+		"upnp:rootdevice",                   // ST: Type
+		"uuid:"+ss.uuid+"::upnp:rootdevice", // USN: ID
+		url.String(),                        // LOCATION: location header
+		runtime.GOOS+" UPnP/1.1 node/"+metadata.VersionAsString(), // SERVER: server header
+		1800) // cache control, max-age
+	if err != nil {
+		return errors.Wrap(err, "failed to start SSDP advertiser")
+	}
+
+	for {
+		select {
+		case <-time.After(30 * time.Second):
+			if err := ss.ssdp.Alive(); err != nil {
+				log.Warn(ssdpLogPrefix, "failed to sent SSDP Alive message: ", err)
+			}
+		case <-ss.quit:
+			return nil
+		}
+	}
+}
+
+func (ss *ssdpServer) Stop() error {
+	ss.once.Do(func() {
+		close(ss.quit)
+	})
+
+	if err := ss.ssdp.Bye(); err != nil {
+		log.Error(ssdpLogPrefix, "failed to send SSDP bye message", err)
+	}
+
+	return errors.Wrap(ss.ssdp.Close(), "failed to send SSDP bye message")
+}
+
+func (ss *ssdpServer) serveDeviceDescriptionDocument() (url.URL, error) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	deviceDoc := ss.deviceDescription()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, deviceDoc)
+	})
+
+	go func() {
+		go http.Serve(listener, mux)
+		<-ss.quit
+		listener.Close()
+	}()
+
+	host := getOutboundIP()
+	port := listener.Addr().(*net.TCPAddr).Port
+	return url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s:%d", host, port),
+	}, nil
+}
+
+func (ss *ssdpServer) deviceDescription() string {
+	var buf bytes.Buffer
+	deviceDescription := template.Must(template.New("SSDPDeviceDescription").Parse(deviceDescriptionTemplate))
+	_ = deviceDescription.Execute(&buf,
+		struct{ URL, Version, UUID string }{
+			ss.url,
+			metadata.VersionAsString(),
+			ss.uuid,
+		})
+
+	return buf.String()
+}
+
+func getOutboundIP() net.IP {
+	conn, err := net.Dial("udp", "8.8.8.8:53")
+	if err != nil {
+		log.Error(ssdpLogPrefix, "Failed to get Outbound IP: ", err)
+		return nil
+	}
+	defer conn.Close()
+
+	return conn.LocalAddr().(*net.UDPAddr).IP
+}
+
+func generateUUID() (string, error) {
+	uid, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+
+	return uid.String(), nil
+}


### PR DESCRIPTION
There are two protocols available right now: SSDP and Bonjour.
LAN discovery starts with a built-in UI server.
Closes: https://github.com/mysteriumnetwork/node/issues/1116