### PR TITLE
Move QualityOracle code to 'core/quality' package

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -157,10 +157,9 @@ type UIServer interface {
 type Dependencies struct {
 	Node *node.Node
 
-	NetworkDefinition    metadata.NetworkDefinition
-	MysteriumAPI         *mysterium.MysteriumAPI
-	MysteriumMorqaClient *quality.MysteriumMORQA
-	EtherClient          *ethclient.Client
+	NetworkDefinition metadata.NetworkDefinition
+	MysteriumAPI      *mysterium.MysteriumAPI
+	EtherClient       *ethclient.Client
 
 	NATService           nat.NATService
 	Storage              Storage
@@ -177,6 +176,7 @@ type Dependencies struct {
 	DiscoveryFetcherAPI *discovery_api.Fetcher
 
 	QualityMetricsSender *quality.Sender
+	QualityClient        *quality.MysteriumMORQA
 
 	IPResolver       ip.Resolver
 	LocationResolver CacheResolver
@@ -460,7 +460,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 	tequilapi_endpoints.AddRoutesForConnectionSessions(router, di.SessionStorage)
 	tequilapi_endpoints.AddRoutesForConnectionLocation(router, di.ConnectionManager, di.LocationResolver)
 	tequilapi_endpoints.AddRoutesForLocation(router, di.LocationResolver)
-	tequilapi_endpoints.AddRoutesForProposals(router, di.DiscoveryFinder, di.MysteriumMorqaClient)
+	tequilapi_endpoints.AddRoutesForProposals(router, di.DiscoveryFinder, di.QualityClient)
 	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, serviceTypesRequestParser, nodeOptions.AccessPolicyEndpointAddress)
 	tequilapi_endpoints.AddRoutesForServiceSessions(router, di.StateKeeper)
 	tequilapi_endpoints.AddRoutesForPayout(router, di.IdentityManager, di.SignerFactory, di.MysteriumAPI)
@@ -537,6 +537,10 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 		network.MysteriumAPIAddress = options.MysteriumAPIAddress
 	}
 
+	if options.QualityOracle != metadata.DefaultNetwork.QualityOracle {
+		network.QualityOracle = options.QualityOracle
+	}
+
 	if options.BrokerAddress != metadata.DefaultNetwork.BrokerAddress {
 		network.BrokerAddress = options.BrokerAddress
 	}
@@ -555,13 +559,11 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 	if _, err := firewall.AllowURLAccess(
 		network.EtherClientRPC,
 		network.MysteriumAPIAddress,
-		network.QualityOracle,
 	); err != nil {
 		return err
 	}
 
 	di.MysteriumAPI = mysterium.NewClient(network.MysteriumAPIAddress)
-	di.MysteriumMorqaClient = quality.NewMorqaClient(network.QualityOracle)
 
 	log.Info("Using Eth endpoint: ", network.EtherClientRPC)
 	if di.EtherClient, err = blockchain.NewClient(network.EtherClientRPC); err != nil {
@@ -637,8 +639,12 @@ func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) 
 	if err != nil {
 		return err
 	}
-
 	di.QualityMetricsSender = quality.NewSender(transport, metadata.VersionAsString())
+
+	if _, err := firewall.AllowURLAccess(di.NetworkDefinition.QualityOracle); err != nil {
+		return err
+	}
+	di.QualityClient = quality.NewMorqaClient(di.NetworkDefinition.QualityOracle)
 	return nil
 }
 

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -159,7 +159,7 @@ type Dependencies struct {
 
 	NetworkDefinition    metadata.NetworkDefinition
 	MysteriumAPI         *mysterium.MysteriumAPI
-	MysteriumMorqaClient quality.QualityOracle
+	MysteriumMorqaClient *quality.MysteriumMORQA
 	EtherClient          *ethclient.Client
 
 	NATService           nat.NATService

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -44,6 +44,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/node"
 	nodevent "github.com/mysteriumnetwork/node/core/node/event"
+	"github.com/mysteriumnetwork/node/core/quality"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/state"
 	statevent "github.com/mysteriumnetwork/node/core/state/event"
@@ -60,7 +61,6 @@ import (
 	"github.com/mysteriumnetwork/node/market/metrics/oracle"
 	"github.com/mysteriumnetwork/node/market/mysterium"
 	"github.com/mysteriumnetwork/node/metadata"
-	"github.com/mysteriumnetwork/node/metrics"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/nat"
 	"github.com/mysteriumnetwork/node/nat/event"
@@ -178,7 +178,7 @@ type Dependencies struct {
 	DiscoveryFinder     *discovery.Finder
 	DiscoveryFetcherAPI *discovery_api.Fetcher
 
-	QualityMetricsSender *metrics.Sender
+	QualityMetricsSender *quality.Sender
 
 	IPResolver       ip.Resolver
 	LocationResolver CacheResolver
@@ -626,13 +626,13 @@ func (di *Dependencies) bootstrapDiscoveryComponents(options node.OptionsDiscove
 }
 
 func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) (err error) {
-	var transport metrics.Transport
+	var transport quality.Transport
 	switch options.Type {
 	case node.QualityTypeMORQA:
 		_, err = firewall.AllowURLAccess(options.Address)
-		transport = metrics.NewElasticSearchTransport(options.Address, 10*time.Second)
+		transport = quality.NewElasticSearchTransport(options.Address, 10*time.Second)
 	case node.QualityTypeNone:
-		transport = metrics.NewNoopTransport()
+		transport = quality.NewNoopTransport()
 	default:
 		err = fmt.Errorf("unknown Quality Oracle provider: %s", options.Type)
 	}
@@ -640,7 +640,7 @@ func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) 
 		return err
 	}
 
-	di.QualityMetricsSender = metrics.NewSender(transport, metadata.VersionAsString())
+	di.QualityMetricsSender = quality.NewSender(transport, metadata.VersionAsString())
 	return nil
 }
 

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -57,8 +57,6 @@ import (
 	identity_selector "github.com/mysteriumnetwork/node/identity/selector"
 	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/market"
-	market_metrics "github.com/mysteriumnetwork/node/market/metrics"
-	"github.com/mysteriumnetwork/node/market/metrics/oracle"
 	"github.com/mysteriumnetwork/node/market/mysterium"
 	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/mysteriumnetwork/node/money"
@@ -161,7 +159,7 @@ type Dependencies struct {
 
 	NetworkDefinition    metadata.NetworkDefinition
 	MysteriumAPI         *mysterium.MysteriumAPI
-	MysteriumMorqaClient market_metrics.QualityOracle
+	MysteriumMorqaClient quality.QualityOracle
 	EtherClient          *ethclient.Client
 
 	NATService           nat.NATService
@@ -563,7 +561,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.OptionsNetwork) 
 	}
 
 	di.MysteriumAPI = mysterium.NewClient(network.MysteriumAPIAddress)
-	di.MysteriumMorqaClient = oracle.NewMorqaClient(network.QualityOracle)
+	di.MysteriumMorqaClient = quality.NewMorqaClient(network.QualityOracle)
 
 	log.Info("Using Eth endpoint: ", network.EtherClientRPC)
 	if di.EtherClient, err = blockchain.NewClient(network.EtherClientRPC); err != nil {

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/node/event"
-	"github.com/mysteriumnetwork/node/metrics"
+	"github.com/mysteriumnetwork/node/core/quality"
 	"github.com/mysteriumnetwork/node/tequilapi"
 )
 
@@ -47,7 +47,7 @@ func NewNode(
 	connectionManager connection.Manager,
 	tequilapiServer tequilapi.APIServer,
 	publisher Publisher,
-	metricsSender *metrics.Sender,
+	metricsSender *quality.Sender,
 	natPinger NatPinger,
 	uiServer UIServer,
 ) *Node {
@@ -66,7 +66,7 @@ type Node struct {
 	connectionManager connection.Manager
 	httpAPIServer     tequilapi.APIServer
 	publisher         Publisher
-	metricsSender     *metrics.Sender
+	metricsSender     *quality.Sender
 	natPinger         NatPinger
 	uiServer          UIServer
 }

--- a/core/quality/elastic_search_transport.go
+++ b/core/quality/elastic_search_transport.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package metrics
+package quality
 
 import (
 	"fmt"

--- a/core/quality/elastic_search_transport_test.go
+++ b/core/quality/elastic_search_transport_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package metrics
+package quality
 
 import (
 	"bytes"

--- a/core/quality/metrics.go
+++ b/core/quality/metrics.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package metrics
+package quality
 
 import (
 	"encoding/json"

--- a/core/quality/metrics.go
+++ b/core/quality/metrics.go
@@ -25,11 +25,6 @@ import (
 
 const mysteriumMetricsLogPrefix = "[Mysterium.metrics] "
 
-// QualityOracle allows to interact with a quality oracle service (MORQA)
-type QualityOracle interface {
-	ProposalsMetrics() []json.RawMessage
-}
-
 // ServiceMetricsResponse represents response from the quality oracle service
 type ServiceMetricsResponse struct {
 	Connects []json.RawMessage `json:"connects"`

--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -29,21 +29,22 @@ const (
 	mysteriumMorqaLogPrefix = "[Mysterium.morqa] "
 )
 
-type mysteriumMorqa struct {
+// MysteriumMORQA HTTP client for Mysterium QualityOracle - MORQA
+type MysteriumMORQA struct {
 	http                 requests.HTTPTransport
 	qualityOracleAddress string
 }
 
 // NewMorqaClient creates Mysterium Morqa client with a real communication
-func NewMorqaClient(qualityOracleAddress string) QualityOracle {
-	return &mysteriumMorqa{
+func NewMorqaClient(qualityOracleAddress string) *MysteriumMORQA {
+	return &MysteriumMORQA{
 		requests.NewHTTPClient(1 * time.Minute),
 		qualityOracleAddress,
 	}
 }
 
 // ProposalsMetrics returns a list of proposals connection metrics
-func (m *mysteriumMorqa) ProposalsMetrics() []json.RawMessage {
+func (m *MysteriumMORQA) ProposalsMetrics() []json.RawMessage {
 	req, err := requests.NewGetRequest(m.qualityOracleAddress, "proposals/quality", nil)
 	if err != nil {
 		log.Warn(mysteriumMorqaLogPrefix, "Failed to create proposals metrics request: ", err)

--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -15,14 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package oracle
+package quality
 
 import (
 	"encoding/json"
 	"time"
 
 	log "github.com/cihub/seelog"
-	"github.com/mysteriumnetwork/node/market/metrics"
 	"github.com/mysteriumnetwork/node/requests"
 )
 
@@ -36,7 +35,7 @@ type mysteriumMorqa struct {
 }
 
 // NewMorqaClient creates Mysterium Morqa client with a real communication
-func NewMorqaClient(qualityOracleAddress string) metrics.QualityOracle {
+func NewMorqaClient(qualityOracleAddress string) QualityOracle {
 	return &mysteriumMorqa{
 		requests.NewHTTPClient(1 * time.Minute),
 		qualityOracleAddress,
@@ -51,7 +50,7 @@ func (m *mysteriumMorqa) ProposalsMetrics() []json.RawMessage {
 		return nil
 	}
 
-	var metricsResponse metrics.ServiceMetricsResponse
+	var metricsResponse ServiceMetricsResponse
 	err = m.http.DoRequestAndParseResponse(req, &metricsResponse)
 	if err != nil {
 		log.Warn(mysteriumMorqaLogPrefix, "Failed to request or parse proposals metrics: ", err)

--- a/core/quality/noop_transport.go
+++ b/core/quality/noop_transport.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package metrics
+package quality
 
 // NewNoopTransport creates transport which ignores requests to send metrics
 func NewNoopTransport() Transport {

--- a/core/quality/noop_transport.go
+++ b/core/quality/noop_transport.go
@@ -18,7 +18,7 @@
 package quality
 
 // NewNoopTransport creates transport which ignores requests to send metrics
-func NewNoopTransport() Transport {
+func NewNoopTransport() *noopTransport {
 	return &noopTransport{}
 }
 

--- a/core/quality/sender.go
+++ b/core/quality/sender.go
@@ -25,6 +25,11 @@ const appName = "myst"
 const startupEventName = "startup"
 const natMappingEventName = "nat_mapping"
 
+// Transport allows sending events
+type Transport interface {
+	SendEvent(Event) error
+}
+
 // NewSender creates metrics sender with appropriate transport
 func NewSender(transport Transport, appVersion string) *Sender {
 	return &Sender{
@@ -37,11 +42,6 @@ func NewSender(transport Transport, appVersion string) *Sender {
 type Sender struct {
 	Transport  Transport
 	AppVersion string
-}
-
-// Transport allows sending events
-type Transport interface {
-	SendEvent(Event) error
 }
 
 // Event contains data about event, which is sent using transport

--- a/core/quality/sender.go
+++ b/core/quality/sender.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package metrics
+package quality
 
 import (
 	"time"

--- a/core/quality/sender_test.go
+++ b/core/quality/sender_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package metrics
+package quality
 
 import (
 	"errors"

--- a/tequilapi/endpoints/proposals_test.go
+++ b/tequilapi/endpoints/proposals_test.go
@@ -67,7 +67,7 @@ func TestProposalsEndpointListByNodeId(t *testing.T) {
 	req.URL.RawQuery = query.Encode()
 
 	resp := httptest.NewRecorder()
-	handlerFunc := NewProposalsEndpoint(mockProposalProvider, &mysteriumMorqaFake{}).List
+	handlerFunc := NewProposalsEndpoint(mockProposalProvider, &mockQualityProvider{}).List
 	handlerFunc(resp, req, nil)
 
 	assert.JSONEq(
@@ -111,7 +111,7 @@ func TestProposalsEndpointAcceptsAccessPolicyParams(t *testing.T) {
 	req.URL.RawQuery = query.Encode()
 
 	resp := httptest.NewRecorder()
-	handlerFunc := NewProposalsEndpoint(mockProposalProvider, &mysteriumMorqaFake{}).List
+	handlerFunc := NewProposalsEndpoint(mockProposalProvider, &mockQualityProvider{}).List
 	handlerFunc(resp, req, nil)
 
 	assert.JSONEq(
@@ -156,7 +156,7 @@ func TestProposalsEndpointList(t *testing.T) {
 	assert.Nil(t, err)
 
 	resp := httptest.NewRecorder()
-	handlerFunc := NewProposalsEndpoint(proposalProvider, &mysteriumMorqaFake{}).List
+	handlerFunc := NewProposalsEndpoint(proposalProvider, &mockQualityProvider{}).List
 	handlerFunc(resp, req, nil)
 
 	assert.JSONEq(
@@ -205,7 +205,7 @@ func TestProposalsEndpointListFetchConnectCounts(t *testing.T) {
 	assert.Nil(t, err)
 
 	resp := httptest.NewRecorder()
-	handlerFunc := NewProposalsEndpoint(proposalProvider, &mysteriumMorqaFake{}).List
+	handlerFunc := NewProposalsEndpoint(proposalProvider, &mockQualityProvider{}).List
 	handlerFunc(resp, req, nil)
 
 	assert.JSONEq(
@@ -250,10 +250,10 @@ func TestProposalsEndpointListFetchConnectCounts(t *testing.T) {
 	)
 }
 
-type mysteriumMorqaFake struct{}
+type mockQualityProvider struct{}
 
 // ProposalsMetrics returns a list of proposals connection metrics
-func (m *mysteriumMorqaFake) ProposalsMetrics() []json.RawMessage {
+func (m *mockQualityProvider) ProposalsMetrics() []json.RawMessage {
 	for _, proposal := range serviceProposals {
 		return []json.RawMessage{json.RawMessage(`{
 			"proposalID": {


### PR DESCRIPTION
- moving related code to same package `core/quality`
- moving interface `core/quality.QualityOracle` to caller side at package `tequilapi/endpoints`