### PR TITLE
Raspberry fix: do apt update before running install

### DIFF
--- a/ci/packages/raspberry.go
+++ b/ci/packages/raspberry.go
@@ -84,6 +84,9 @@ func configureRaspbianImage(raspbianImagePath string) error {
 		"DEBIAN_FRONTEND": "noninteractive",
 	}
 
+	if err := shell.NewCmd("sudo apt-get update").Run(); err != nil {
+		return err
+	}
 	if err := shell.NewCmd("sudo apt-get install -y qemu qemu-user-static binfmt-support systemd-container").RunWith(envs); err != nil {
 		return err
 	}


### PR DESCRIPTION
Encountered errors on linode runners:
https://gitlab.com/mysteriumnetwork/node/-/jobs/228131727

To avoid missing package errors, e.g.:
```
E: Failed to fetch http://mirrors.linode.com/debian-security/pool/updates/main/q/qemu/qemu-system-common_2.8+dfsg-6+deb9u6_amd64.deb  404  Not Found [IP: 2a01:7e01:1::8ba2:8ce8 80]
E: Failed to fetch http://mirrors.linode.com/debian-security/pool/updates/main/q/qemu/qemu-system-arm_2.8+dfsg-6+deb9u6_amd64.deb  404  Not Found [IP: 2a01:7e01:1::8ba2:8ce8 80]
E: Failed to fetch http://mirrors.linode.com/debian-security/pool/updates/main/q/qemu/qemu-system-mips_2.8+dfsg-6+deb9u6_amd64.deb  404  Not Found [IP: 2a01:7e01:1::8ba2:8ce8 80]
```