### PR TITLE
Metric transport to map events to new QualityOracle

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -499,6 +499,14 @@
   version = "0.0.14"
 
 [[projects]]
+  branch = "master"
+  digest = "1:ef19d273bca8368da97ab851fd14f1afbfa4358c378a9dee3ed4e50bef6409d5"
+  name = "github.com/mysteriumnetwork/metrics"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e10352387a0b66e2f1cb447bbc910ff360b6873e"
+
+[[projects]]
   digest = "1:8a20b209f06b19844908cf0367975d0966d6c188e5381ebd9327d6cd5d2ab990"
   name = "github.com/mysteriumnetwork/payments"
   packages = [
@@ -1075,6 +1083,7 @@
     "github.com/gin-contrib/cors",
     "github.com/gin-gonic/gin",
     "github.com/gofrs/uuid",
+    "github.com/golang/protobuf/proto",
     "github.com/google/go-github/github",
     "github.com/huin/goupnp",
     "github.com/huin/goupnp/httpu",
@@ -1097,6 +1106,7 @@
     "github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/state",
     "github.com/mysteriumnetwork/go-openvpn/openvpn/tls",
     "github.com/mysteriumnetwork/go-openvpn/openvpn3",
+    "github.com/mysteriumnetwork/metrics",
     "github.com/mysteriumnetwork/payments/cli/helpers",
     "github.com/mysteriumnetwork/payments/contracts/abigen",
     "github.com/mysteriumnetwork/payments/identity",

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -631,16 +631,19 @@ func (di *Dependencies) bootstrapDiscoveryComponents(options node.OptionsDiscove
 }
 
 func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) (err error) {
-	if _, err = firewall.AllowURLAccess(di.NetworkDefinition.QualityOracle); err != nil {
+	if _, err := firewall.AllowURLAccess(di.NetworkDefinition.QualityOracle); err != nil {
 		return err
 	}
-	di.QualityClient = quality.NewMorqaClient(di.NetworkDefinition.QualityOracle, 5*time.Second)
+	di.QualityClient = quality.NewMorqaClient(di.NetworkDefinition.QualityOracle, 30*time.Second)
 
 	var transport quality.Transport
 	switch options.Type {
+	case node.QualityTypeElastic:
+		_, err = firewall.AllowURLAccess(options.Address)
+		transport = quality.NewElasticSearchTransport(options.Address, 10*time.Second)
 	case node.QualityTypeMORQA:
 		_, err = firewall.AllowURLAccess(options.Address)
-		transport = quality.NewMORQATransport(di.QualityClient, quality.NewNoopTransport())
+		transport = quality.NewMORQATransport(di.QualityClient)
 	case node.QualityTypeNone:
 		transport = quality.NewNoopTransport()
 	default:

--- a/cmd/flags_quality.go
+++ b/cmd/flags_quality.go
@@ -28,12 +28,13 @@ var (
 	qualityTypeFlag = cli.StringFlag{
 		Name: "quality.type",
 		Usage: fmt.Sprintf(
-			"Quality Oracle adapter. Options:  (%s, %s - %s)",
+			"Quality Oracle adapter. Options:  (%s, %s, %s - %s)",
+			node.QualityTypeElastic,
 			node.QualityTypeMORQA,
 			node.QualityTypeNone,
 			"opt-out from sending quality metrics",
 		),
-		Value: string(node.QualityTypeMORQA),
+		Value: string(node.QualityTypeElastic),
 	}
 	qualityAddressFlag = cli.StringFlag{
 		Name: "quality.address",

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -73,12 +73,7 @@ type Node struct {
 
 // Start starts Mysterium node (Tequilapi service, fetches location)
 func (node *Node) Start() error {
-	go func() {
-		err := node.metricsSender.SendStartupEvent()
-		if err != nil {
-			log.Warn("Failed to send startup event: ", err)
-		}
-	}()
+	go node.metricsSender.SendStartupEvent()
 
 	node.httpAPIServer.StartServing()
 	address, err := node.httpAPIServer.Address()

--- a/core/node/options_quality.go
+++ b/core/node/options_quality.go
@@ -21,6 +21,8 @@ package node
 type QualityType string
 
 const (
+	// QualityTypeElastic defines type which uses ElasticSearch as Quality Oracle provider
+	QualityTypeElastic = QualityType("elastic")
 	// QualityTypeMORQA defines type which uses Mysterium MORQA as Quality Oracle provider
 	QualityTypeMORQA = QualityType("morqa")
 	// QualityTypeNone defines type which disables Quality Oracle

--- a/core/quality/elastic_search_transport_test.go
+++ b/core/quality/elastic_search_transport_test.go
@@ -49,15 +49,13 @@ func TestElasticSearchTransport_SendEvent_Success(t *testing.T) {
 		invoked = true
 	}))
 
-	transport := NewElasticSearchTransport(server.URL, time.Second)
-
 	app := appInfo{Name: "test app", Version: "test version"}
 	event := Event{Application: app}
 
-	err := transport.SendEvent(event)
+	transport := NewElasticSearchTransport(server.URL, time.Second)
+	transport.SendEvent(event)
 
 	assert.True(t, invoked)
-	assert.NoError(t, err)
 }
 
 func TestElasticSearchTransport_SendEvent_WithUnexpectedStatus(t *testing.T) {
@@ -69,11 +67,9 @@ func TestElasticSearchTransport_SendEvent_WithUnexpectedStatus(t *testing.T) {
 	}))
 
 	transport := NewElasticSearchTransport(server.URL, time.Second)
-
-	err := transport.SendEvent(Event{})
+	transport.SendEvent(Event{})
 
 	assert.True(t, invoked)
-	assert.EqualError(t, err, "unexpected response status: 500 Internal Server Error, body: something not cool happened")
 }
 
 func TestElasticSearchTransport_SendEvent_WithUnexpectedResponse(t *testing.T) {
@@ -84,9 +80,7 @@ func TestElasticSearchTransport_SendEvent_WithUnexpectedResponse(t *testing.T) {
 	}))
 
 	transport := NewElasticSearchTransport(server.URL, time.Second)
-
-	err := transport.SendEvent(Event{})
+	transport.SendEvent(Event{})
 
 	assert.True(t, invoked)
-	assert.EqualError(t, err, "unexpected response body: bad")
 }

--- a/core/quality/morqa_transport.go
+++ b/core/quality/morqa_transport.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package quality
+
+import (
+	"github.com/mysteriumnetwork/metrics"
+)
+
+var (
+	emptyMetric = &metrics.Event{}
+)
+
+// NewMORQATransport creates transport allowing to send events to Mysterium Quality Oracle - MORQA
+func NewMORQATransport(morqaClient *MysteriumMORQA, backupTransport Transport) *morqaTransport {
+	return &morqaTransport{
+		morqaClient:     morqaClient,
+		backupTransport: backupTransport,
+	}
+}
+
+type morqaTransport struct {
+	morqaClient     *MysteriumMORQA
+	backupTransport Transport
+}
+
+func (transport *morqaTransport) SendEvent(event Event) error {
+	if metric := mapEventToMetric(event); metric != emptyMetric {
+		err := transport.morqaClient.SendMetric(metric)
+		if err != nil {
+			return err
+		}
+	}
+
+	return transport.backupTransport.SendEvent(event)
+}
+
+func mapEventToMetric(event Event) *metrics.Event {
+	switch event.EventName {
+	case startupEventName:
+		return &metrics.Event{
+			IsProvider: false,
+			TargetId:   "0x1",
+			Metric: &metrics.Event_VersionPayload{
+				VersionPayload: &metrics.VersionPayload{
+					Version: event.Application.Version,
+				},
+			},
+		}
+	}
+	return emptyMetric
+}

--- a/core/quality/morqa_transport.go
+++ b/core/quality/morqa_transport.go
@@ -18,6 +18,8 @@
 package quality
 
 import (
+	"fmt"
+
 	"github.com/mysteriumnetwork/metrics"
 )
 
@@ -26,27 +28,22 @@ var (
 )
 
 // NewMORQATransport creates transport allowing to send events to Mysterium Quality Oracle - MORQA
-func NewMORQATransport(morqaClient *MysteriumMORQA, backupTransport Transport) *morqaTransport {
+func NewMORQATransport(morqaClient *MysteriumMORQA) *morqaTransport {
 	return &morqaTransport{
-		morqaClient:     morqaClient,
-		backupTransport: backupTransport,
+		morqaClient: morqaClient,
 	}
 }
 
 type morqaTransport struct {
-	morqaClient     *MysteriumMORQA
-	backupTransport Transport
+	morqaClient *MysteriumMORQA
 }
 
 func (transport *morqaTransport) SendEvent(event Event) error {
 	if metric := mapEventToMetric(event); metric != emptyMetric {
-		err := transport.morqaClient.SendMetric(metric)
-		if err != nil {
-			return err
-		}
+		return transport.morqaClient.SendMetric(metric)
 	}
 
-	return transport.backupTransport.SendEvent(event)
+	return fmt.Errorf("event not implemented")
 }
 
 func mapEventToMetric(event Event) *metrics.Event {

--- a/core/quality/morqa_transport_test.go
+++ b/core/quality/morqa_transport_test.go
@@ -30,15 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// func mockMORQATransport() *morqaTransport {
-// 	morqaClient := &MysteriumMORQA{
-// 		http:    &http.Client{Timeout: 5 * time.Second},
-// 		baseURL: qualityOracleAddress,
-// 	}
-//
-// 	NewMORQATransport(NewMorqaClient(), NewNoopTransport())
-// }
-
 var (
 	eventStartup = Event{
 		EventName:   startupEventName,

--- a/core/quality/morqa_transport_test.go
+++ b/core/quality/morqa_transport_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package quality
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/mysteriumnetwork/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+// func mockMORQATransport() *morqaTransport {
+// 	morqaClient := &MysteriumMORQA{
+// 		http:    &http.Client{Timeout: 5 * time.Second},
+// 		baseURL: qualityOracleAddress,
+// 	}
+//
+// 	NewMORQATransport(NewMorqaClient(), NewNoopTransport())
+// }
+
+var (
+	eventStartup = Event{
+		EventName:   startupEventName,
+		Application: appInfo{Version: "test version"},
+	}
+)
+
+func TestMORQATransport_SendEvent_HandlesSuccess(t *testing.T) {
+	var lastEvent metrics.Event
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		body, _ := ioutil.ReadAll(request.Body)
+		proto.Unmarshal(body, &lastEvent)
+		response.WriteHeader(http.StatusAccepted)
+	}))
+
+	transport := &morqaTransport{morqaClient: NewMorqaClient(server.URL, 10*time.Millisecond)}
+	err := transport.SendEvent(eventStartup)
+
+	assert.NoError(t, err)
+	assert.Exactly(
+		t,
+		metrics.Event{
+			IsProvider: false,
+			TargetId:   "0x1",
+			Metric: &metrics.Event_VersionPayload{
+				VersionPayload: &metrics.VersionPayload{
+					Version: "test version",
+				},
+			},
+		},
+		lastEvent,
+	)
+}
+
+func TestMORQATransport_SendEvent_HandlesErrorsWithMessages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{
+			"message": "invalid payload given"
+		}`))
+	}))
+
+	transport := &morqaTransport{morqaClient: NewMorqaClient(server.URL, 10*time.Millisecond)}
+	err := transport.SendEvent(eventStartup)
+
+	assert.EqualError(t, err, fmt.Sprintf(
+		"server response invalid: 400 Bad Request (%s/metrics). Possible error: invalid payload given",
+		server.URL,
+	))
+}
+
+func TestMORQATransport_SendEvent_HandlesValidationErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{
+			"message": "validation problems",
+			"errors": {
+				"field": [ {"code": "required", "message": "Field is required"} ]
+			}
+		}`))
+	}))
+
+	transport := &morqaTransport{morqaClient: NewMorqaClient(server.URL, 10*time.Millisecond)}
+	err := transport.SendEvent(eventStartup)
+
+	assert.EqualError(t, err, fmt.Sprintf(
+		"server response invalid: 422 Unprocessable Entity (%s/metrics). Possible error: validation problems",
+		server.URL,
+	))
+}
+
+func TestMORQATransport_SendEvent_HandlesFatalErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{}`))
+	}))
+
+	transport := &morqaTransport{morqaClient: NewMorqaClient(server.URL, 10*time.Millisecond)}
+	err := transport.SendEvent(eventStartup)
+
+	assert.EqualError(t, err, fmt.Sprintf(
+		"server response invalid: 500 Internal Server Error (%s/metrics). Possible error: ",
+		server.URL,
+	))
+}
+
+func TestMORQATransport_SendEvent_WithUnexpectedErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	transport := &morqaTransport{morqaClient: NewMorqaClient(server.URL, 10*time.Millisecond)}
+	err := transport.SendEvent(eventStartup)
+
+	assert.EqualError(t, err, fmt.Sprintf(
+		"server response invalid: 500 Internal Server Error (%s/metrics). Possible error: unexpected end of JSON input",
+		server.URL,
+	))
+}

--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -78,7 +78,7 @@ func (m *MysteriumMORQA) ProposalsMetrics() []json.RawMessage {
 	return metricsResponse.Connects
 }
 
-// SentEvent metric event to oracle
+// SendMetric submits new metric
 func (m *MysteriumMORQA) SendMetric(event *metrics.Event) error {
 	request, err := m.newRequestBinary(http.MethodPost, "metrics", event)
 	if err != nil {

--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -18,45 +18,148 @@
 package quality
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"time"
 
 	log "github.com/cihub/seelog"
-	"github.com/mysteriumnetwork/node/requests"
+	"github.com/golang/protobuf/proto"
+	"github.com/mysteriumnetwork/metrics"
 )
 
 const (
 	mysteriumMorqaLogPrefix = "[Mysterium.morqa] "
+	mysteriumMorqaAgentName = "goclient-v0.1"
 )
+
+// HttpClient sends actual HTTP requests
+type HttpClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
 
 // MysteriumMORQA HTTP client for Mysterium QualityOracle - MORQA
 type MysteriumMORQA struct {
-	http                 requests.HTTPTransport
-	qualityOracleAddress string
+	http    HttpClient
+	baseURL string
 }
 
 // NewMorqaClient creates Mysterium Morqa client with a real communication
-func NewMorqaClient(qualityOracleAddress string) *MysteriumMORQA {
+func NewMorqaClient(baseURL string, timeout time.Duration) *MysteriumMORQA {
 	return &MysteriumMORQA{
-		requests.NewHTTPClient(1 * time.Minute),
-		qualityOracleAddress,
+		http:    &http.Client{Timeout: timeout},
+		baseURL: baseURL,
 	}
 }
 
 // ProposalsMetrics returns a list of proposals connection metrics
 func (m *MysteriumMORQA) ProposalsMetrics() []json.RawMessage {
-	req, err := requests.NewGetRequest(m.qualityOracleAddress, "proposals/quality", nil)
+	request, err := m.newRequestJSON(http.MethodGet, "proposals/quality", nil)
 	if err != nil {
 		log.Warn(mysteriumMorqaLogPrefix, "Failed to create proposals metrics request: ", err)
 		return nil
 	}
 
-	var metricsResponse ServiceMetricsResponse
-	err = m.http.DoRequestAndParseResponse(req, &metricsResponse)
+	response, err := m.http.Do(request)
 	if err != nil {
-		log.Warn(mysteriumMorqaLogPrefix, "Failed to request or parse proposals metrics: ", err)
+		log.Warn(mysteriumMorqaLogPrefix, err)
+		return nil
+	}
+	defer response.Body.Close()
+
+	var metricsResponse ServiceMetricsResponse
+	if err = parseResponseJSON(response, &metricsResponse); err != nil {
+		log.Warn(mysteriumMorqaLogPrefix, err)
 		return nil
 	}
 
 	return metricsResponse.Connects
+}
+
+// SentEvent metric event to oracle
+func (m *MysteriumMORQA) SendMetric(event *metrics.Event) error {
+	request, err := m.newRequestBinary(http.MethodPost, "metrics", event)
+	if err != nil {
+		log.Warn(mysteriumMorqaLogPrefix, err)
+		return err
+	}
+
+	response, err := m.http.Do(request)
+	if err != nil {
+		log.Warn(mysteriumMorqaLogPrefix, err)
+		return err
+	}
+	defer response.Body.Close()
+
+	if err = parseResponseError(response); err != nil {
+		log.Warn(mysteriumMorqaLogPrefix, err)
+		return err
+	}
+
+	return nil
+}
+
+func (m *MysteriumMORQA) newRequest(method, path string, body []byte) (*http.Request, error) {
+	url := m.baseURL
+	if len(path) > 0 {
+		url = fmt.Sprintf("%v/%v", url, path)
+	}
+
+	request, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	request.Header.Set("User-Agent", mysteriumMorqaAgentName)
+	request.Header.Set("Accept", "application/json")
+	return request, err
+}
+
+func (m *MysteriumMORQA) newRequestJSON(method, path string, payload interface{}) (*http.Request, error) {
+	payloadBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := m.newRequest(method, path, payloadBody)
+	req.Header.Set("Accept", "application/json")
+	return req, err
+}
+
+func (m *MysteriumMORQA) newRequestBinary(method, path string, payload proto.Message) (*http.Request, error) {
+	payloadBody, err := proto.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := m.newRequest(method, path, payloadBody)
+	request.Header.Set("Content-Type", "application/octet-stream")
+	return request, nil
+}
+
+func parseResponseJSON(response *http.Response, dto interface{}) error {
+	responseJSON, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(responseJSON, dto)
+}
+
+type errorDTO struct {
+	Message string `json:"message"`
+}
+
+// Sometimes we can get json message with single "message" field which represents error - try to get that
+func parseResponseError(response *http.Response) error {
+	if response.StatusCode >= 200 && response.StatusCode < 300 {
+		return nil
+	}
+
+	var parsedBody errorDTO
+	var message string
+	err := parseResponseJSON(response, &parsedBody)
+	if err != nil {
+		message = err.Error()
+	} else {
+		message = parsedBody.Message
+	}
+	return fmt.Errorf("server response invalid: %s (%s). Possible error: %s", response.Status, response.Request.URL, message)
 }

--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -82,19 +82,16 @@ func (m *MysteriumMORQA) ProposalsMetrics() []json.RawMessage {
 func (m *MysteriumMORQA) SendMetric(event *metrics.Event) error {
 	request, err := m.newRequestBinary(http.MethodPost, "metrics", event)
 	if err != nil {
-		log.Warn(mysteriumMorqaLogPrefix, err)
 		return err
 	}
 
 	response, err := m.http.Do(request)
 	if err != nil {
-		log.Warn(mysteriumMorqaLogPrefix, err)
 		return err
 	}
 	defer response.Body.Close()
 
 	if err = parseResponseError(response); err != nil {
-		log.Warn(mysteriumMorqaLogPrefix, err)
 		return err
 	}
 

--- a/core/quality/sender_test.go
+++ b/core/quality/sender_test.go
@@ -42,31 +42,19 @@ func TestSender_SendStartupEvent_SendsToTransport(t *testing.T) {
 	mockTransport := buildMockEventsTransport(nil)
 	sender := &Sender{Transport: mockTransport, AppVersion: "test version"}
 
-	err := sender.SendStartupEvent()
-	assert.NoError(t, err)
+	sender.SendStartupEvent()
 
 	sentEvent := mockTransport.sentEvent
-
 	assert.Equal(t, "startup", sentEvent.EventName)
 	assert.Equal(t, appInfo{Name: "myst", Version: "test version"}, sentEvent.Application)
 	assert.NotZero(t, sentEvent.CreatedAt)
-}
-
-func TestSender_SendStartupEvent_ReturnsTransportErrors(t *testing.T) {
-	mockTransport := buildMockEventsTransport(nil)
-	mockTransport.mockResponse = errors.New("mock error")
-	sender := &Sender{Transport: mockTransport, AppVersion: "test version"}
-
-	err := sender.SendStartupEvent()
-	assert.Error(t, err)
 }
 
 func TestSender_SendNATMappingSuccessEvent_SendsToTransport(t *testing.T) {
 	mockTransport := buildMockEventsTransport(nil)
 	sender := &Sender{Transport: mockTransport, AppVersion: "test version"}
 
-	err := sender.SendNATMappingSuccessEvent("port_mapping", nil)
-	assert.NoError(t, err)
+	sender.SendNATMappingSuccessEvent("port_mapping", nil)
 
 	sentEvent := mockTransport.sentEvent
 	assert.Equal(t, "nat_mapping", sentEvent.EventName)
@@ -75,27 +63,16 @@ func TestSender_SendNATMappingSuccessEvent_SendsToTransport(t *testing.T) {
 	assert.Equal(t, natMappingContext{Successful: true, Stage: "port_mapping"}, sentEvent.Context)
 }
 
-func TestSender_SendNATMappingSuccessEvent_ReturnsTransportErrors(t *testing.T) {
-	mockTransport := buildMockEventsTransport(nil)
-	mockTransport.mockResponse = errors.New("mock error")
-	sender := &Sender{Transport: mockTransport, AppVersion: "test version"}
-
-	err := sender.SendNATMappingSuccessEvent("port_mapping", nil)
-	assert.Error(t, err)
-}
-
 func TestSender_SendNATMappingFailEvent_SendsToTransport(t *testing.T) {
 	mockTransport := buildMockEventsTransport(nil)
 
 	mockGateways := []map[string]string{
 		{"test": "test"},
 	}
+	mockError := errors.New("mock nat mapping error")
 
 	sender := &Sender{Transport: mockTransport, AppVersion: "test version"}
-
-	mockError := errors.New("mock nat mapping error")
-	err := sender.SendNATMappingFailEvent("hole_punching", mockGateways, mockError)
-	assert.NoError(t, err)
+	sender.SendNATMappingFailEvent("hole_punching", mockGateways, mockError)
 
 	sentEvent := mockTransport.sentEvent
 	assert.Equal(t, "nat_mapping", sentEvent.EventName)
@@ -106,13 +83,4 @@ func TestSender_SendNATMappingFailEvent_SendsToTransport(t *testing.T) {
 	assert.Equal(t, "mock nat mapping error", *c.ErrorMessage)
 	assert.Equal(t, "hole_punching", c.Stage)
 	assert.Equal(t, mockGateways, c.Gateways)
-}
-
-func TestSender_SendNATMappingFailEvent_ReturnsTransportErrors(t *testing.T) {
-	mockTransport := buildMockEventsTransport(nil)
-	mockTransport.mockResponse = errors.New("mock error")
-	sender := &Sender{Transport: mockTransport, AppVersion: "test version"}
-
-	err := sender.SendNATMappingFailEvent("hole_punching", nil, errors.New("mock nat mapping error"))
-	assert.Error(t, err)
 }

--- a/nat/event/sender_test.go
+++ b/nat/event/sender_test.go
@@ -37,18 +37,16 @@ func buildMockMetricsSender(mockResponse error) *mockMetricsSender {
 	return &mockMetricsSender{mockResponse: mockResponse, successSent: false}
 }
 
-func (sender *mockMetricsSender) SendNATMappingSuccessEvent(stage string, gateways []map[string]string) error {
+func (sender *mockMetricsSender) SendNATMappingSuccessEvent(stage string, gateways []map[string]string) {
 	sender.successSent = true
 	sender.stageSent = stage
 	sender.gatewaysSent = gateways
-	return nil
 }
 
-func (sender *mockMetricsSender) SendNATMappingFailEvent(stage string, gateways []map[string]string, err error) error {
+func (sender *mockMetricsSender) SendNATMappingFailEvent(stage string, gateways []map[string]string, err error) {
 	sender.failErrorSent = err
 	sender.stageSent = stage
 	sender.gatewaysSent = gateways
-	return nil
 }
 
 type mockIPResolver struct {

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -295,7 +295,7 @@ func (p *Pinger) pingReceiver(conn *net.UDPConn, stop <-chan struct{}) error {
 		}
 
 		if n > 0 {
-			log.Infof(prefix, "remote peer data received: %s, len: %d", string(buf[:n]), n)
+			log.Infof(prefix, "%sRemote peer data received: %s, len: %d", string(buf[:n]), n)
 			return nil
 		}
 	}


### PR DESCRIPTION
*Changes made:*
- 3 different QualityOracle providers are now supported: `elastic`, `morqa`, and `none`
- `--quality.type=morqa` allows to configure metrics sending to new QualityOracle
- Anyways `--quality.type=elastic` is still a default behavior