### PR TITLE
Openvpn server now reports session data transfer statistics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -479,7 +479,7 @@
   version = "0.0.7"
 
 [[projects]]
-  digest = "1:722ca4885d4c2a54e87e065857d59414791f4b3b775ad024039232a7c4832438"
+  digest = "1:4d5402ba3b77f26c810297827842889cf315bfc7a64ff7a0e6a477e2bf1823ce"
   name = "github.com/mysteriumnetwork/go-openvpn"
   packages = [
     "openvpn",
@@ -488,14 +488,15 @@
     "openvpn/middlewares/client/auth",
     "openvpn/middlewares/client/bytescount",
     "openvpn/middlewares/server/auth",
+    "openvpn/middlewares/server/bytecount",
     "openvpn/middlewares/state",
     "openvpn/tls",
     "openvpn/tunnel",
     "openvpn3",
   ]
   pruneopts = "T"
-  revision = "123097496fe71e64e9f5752127a257e3dce0631b"
-  version = "0.0.13"
+  revision = "39a3593d80f134010ecf7505eed440f070f7e575"
+  version = "0.0.14"
 
 [[projects]]
   digest = "1:8a20b209f06b19844908cf0367975d0966d6c188e5381ebd9327d6cd5d2ab990"
@@ -1092,6 +1093,7 @@
     "github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/client/auth",
     "github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/client/bytescount",
     "github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/auth",
+    "github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/bytecount",
     "github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/state",
     "github.com/mysteriumnetwork/go-openvpn/openvpn/tls",
     "github.com/mysteriumnetwork/go-openvpn/openvpn3",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@
 
 [[constraint]]
   name = "github.com/mysteriumnetwork/go-openvpn"
-  version = "0.0.13"
+  version = "0.0.14"
 
 [prune]
   go-tests = true

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -20,8 +20,6 @@
 package cmd
 
 import (
-	"errors"
-
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
 	nats_dialog "github.com/mysteriumnetwork/node/communication/nats/dialog"
@@ -44,15 +42,21 @@ import (
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/mysteriumnetwork/node/ui"
 	uinoop "github.com/mysteriumnetwork/node/ui/noop"
+	"github.com/pkg/errors"
 )
 
 // bootstrapServices loads all the components required for running services
-func (di *Dependencies) bootstrapServices(nodeOptions node.Options) {
-	di.bootstrapServiceComponents(nodeOptions)
+func (di *Dependencies) bootstrapServices(nodeOptions node.Options) error {
+	err := di.bootstrapServiceComponents(nodeOptions)
+	if err != nil {
+		return errors.Wrap(err, "service bootstrap failed")
+	}
 
 	di.bootstrapServiceOpenvpn(nodeOptions)
 	di.bootstrapServiceNoop(nodeOptions)
 	di.bootstrapServiceWireguard(nodeOptions)
+
+	return nil
 }
 
 func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options) {
@@ -178,13 +182,19 @@ func (di *Dependencies) bootstrapServiceNoop(nodeOptions node.Options) {
 }
 
 // bootstrapServiceComponents initiates ServicesManager dependency
-func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) {
+func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) error {
 	di.NATService = nat.NewService()
 	if err := di.NATService.Enable(); err != nil {
 		log.Warn(logPrefix, "Failed to enable NAT forwarding: ", err)
 	}
 	di.ServiceRegistry = service.NewRegistry()
-	di.ServiceSessionStorage = session.NewStorageMemory(di.EventBus)
+	storage := session.NewEventBasedStorage(di.EventBus, session.NewStorageMemory())
+	di.ServiceSessionStorage = storage
+
+	err := storage.Subscribe()
+	if err != nil {
+		return errors.Wrap(err, "could not bootstrap service components")
+	}
 
 	registeredIdentityValidator := func(peerID identity.Identity) error {
 		registered, err := di.IdentityRegistry.IsRegistered(peerID)
@@ -244,6 +254,8 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) {
 	if err := di.EventBus.Subscribe(service.StatusTopic, serviceCleaner.HandleServiceStatus); err != nil {
 		log.Error(logPrefix, "failed to subscribe service cleaner")
 	}
+
+	return nil
 }
 
 func (di *Dependencies) registerConnections(nodeOptions node.Options) {

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -156,6 +156,7 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 			mapPort,
 			di.NATTracker,
 			portPool,
+			di.EventBus,
 		)
 		return manager, proposal, nil
 	}

--- a/cmd/di_mobile.go
+++ b/cmd/di_mobile.go
@@ -25,8 +25,9 @@ import (
 )
 
 // bootstrapServices loads all the components required for running services
-func (di *Dependencies) bootstrapServices(nodeOptions node.Options) {
+func (di *Dependencies) bootstrapServices(nodeOptions node.Options) error {
 	// Running services on mobile is not supported, nothing to bootstrap.
+	return nil
 }
 
 func (di *Dependencies) registerConnections(nodeOptions node.Options) {

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -62,7 +62,7 @@ type ServiceSession struct {
 	// example: 2019-06-06T11:04:43.910035Z
 	CreatedAt time.Time `json:"createdAt"`
 	// example: 12345
-	BytesUp int64 `json:"bytesUp"`
+	BytesOut int64 `json:"bytesOut"`
 	// example: 23451
-	BytesDown int64 `json:"bytesDown"`
+	BytesIn int64 `json:"bytesIn"`
 }

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -61,4 +61,8 @@ type ServiceSession struct {
 	ConsumerID string `json:"consumerId"`
 	// example: 2019-06-06T11:04:43.910035Z
 	CreatedAt time.Time `json:"createdAt"`
+	// example: 12345
+	BytesUp int64 `json:"bytesUp"`
+	// example: 23451
+	BytesDown int64 `json:"bytesDown"`
 }

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -145,8 +145,8 @@ func (k *Keeper) updateSessionState(_ interface{}) {
 			ID:         string(sessions[i].ID),
 			ConsumerID: sessions[i].ConsumerID.Address,
 			CreatedAt:  sessions[i].CreatedAt,
-			BytesUp:    sessions[i].DataTransfered.Up,
-			BytesDown:  sessions[i].DataTransfered.Down,
+			BytesOut:   sessions[i].DataTransfered.Up,
+			BytesIn:    sessions[i].DataTransfered.Down,
 		}
 	}
 

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -145,6 +145,8 @@ func (k *Keeper) updateSessionState(_ interface{}) {
 			ID:         string(sessions[i].ID),
 			ConsumerID: sessions[i].ConsumerID.Address,
 			CreatedAt:  sessions[i].CreatedAt,
+			BytesUp:    sessions[i].DataTransfered.Up,
+			BytesDown:  sessions[i].DataTransfered.Down,
 		}
 	}
 

--- a/services/openvpn/session/client_map.go
+++ b/services/openvpn/session/client_map.go
@@ -39,6 +39,14 @@ type clientMap struct {
 	sessionMapLock   sync.Mutex
 }
 
+// NewClientMap creates a new instance of client map
+func NewClientMap(sessionMap SessionMap) *clientMap {
+	return &clientMap{
+		sessions:         sessionMap,
+		sessionClientIDs: make(map[session.ID]int),
+	}
+}
+
 // FindClientSession returns OpenVPN session instance by given session id
 func (cm *clientMap) FindClientSession(clientID int, id session.ID) (session.Session, bool, error) {
 	cm.sessionMapLock.Lock()
@@ -65,6 +73,20 @@ func (cm *clientMap) UpdateClientSession(clientID int, id session.ID) bool {
 	}
 
 	return cm.sessionClientIDs[id] == clientID
+}
+
+// GetClientSessions returns the list of sessions for client found in the client map
+func (cm *clientMap) GetClientSessions(clientID int) []session.ID {
+	cm.sessionMapLock.Lock()
+	defer cm.sessionMapLock.Unlock()
+	res := make([]session.ID, 0)
+
+	for k, v := range cm.sessionClientIDs {
+		if v == clientID {
+			res = append(res, k)
+		}
+	}
+	return res
 }
 
 // RemoveSession removes given session from underlying session managers

--- a/services/openvpn/session/validator.go
+++ b/services/openvpn/session/validator.go
@@ -18,8 +18,6 @@
 package session
 
 import (
-	"sync"
-
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/session"
 )
@@ -34,13 +32,9 @@ type Validator struct {
 }
 
 // NewValidator return Validator instance
-func NewValidator(sessionMap SessionMap, extractor identity.Extractor) *Validator {
+func NewValidator(clientMap *clientMap, extractor identity.Extractor) *Validator {
 	return &Validator{
-		clientMap: &clientMap{
-			sessions:         sessionMap,
-			sessionClientIDs: make(map[session.ID]int),
-			sessionMapLock:   sync.Mutex{},
-		},
+		clientMap:         clientMap,
 		identityExtractor: extractor,
 	}
 }

--- a/services/openvpn/session/validator_mocks.go
+++ b/services/openvpn/session/validator_mocks.go
@@ -31,7 +31,7 @@ func mockValidator(identityToExtract identity.Identity) *Validator {
 		session.Session{},
 		false,
 	}
-	return NewValidator(mockSessions, mockExtractor)
+	return NewValidator(NewClientMap(mockSessions), mockExtractor)
 }
 
 func mockValidatorWithSession(identityToExtract identity.Identity, sessionInstance session.Session) *Validator {
@@ -43,7 +43,7 @@ func mockValidatorWithSession(identityToExtract identity.Identity, sessionInstan
 		sessionInstance,
 		true,
 	}
-	return NewValidator(mockSessions, mockExtractor)
+	return NewValidator(NewClientMap(mockSessions), mockExtractor)
 }
 
 // mockIdentityExtractor mocked identity extractor

--- a/session/dto.go
+++ b/session/dto.go
@@ -32,15 +32,21 @@ type BalanceTracker interface {
 	Stop()
 }
 
+// DataTransfered represents the data transfered on each session
+type DataTransfered struct {
+	Up, Down int64
+}
+
 // Session structure holds all required information about current session between service consumer and provider
 type Session struct {
-	ID         ID
-	ConsumerID identity.Identity
-	Config     ServiceConfiguration
-	serviceID  string
-	CreatedAt  time.Time
-	Last       bool
-	done       chan struct{}
+	ID             ID
+	ConsumerID     identity.Identity
+	Config         ServiceConfiguration
+	serviceID      string
+	CreatedAt      time.Time
+	DataTransfered DataTransfered
+	Last           bool
+	done           chan struct{}
 }
 
 // ServiceConfiguration defines service configuration from underlying transport mechanism to be passed to remote party

--- a/session/event/event.go
+++ b/session/event/event.go
@@ -20,6 +20,15 @@ package event
 // Topic represents the session change topic
 const Topic = "Session change"
 
+// DataTransfered represents the data transfer topic
+const DataTransfered = "Session data transfered"
+
+// DataTransferEventPayload represents the data transfer event
+type DataTransferEventPayload struct {
+	ID       string
+	Up, Down int64
+}
+
 // Action represents the different actions that might happen on a session
 type Action string
 
@@ -28,6 +37,8 @@ const (
 	Created Action = "Created"
 	// Removed indicates a session has been removed
 	Removed Action = "Removed"
+	// Updated indicates a session has been updated
+	Updated Action = "Updated"
 )
 
 // Payload represents the event payload

--- a/session/event_based_storage.go
+++ b/session/event_based_storage.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package session
+
+import "github.com/mysteriumnetwork/node/session/event"
+
+type eventPublisher interface {
+	Publish(topic string, data interface{})
+	SubscribeAsync(topic string, f interface{}) error
+}
+
+type storage interface {
+	Add(sessionInstance Session)
+	GetAll() []Session
+	UpdateDataTransfer(id ID, up, down int64)
+	Find(id ID) (Session, bool)
+	Remove(id ID)
+	RemoveForService(serviceID string)
+}
+
+// EventBasedStorage wraps storage methods and adds relevant event pub/sub where required
+type EventBasedStorage struct {
+	bus     eventPublisher
+	storage storage
+}
+
+// NewEventBasedStorage returns a new instance of event based storage
+func NewEventBasedStorage(bus eventPublisher, storage storage) *EventBasedStorage {
+	return &EventBasedStorage{
+		bus:     bus,
+		storage: storage,
+	}
+}
+
+// Add adds a session and publishes a creation event
+func (ebs *EventBasedStorage) Add(sessionInstance Session) {
+	ebs.storage.Add(sessionInstance)
+	go ebs.bus.Publish(event.Topic, event.Payload{
+		ID:     string(sessionInstance.ID),
+		Action: event.Created,
+	})
+}
+
+// GetAll returns all sessions
+func (ebs *EventBasedStorage) GetAll() []Session {
+	return ebs.storage.GetAll()
+}
+
+func (ebs *EventBasedStorage) consumeDataTransferedEvent(e event.DataTransferEventPayload) {
+	// From a server perspective, bytes up are the actual bytes the client downloaded(aka the bytes we pushed to the consumer)
+	// To lessen the confusion, I suggest having the bytes reversed on the session instance.
+	// This way, the session will show that it downloaded the bytes in a manner that is easier to comprehend.
+	ebs.UpdateDataTransfer(ID(e.ID), e.Down, e.Up)
+}
+
+// UpdateDataTransfer updates the data transfer for a session
+func (ebs *EventBasedStorage) UpdateDataTransfer(id ID, up, down int64) {
+	ebs.storage.UpdateDataTransfer(id, up, down)
+	go ebs.bus.Publish(event.Topic, event.Payload{
+		ID:     string(id),
+		Action: event.Updated,
+	})
+}
+
+// Find finds a session
+func (ebs *EventBasedStorage) Find(id ID) (Session, bool) {
+	return ebs.storage.Find(id)
+}
+
+// Remove removes the session and publishes a removal event
+func (ebs *EventBasedStorage) Remove(id ID) {
+	ebs.storage.Remove(id)
+	go ebs.bus.Publish(event.Topic, event.Payload{
+		ID:     string(id),
+		Action: event.Removed,
+	})
+}
+
+// RemoveForService removes all the sessions for a service and publishes a delete event
+func (ebs *EventBasedStorage) RemoveForService(serviceID string) {
+	ebs.storage.RemoveForService(serviceID)
+	go ebs.bus.Publish(event.Topic, event.Payload{
+		ID:     "",
+		Action: event.Removed,
+	})
+}
+
+// Subscribe subscribes the ebs to relevant events
+func (ebs *EventBasedStorage) Subscribe() error {
+	return ebs.bus.SubscribeAsync(event.DataTransfered, ebs.consumeDataTransferedEvent)
+}

--- a/session/event_based_storage_test.go
+++ b/session/event_based_storage_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package session
+
+import (
+	"testing"
+	"time"
+
+	sessionEvent "github.com/mysteriumnetwork/node/session/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventBasedStorage_PublishesEventsOnCreate(t *testing.T) {
+	instance := expectedSession
+	mp := &mockPublisher{}
+	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
+
+	sessionStore.Add(instance)
+
+	// since we're shooting the event in an asynchronous fashion, try every millisecond to see if we already have it
+	attempts := 0
+	for range time.After(time.Millisecond) {
+		if attempts > 50 {
+			assert.Fail(t, "no change after a 50 attempts")
+			break
+		}
+		attempts++
+		if mp.getLast().Action == sessionEvent.Created {
+			break
+		}
+	}
+
+	assert.Equal(t, sessionEvent.Payload{
+		Action: sessionEvent.Created,
+		ID:     string(expectedID),
+	}, mp.published)
+}
+
+func TestEventBasedStorage_PublishesEventsOnDelete(t *testing.T) {
+	instance := expectedSession
+	mp := &mockPublisher{}
+	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
+	sessionStore.Add(instance)
+
+	time.Sleep(time.Millisecond * 5)
+
+	sessionStore.Remove(instance.ID)
+
+	// since we're shooting the event in an asynchronous fashion, try every microsecond to see if we already have it
+	attempts := 0
+
+	for range time.After(time.Millisecond) {
+		if attempts > 50 {
+			assert.Fail(t, "no change after a 50 attempts")
+			break
+		}
+		attempts++
+		t.Log("attempts", attempts)
+		if mp.getLast().Action == sessionEvent.Removed {
+			break
+		}
+	}
+
+	assert.Equal(t, sessionEvent.Payload{
+		Action: sessionEvent.Removed,
+		ID:     string(expectedID),
+	}, mp.published)
+}
+
+func TestEventBasedStorage_PublishesEventsOnDataTransferUpdate(t *testing.T) {
+	instance := expectedSession
+	mp := &mockPublisher{}
+	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
+	sessionStore.Add(instance)
+
+	time.Sleep(time.Millisecond * 5)
+
+	sessionStore.UpdateDataTransfer(instance.ID, 1, 2)
+
+	// since we're shooting the event in an asynchronous fashion, try every microsecond to see if we already have it
+	attempts := 0
+
+	for range time.After(time.Millisecond) {
+		if attempts > 50 {
+			assert.Fail(t, "no change after a 50 attempts")
+			break
+		}
+		attempts++
+		t.Log("attempts", attempts)
+		if mp.getLast().Action == sessionEvent.Updated {
+			break
+		}
+	}
+
+	assert.Equal(t, sessionEvent.Payload{
+		Action: sessionEvent.Updated,
+		ID:     string(expectedID),
+	}, mp.published)
+}
+
+func TestEventBasedStorage_PublishesEventsOnRemoveForService(t *testing.T) {
+	instance := expectedSession
+	mp := &mockPublisher{}
+	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
+	sessionStore.Add(instance)
+
+	time.Sleep(time.Millisecond * 5)
+
+	sessionStore.RemoveForService("whatever")
+
+	// since we're shooting the event in an asynchronous fashion, try every microsecond to see if we already have it
+	attempts := 0
+
+	for range time.After(time.Millisecond) {
+		if attempts > 50 {
+			assert.Fail(t, "no change after a 50 attempts")
+			break
+		}
+		attempts++
+		t.Log("attempts", attempts)
+		if mp.getLast().Action == sessionEvent.Removed {
+			break
+		}
+	}
+
+	assert.Equal(t, sessionEvent.Payload{
+		Action: sessionEvent.Removed,
+		ID:     "",
+	}, mp.published)
+}

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -54,6 +54,10 @@ func (mp *mockPublisher) Publish(topic string, data interface{}) {
 	mp.lock.Unlock()
 }
 
+func (mp *mockPublisher) SubscribeAsync(topic string, f interface{}) error {
+	return nil
+}
+
 func (mp *mockPublisher) getLast() sessionEvent.Payload {
 	mp.lock.Lock()
 	defer mp.lock.Unlock()

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -50,8 +50,8 @@ type mockPublisher struct {
 
 func (mp *mockPublisher) Publish(topic string, data interface{}) {
 	mp.lock.Lock()
+	defer mp.lock.Unlock()
 	mp.published = data.(sessionEvent.Payload)
-	mp.lock.Unlock()
 }
 
 func (mp *mockPublisher) SubscribeAsync(topic string, f interface{}) error {
@@ -87,8 +87,7 @@ func mockBalanceTrackerFactory(consumer, provider, issuer identity.Identity) (Ba
 func TestManager_Create_StoresSession(t *testing.T) {
 	expectedResult := expectedSession
 
-	mp := &mockPublisher{}
-	sessionStore := NewStorageMemory(mp)
+	sessionStore := NewStorageMemory()
 
 	natPinger := func(*traversal.Params) {}
 
@@ -109,7 +108,7 @@ func TestManager_Create_StoresSession(t *testing.T) {
 }
 
 func TestManager_Create_RejectsUnknownProposal(t *testing.T) {
-	sessionStore := NewStorageMemory(&mockPublisher{})
+	sessionStore := NewStorageMemory()
 	natPinger := func(*traversal.Params) {}
 
 	manager := NewManager(currentProposal, generateSessionID, sessionStore, mockBalanceTrackerFactory, natPinger,

--- a/session/storage_memory_test.go
+++ b/session/storage_memory_test.go
@@ -94,8 +94,8 @@ func TestStorage_Remove(t *testing.T) {
 
 func TestStorage_RemoveNonExisting(t *testing.T) {
 	storage := &StorageMemory{
-		sessions:  map[ID]Session{},
-		publisher: &mockPublisher{},
+		sessions: map[ID]Session{},
+		bus:      &mockPublisher{},
 	}
 	storage.Remove(sessionExisting.ID)
 	assert.Len(t, storage.sessions, 0)
@@ -171,8 +171,8 @@ func TestStorage_PublishesEventsOnDelete(t *testing.T) {
 
 func mockStorage(sessionInstance Session) *StorageMemory {
 	return &StorageMemory{
-		sessions:  map[ID]Session{sessionInstance.ID: sessionInstance},
-		publisher: &mockPublisher{},
+		sessions: map[ID]Session{sessionInstance.ID: sessionInstance},
+		bus:      &mockPublisher{},
 	}
 }
 


### PR DESCRIPTION
The openvpn service will now publish events on statistics data change. These will trigger an event in the session storage, which will in turn update the required session. It will notify all the subscribers of a session change after that. This will in turn update the state and push the change through the events endpoint via sse.