### PR TITLE
Enable SSH server on raspberry

### DIFF
--- a/bin/package/raspberry/files/1-setup-node.sh
+++ b/bin/package/raspberry/files/1-setup-node.sh
@@ -3,6 +3,7 @@
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 export DEBIAN_FRONTEND="noninteractive"
 
+systemctl enable ssh
 sed -i -e 's/#PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 
 install -m 644 default-myst-conf /etc/default/mysterium-node


### PR DESCRIPTION
Replicates behavior from old pi-gen based build
https://github.com/RPi-Distro/pi-gen/blob/7fbfdda31e5771b849876d306c25ede237bc577b/stage2/01-sys-tweaks/01-run.sh#L18