### PR TITLE
the ui will not get included in mobile entrypoint anymore

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -81,7 +81,6 @@ import (
 	"github.com/mysteriumnetwork/node/tequilapi"
 	tequilapi_endpoints "github.com/mysteriumnetwork/node/tequilapi/endpoints"
 	"github.com/mysteriumnetwork/node/tequilapi/sse"
-	"github.com/mysteriumnetwork/node/ui"
 	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
 )
@@ -374,15 +373,6 @@ func (di *Dependencies) bootstrapStorage(path string) error {
 
 	di.Storage = localStorage
 	return nil
-}
-
-func (di *Dependencies) bootstrapUIServer(options node.OptionsUI) {
-	if options.UIEnabled {
-		di.UIServer = ui.NewServer(options.UIPort)
-		return
-	}
-
-	di.UIServer = ui.NewNoopServer()
 }
 
 func (di *Dependencies) subscribeEventConsumers() error {

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -42,6 +42,8 @@ import (
 	wireguard_connection "github.com/mysteriumnetwork/node/services/wireguard/connection"
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/mysteriumnetwork/node/session"
+	"github.com/mysteriumnetwork/node/ui"
+	uinoop "github.com/mysteriumnetwork/node/ui/noop"
 )
 
 // bootstrapServices loads all the components required for running services
@@ -252,4 +254,13 @@ func (di *Dependencies) registerConnections(nodeOptions node.Options) {
 func (di *Dependencies) registerWireguardConnection() {
 	wireguard.Bootstrap()
 	di.ConnectionRegistry.Register(wireguard.ServiceType, wireguard_connection.NewConnectionCreator())
+}
+
+func (di *Dependencies) bootstrapUIServer(options node.OptionsUI) {
+	if options.UIEnabled {
+		di.UIServer = ui.NewServer(options.UIPort)
+		return
+	}
+
+	di.UIServer = uinoop.NewServer()
 }

--- a/cmd/di_mobile.go
+++ b/cmd/di_mobile.go
@@ -21,6 +21,7 @@ package cmd
 
 import (
 	"github.com/mysteriumnetwork/node/core/node"
+	"github.com/mysteriumnetwork/node/ui/noop"
 )
 
 // bootstrapServices loads all the components required for running services
@@ -30,4 +31,8 @@ func (di *Dependencies) bootstrapServices(nodeOptions node.Options) {
 
 func (di *Dependencies) registerConnections(nodeOptions node.Options) {
 	di.registerNoopConnection()
+}
+
+func (di *Dependencies) bootstrapUIServer(options node.OptionsUI) {
+	di.UIServer = noop.NewServer()
 }

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -50,13 +50,13 @@ func (dt *debounceTester) get() int {
 
 func Test_Debounce_CallsOnceInInterval(t *testing.T) {
 	dt := &debounceTester{}
-	duration := time.Microsecond * 1000
+	duration := time.Millisecond * 10
 	f := debounce(dt.do, duration)
 	for i := 1; i < 10; i++ {
 		f(struct{}{})
 	}
 
-	time.Sleep(duration * 5)
+	time.Sleep(duration * 2)
 	assert.Equal(t, 1, dt.get())
 }
 

--- a/session/storage_memory_test.go
+++ b/session/storage_memory_test.go
@@ -122,9 +122,9 @@ func TestStorage_PublishesEventsOnCreate(t *testing.T) {
 
 	// since we're shooting the event in an asynchronous fashion, try every millisecond to see if we already have it
 	attempts := 0
-	for range time.After(time.Microsecond) {
-		if attempts > 1000 {
-			assert.Fail(t, "no change after a 1000 attempts")
+	for range time.After(time.Millisecond) {
+		if attempts > 50 {
+			assert.Fail(t, "no change after a 50 attempts")
 			break
 		}
 		attempts++
@@ -152,9 +152,9 @@ func TestStorage_PublishesEventsOnDelete(t *testing.T) {
 	// since we're shooting the event in an asynchronous fashion, try every microsecond to see if we already have it
 	attempts := 0
 
-	for range time.After(time.Microsecond) {
-		if attempts > 1000 {
-			assert.Fail(t, "no change after a 1000 attempts")
+	for range time.After(time.Millisecond) {
+		if attempts > 50 {
+			assert.Fail(t, "no change after a 50 attempts")
 			break
 		}
 		attempts++

--- a/ui/noop/noop.go
+++ b/ui/noop/noop.go
@@ -15,30 +15,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ui
+package noop
 
 import "sync"
 
-// NoopServer doesn't do much really
-type NoopServer struct {
+// Server doesn't do much really
+type Server struct {
 	iSimulateWork chan error
 	once          sync.Once
 }
 
-// NewNoopServer returns a new noop server
-func NewNoopServer() *NoopServer {
-	return &NoopServer{
+// NewServer returns a new noop server
+func NewServer() *Server {
+	return &Server{
 		iSimulateWork: make(chan error),
 	}
 }
 
 // Serve blocks
-func (s *NoopServer) Serve() error {
+func (s *Server) Serve() error {
 	return <-s.iSimulateWork
 }
 
 // Stop stops the blocking of serve
-func (s *NoopServer) Stop() {
+func (s *Server) Stop() {
 	s.once.Do(func() {
 		close(s.iSimulateWork)
 	})


### PR DESCRIPTION
Split noop to its own package and include it in mobile di. This way the main server does not get included and the mobile binary does not get bloated.