### PR TITLE
Automatically prefix package name to logger

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -84,8 +83,6 @@ import (
 	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
 )
-
-const logPrefix = "[service bootstrap] "
 
 // Storage stores persistent objects for future usage
 type Storage interface {
@@ -714,7 +711,7 @@ func (di *Dependencies) bootstrapBandwidthTracker() error {
 func (di *Dependencies) bootstrapNATComponents(options node.Options) {
 	di.NATTracker = event.NewTracker()
 	if options.ExperimentNATPunching {
-		log.Trace(logPrefix + "experimental NAT punching enabled, creating a pinger")
+		log.Trace("experimental NAT punching enabled, creating a pinger")
 		di.NATPinger = traversal.NewPinger(
 			di.NATTracker,
 			config.NewConfigParser(),

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -20,7 +20,6 @@
 package cmd
 
 import (
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
 	nats_dialog "github.com/mysteriumnetwork/node/communication/nats/dialog"
 	nats_discovery "github.com/mysteriumnetwork/node/communication/nats/discovery"
@@ -86,7 +85,7 @@ func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options) {
 
 			var portPool port.ServicePortSupplier
 			if wgOptions.Ports.IsSpecified() {
-				log.Infof("%s fixed service port range (%s) configured, using custom port pool", logPrefix, wgOptions.Ports)
+				log.Infof("fixed service port range (%s) configured, using custom port pool", wgOptions.Ports)
 				portPool = port.NewFixedRangePool(*wgOptions.Ports)
 			} else {
 				portPool = port.NewPool()
@@ -185,7 +184,7 @@ func (di *Dependencies) bootstrapServiceNoop(nodeOptions node.Options) {
 func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) error {
 	di.NATService = nat.NewService()
 	if err := di.NATService.Enable(); err != nil {
-		log.Warn(logPrefix, "Failed to enable NAT forwarding: ", err)
+		log.Warn("Failed to enable NAT forwarding: ", err)
 	}
 	di.ServiceRegistry = service.NewRegistry()
 	storage := session.NewEventBasedStorage(di.EventBus, session.NewStorageMemory())
@@ -252,7 +251,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 
 	serviceCleaner := service.Cleaner{SessionStorage: di.ServiceSessionStorage}
 	if err := di.EventBus.Subscribe(service.StatusTopic, serviceCleaner.HandleServiceStatus); err != nil {
-		log.Error(logPrefix, "failed to subscribe service cleaner")
+		log.Error("failed to subscribe service cleaner")
 	}
 
 	return nil

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package cmd
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/cmd/mysterium_node/mysterium_node.go
+++ b/cmd/mysterium_node/mysterium_node.go
@@ -20,7 +20,6 @@ package main
 import (
 	"os"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/cmd"
 	command_cli "github.com/mysteriumnetwork/node/cmd/commands/cli"
 	"github.com/mysteriumnetwork/node/cmd/commands/daemon"
@@ -33,6 +32,7 @@ import (
 )
 
 var (
+	log              = logconfig.NewLogger()
 	licenseCopyright = metadata.LicenseCopyright(
 		"run command 'license --warranty'",
 		"run command 'license --conditions'",
@@ -48,14 +48,14 @@ var (
 func main() {
 	app, err := NewCommand()
 	if err != nil {
-		log.Error("Failed to create command: ", err)
+		log.Error("failed to create command: ", err)
 		log.Flush()
 		os.Exit(1)
 	}
 
 	err = app.Run(os.Args)
 	if err != nil {
-		log.Error("Failed to execute command: ", err)
+		log.Error("failed to execute command: ", err)
 		log.Flush()
 		os.Exit(1)
 	}

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -17,10 +17,6 @@
 
 package auth
 
-import (
-	log "github.com/cihub/seelog"
-)
-
 // Authenticator provides an authentication method for builtin UI.
 type Authenticator struct {
 	storage Storage

--- a/core/auth/credentials.go
+++ b/core/auth/credentials.go
@@ -18,7 +18,6 @@
 package auth
 
 import (
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/core/storage"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
@@ -72,7 +71,7 @@ func (credentials *Credentials) loadOrInitialize() (s string, err error) {
 	var storedHash string
 	err = credentials.db.GetValue(credentialsDBBucket, username, &storedHash)
 	if err == storage.ErrNotFound {
-		log.Info("[web-ui-auth] credentials not found, initializing to default")
+		log.Info("credentials not found, initializing to default")
 		err = NewCredentials(username, initialPassword, credentials.db).Set()
 		if err != nil {
 			return "", errors.Wrap(err, "failed to set initial credentials")

--- a/core/auth/log.go
+++ b/core/auth/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package auth
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/connection/log.go
+++ b/core/connection/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package connection
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/consumer"
 	"github.com/mysteriumnetwork/node/core/ip"
@@ -36,8 +35,6 @@ import (
 	"github.com/mysteriumnetwork/node/session/balance"
 	"github.com/mysteriumnetwork/node/session/promise"
 )
-
-const managerLogPrefix = "[connection-manager] "
 
 var (
 	// ErrNoConnection error indicates that action applied to manager expects active connection (i.e. disconnect)
@@ -202,7 +199,7 @@ func (manager *connectionManager) cleanConnection() {
 	for i := len(manager.cleanup) - 1; i >= 0; i-- {
 		err := manager.cleanup[i]()
 		if err != nil {
-			log.Warn(managerLogPrefix, "cleanup error:", err)
+			log.Warn("cleanup error:", err)
 		}
 	}
 	manager.cleanup = make([]func() error, 0)
@@ -270,7 +267,7 @@ func (manager *connectionManager) startConnection(
 
 	defer func() {
 		if err != nil {
-			log.Info(managerLogPrefix, "Cancelling connection initiation: ", err)
+			log.Info("cancelling connection initiation: ", err)
 			logDisconnectError(manager.Disconnect())
 		}
 	}()
@@ -343,24 +340,24 @@ func (manager *connectionManager) Disconnect() error {
 func (manager *connectionManager) payForService(payments PaymentIssuer) {
 	err := payments.Start()
 	if err != nil {
-		log.Error(managerLogPrefix, "payment error: ", err)
+		log.Error("payment error: ", err)
 		err = manager.Disconnect()
 		if err != nil {
-			log.Error(managerLogPrefix, "could not disconnect gracefully:", err)
+			log.Error("could not disconnect gracefully:", err)
 		}
 	}
 }
 
 func warnOnClean() {
-	log.Warn(managerLogPrefix, "Trying to close when there is nothing to close. Possible bug or race condition")
+	log.Warn("trying to close when there is nothing to close. Possible bug or race condition")
 }
 
 func (manager *connectionManager) connectionWaiter(connection Connection) {
 	err := connection.Wait()
 	if err != nil {
-		log.Warn(managerLogPrefix, "Connection exited with error: ", err)
+		log.Warn("connection exited with error: ", err)
 	} else {
-		log.Info(managerLogPrefix, "Connection exited")
+		log.Info("connection exited")
 	}
 
 	logDisconnectError(manager.Disconnect())
@@ -392,7 +389,7 @@ func (manager *connectionManager) consumeConnectionStates(stateChannel <-chan St
 		manager.onStateChanged(state)
 	}
 
-	log.Debug(managerLogPrefix, "State updater stopCalled")
+	log.Debug("state updater stopCalled")
 	logDisconnectError(manager.Disconnect())
 }
 
@@ -434,6 +431,6 @@ func (manager *connectionManager) setupTrafficBlock(disableKillSwitch bool) erro
 
 func logDisconnectError(err error) {
 	if err != nil && err != ErrNoConnection {
-		log.Error(managerLogPrefix, "Disconnect error", err)
+		log.Error("disconnect error", err)
 	}
 }

--- a/core/connection/stubs_test.go
+++ b/core/connection/stubs_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"sync"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/consumer"
 	"github.com/mysteriumnetwork/node/identity"
@@ -246,7 +245,7 @@ func (md *mockDialog) Close() error {
 	defer md.Unlock()
 
 	md.closed = true
-	log.Info(mockDialogLog, "Dialog closed")
+	log.Info(mockDialogLog, "dialog closed")
 	return nil
 }
 

--- a/core/discovery/api/fetcher.go
+++ b/core/discovery/api/fetcher.go
@@ -20,13 +20,8 @@ package api
 import (
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/core/discovery"
 	"github.com/mysteriumnetwork/node/market"
-)
-
-const (
-	fetcherLogPrefix = "[proposal-fetcher-api] "
 )
 
 // FetchCallback does real fetch of proposals through Mysterium API
@@ -89,11 +84,11 @@ func (fetcher *Fetcher) fetchLoop() {
 func (fetcher *Fetcher) fetchDo() error {
 	proposals, err := fetcher.fetch()
 	if err != nil {
-		log.Warnf("%s Failed to fetch proposals: %s", fetcherLogPrefix, err)
+		log.Warnf("failed to fetch proposals: %s", err)
 		return err
 	}
 
-	log.Infof("%s Proposals fetched: %d", fetcherLogPrefix, len(proposals))
+	log.Infof("proposals fetched: %d", len(proposals))
 	fetcher.proposalStorage.Set(proposals...)
 
 	for _, proposal := range proposals {

--- a/core/discovery/api/log.go
+++ b/core/discovery/api/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package api
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/discovery/log.go
+++ b/core/discovery/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package discovery
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/ip/log.go
+++ b/core/ip/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package ip
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/ip/rest_resolver.go
+++ b/core/ip/rest_resolver.go
@@ -20,12 +20,10 @@ package ip
 import (
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/requests"
 )
 
 const apiClient = "goclient-v0.1"
-const ipAPILogPrefix = "[ip-detector.api] "
 
 // NewResolver creates new ip-detector resolver with default timeout of one minute
 func NewResolver(url string) Resolver {
@@ -56,7 +54,7 @@ func (client *clientRest) GetPublicIP() (string, error) {
 	request.Header.Set("User-Agent", apiClient)
 	request.Header.Set("Accept", "application/json")
 	if err != nil {
-		log.Critical(ipAPILogPrefix, err)
+		log.Critical(err)
 		return "", err
 	}
 
@@ -65,7 +63,7 @@ func (client *clientRest) GetPublicIP() (string, error) {
 		return "", err
 	}
 
-	log.Trace(ipAPILogPrefix, "IP detected: ", ipResponse.IP)
+	log.Trace("IP detected: ", ipResponse.IP)
 	return ipResponse.IP, nil
 }
 

--- a/core/location/built_in_resolver.go
+++ b/core/location/built_in_resolver.go
@@ -28,6 +28,7 @@ import (
 
 // NewBuiltInResolver returns new db resolver initialized from built in data
 func NewBuiltInResolver(ipResolver ip.Resolver) (*DBResolver, error) {
+	log.Debug("detecting with built-in resolver")
 	dbBytes, err := gendb.LoadData()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load builtin db")

--- a/core/location/cache.go
+++ b/core/location/cache.go
@@ -21,12 +21,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/core/connection"
 	nodevent "github.com/mysteriumnetwork/node/core/node/event"
 )
-
-const locationCacheLogPrefix = "[location-cache] "
 
 // Cache allows us to cache location resolution
 type Cache struct {
@@ -90,11 +87,11 @@ func (c *Cache) HandleConnectionEvent(se connection.StateEvent) {
 
 	loc, err := c.fetchAndSave()
 	if err != nil {
-		log.Error(locationCacheLogPrefix, "location update failed", err)
+		log.Error("location update failed", err)
 		// reset time so a fetch is tried the next time a get is called
 		c.lastFetched = time.Time{}
 	} else {
-		log.Trace(locationCacheLogPrefix, "location update succeeded", loc)
+		log.Trace("location update succeeded", loc)
 	}
 }
 
@@ -109,8 +106,8 @@ func (c *Cache) HandleNodeEvent(se nodevent.Payload) {
 	var err error
 	c.origin, err = c.locationDetector.DetectLocation()
 	if err != nil {
-		log.Warn(locationCacheLogPrefix, "Failed to detect original location: ", err)
+		log.Warn("failed to detect original location: ", err)
 	} else {
-		log.Tracef("%sOriginal location detected: %s (%s)", locationCacheLogPrefix, c.origin.Country, c.origin.NodeType)
+		log.Tracef("original location detected: %s (%s)", c.origin.Country, c.origin.NodeType)
 	}
 }

--- a/core/location/db_resolver.go
+++ b/core/location/db_resolver.go
@@ -46,6 +46,7 @@ func NewExternalDBResolver(databasePath string, ipResolver ip.Resolver) (*DBReso
 
 // DetectLocation detects current IP-address provides location information for the IP.
 func (r *DBResolver) DetectLocation() (loc Location, err error) {
+	log.Debug("detecting with DB resolver")
 	ipAddress, err := r.ipResolver.GetPublicIP()
 	if err != nil {
 		return Location{}, errors.Wrap(err, "failed to get public IP")

--- a/core/location/fallback_resolver.go
+++ b/core/location/fallback_resolver.go
@@ -18,11 +18,8 @@
 package location
 
 import (
-	log "github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
-
-const fallbackResolverLogPrefix = "[fallback-resolver] "
 
 // ErrLocationResolutionFailed represents a failure to resolve location and running out of fallbacks to try
 var ErrLocationResolutionFailed = errors.New("location resolution failed")
@@ -41,10 +38,11 @@ func NewFallbackResolver(resolvers []Resolver) *FallbackResolver {
 
 // DetectLocation allows us to detect our current location
 func (fr *FallbackResolver) DetectLocation() (Location, error) {
+	log.Debug("detecting with fallback resolver")
 	for _, v := range fr.LocationResolvers {
 		loc, err := v.DetectLocation()
 		if err != nil {
-			log.Warn(fallbackResolverLogPrefix, "could not resolve location", err)
+			log.Warn("could not resolve location", err)
 		} else {
 			return loc, err
 		}

--- a/core/location/log.go
+++ b/core/location/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package location
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/location/oracle_resolver.go
+++ b/core/location/oracle_resolver.go
@@ -20,12 +20,9 @@ package location
 import (
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/requests"
 	"github.com/pkg/errors"
 )
-
-const oracleResolverLogPrefix = "[location.Oracle.Resolver] "
 
 type oracleResolver struct {
 	http                  requests.HTTPTransport
@@ -42,9 +39,10 @@ func NewOracleResolver(address string) *oracleResolver {
 
 // DetectLocation detects current IP-address provides location information for the IP.
 func (o *oracleResolver) DetectLocation() (location Location, err error) {
+	log.Debug("detecting with oracle resolver")
 	request, err := requests.NewGetRequest(o.oracleResolverAddress, "", nil)
 	if err != nil {
-		log.Error(oracleResolverLogPrefix, err)
+		log.Error(err)
 		return Location{}, errors.Wrap(err, "failed to create request")
 	}
 

--- a/core/location/static_resolver.go
+++ b/core/location/static_resolver.go
@@ -54,6 +54,7 @@ func NewFailingResolver(err error) *StaticResolver {
 
 // DetectLocation detects current IP-address provides location information for the IP.
 func (d *StaticResolver) DetectLocation() (Location, error) {
+	log.Debug("detecting with static resolver")
 	pubIP, err := d.ipResolver.GetPublicIP()
 	if err != nil {
 		return Location{}, errors.Wrap(err, "failed to get public IP")

--- a/core/node/log.go
+++ b/core/node/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package node
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -18,7 +18,6 @@
 package node
 
 import (
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/node/event"
 	"github.com/mysteriumnetwork/node/core/quality"
@@ -90,7 +89,7 @@ func (node *Node) Start() error {
 
 	node.publisher.Publish(event.Topic, event.Payload{Status: event.StatusStarted})
 
-	log.Infof("Api started on: %v", address)
+	log.Infof("API started on: %v", address)
 	go node.natPinger.Start()
 
 	return nil
@@ -108,22 +107,22 @@ func (node *Node) Kill() error {
 	if err != nil {
 		switch err {
 		case connection.ErrNoConnection:
-			log.Info("No active connection - proceeding")
+			log.Info("no active connection - proceeding")
 		default:
 			return err
 		}
 	} else {
-		log.Info("Connection closed")
+		log.Info("connection closed")
 	}
 
 	node.httpAPIServer.Stop()
-	log.Info("Api stopped")
+	log.Info("API stopped")
 
 	node.uiServer.Stop()
-	log.Info("Web server stopped")
+	log.Info("web server stopped")
 
 	node.natPinger.Stop()
-	log.Info("Nat pinger stopped")
+	log.Info("NAT pinger stopped")
 
 	return nil
 }

--- a/core/node/options_directory.go
+++ b/core/node/options_directory.go
@@ -20,8 +20,6 @@ package node
 import (
 	"errors"
 	"os"
-
-	log "github.com/cihub/seelog"
 )
 
 // OptionsDirectory describes data structure holding directories as parameters
@@ -63,7 +61,7 @@ func (options *OptionsDirectory) Check() error {
 func ensureOrCreateDir(dir string) error {
 	err := ensureDirExists(dir)
 	if os.IsNotExist(err) {
-		log.Info("[Directory config checker] ", "Directory: ", dir, " does not exit. Creating new one")
+		log.Info("directory: ", dir, " does not exit, creating a new one")
 		return os.MkdirAll(dir, 0700)
 	}
 	return err

--- a/core/port/availability.go
+++ b/core/port/availability.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"strconv"
 
-	log "github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
 
@@ -34,7 +33,7 @@ func available(port int) (bool, error) {
 
 	conn, err := net.ListenUDP("udp", addr)
 	if err != nil {
-		log.Infof("%s cannot listen on UDP port %v: %v", logPrefix, port, err)
+		log.Infof("cannot listen on UDP port %v: %v", port, err)
 		return false, nil
 	}
 	defer conn.Close()

--- a/core/port/log.go
+++ b/core/port/log.go
@@ -17,10 +17,6 @@
 
 package port
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/port/pool.go
+++ b/core/port/pool.go
@@ -21,7 +21,6 @@ import (
 	"math/rand"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
 
@@ -64,7 +63,7 @@ func (pool *Pool) Acquire() (port Port, err error) {
 	if !available {
 		p, err = pool.seekAvailablePort()
 	}
-	log.Infof("%ssupplying port %v, err %v", logPrefix, p, err)
+	log.Infof("supplying port %v, err %v", p, err)
 	return Port(p), errors.Wrap(err, "could not acquire port")
 }
 

--- a/core/promise/methods/noop/log.go
+++ b/core/promise/methods/noop/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package noop
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/promise/methods/noop/promise_issuer.go
+++ b/core/promise/methods/noop/promise_issuer.go
@@ -18,16 +18,11 @@
 package noop
 
 import (
-	"fmt"
-
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/core/promise"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 )
-
-const issuerLogPrefix = "[promise-issuer] "
 
 // PromiseIssuer issues promises in such way, that no actual money is added to promise
 type PromiseIssuer struct {
@@ -83,9 +78,9 @@ func (issuer *PromiseIssuer) subscribePromiseBalance() error {
 
 func (issuer *PromiseIssuer) processBalanceMessage(message promise.BalanceMessage) error {
 	if !message.Accepted {
-		log.Warn(issuerLogPrefix, fmt.Sprintf("Promise balance rejected: %s", message.Balance.String()))
+		log.Warnf("promise balance rejected: %s", message.Balance.String())
 	}
 
-	log.Info(issuerLogPrefix, fmt.Sprintf("Promise balance notified: %s", message.Balance.String()))
+	log.Infof("promise balance notified: %s", message.Balance.String())
 	return nil
 }

--- a/core/promise/methods/noop/promise_issuer_test.go
+++ b/core/promise/methods/noop/promise_issuer_test.go
@@ -71,7 +71,7 @@ func TestPromiseIssuer_Start_SubscriptionOfBalances(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, logs, 1)
-	assert.Equal(t, "[promise-issuer] Promise balance notified: 1000000000TEST", logs[0])
+	assert.Contains(t, logs[0], "promise balance notified: 1000000000TEST")
 }
 
 func testToken(amount float64) money.Money {

--- a/core/promise/methods/noop/promise_processor.go
+++ b/core/promise/methods/noop/promise_processor.go
@@ -18,11 +18,9 @@
 package noop
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/core/promise"
 	"github.com/mysteriumnetwork/node/identity"
@@ -31,8 +29,6 @@ import (
 )
 
 const (
-	processorLogPrefix = "[promise-processor] "
-
 	balanceNotifying = balanceState("Notifying")
 	balanceStopped   = balanceState("Stopped")
 )
@@ -126,7 +122,7 @@ func (processor *PromiseProcessor) getBalanceState() balanceState {
 }
 
 func (processor *PromiseProcessor) balanceSend(message promise.BalanceMessage) error {
-	log.Info(processorLogPrefix, fmt.Sprintf("Notifying balance %s", message.Balance.String()))
+	log.Infof("notifying balance %s", message.Balance.String())
 	return processor.dialog.Send(&promise.BalanceMessageProducer{
 		Message: message,
 	})

--- a/core/quality/log.go
+++ b/core/quality/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package quality
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/quality/metrics.go
+++ b/core/quality/metrics.go
@@ -19,11 +19,7 @@ package quality
 
 import (
 	"encoding/json"
-
-	log "github.com/cihub/seelog"
 )
-
-const mysteriumMetricsLogPrefix = "[Mysterium.metrics] "
 
 // ServiceMetricsResponse represents response from the quality oracle service
 type ServiceMetricsResponse struct {
@@ -37,18 +33,18 @@ func Parse(msg json.RawMessage, proposal interface{}) ([]byte, error) {
 	}
 
 	if err := json.Unmarshal(msg, &proposal); err != nil {
-		log.Warn(mysteriumMetricsLogPrefix, "Failed to parse proposal info")
+		log.Warn("failed to parse proposal info")
 		return nil, err
 	}
 
 	if err := json.Unmarshal(msg, &metrics); err != nil {
-		log.Warn(mysteriumMetricsLogPrefix, "Failed to parse metrics")
+		log.Warn("failed to parse metrics")
 		return nil, err
 	}
 
 	out, err := json.Marshal(metrics)
 	if err != nil {
-		log.Warn(mysteriumMetricsLogPrefix, "Failed to marshal metrics JSON")
+		log.Warn("failed to marshal metrics JSON")
 		return nil, err
 	}
 	return out, err

--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -25,13 +25,11 @@ import (
 	"net/http"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/golang/protobuf/proto"
 	"github.com/mysteriumnetwork/metrics"
 )
 
 const (
-	mysteriumMorqaLogPrefix = "[Mysterium.morqa] "
 	mysteriumMorqaAgentName = "goclient-v0.1"
 )
 
@@ -58,20 +56,20 @@ func NewMorqaClient(baseURL string, timeout time.Duration) *MysteriumMORQA {
 func (m *MysteriumMORQA) ProposalsMetrics() []json.RawMessage {
 	request, err := m.newRequestJSON(http.MethodGet, "proposals/quality", nil)
 	if err != nil {
-		log.Warn(mysteriumMorqaLogPrefix, "Failed to create proposals metrics request: ", err)
+		log.Warn("failed to create proposals metrics request: ", err)
 		return nil
 	}
 
 	response, err := m.http.Do(request)
 	if err != nil {
-		log.Warn(mysteriumMorqaLogPrefix, "Failed to request or parse proposals metrics: ", err)
+		log.Warn("failed to request or parse proposals metrics: ", err)
 		return nil
 	}
 	defer response.Body.Close()
 
 	var metricsResponse ServiceMetricsResponse
 	if err = parseResponseJSON(response, &metricsResponse); err != nil {
-		log.Warn(mysteriumMorqaLogPrefix, "Failed to request or parse proposals metrics: ", err)
+		log.Warn("failed to request or parse proposals metrics: ", err)
 		return nil
 	}
 

--- a/core/quality/sender.go
+++ b/core/quality/sender.go
@@ -18,17 +18,13 @@
 package quality
 
 import (
-	"fmt"
 	"time"
-
-	log "github.com/cihub/seelog"
 )
 
 const (
 	appName             = "myst"
 	startupEventName    = "startup"
 	natMappingEventName = "nat_mapping"
-	logPrefix           = "[quality-oracle] "
 )
 
 // Transport allows sending events
@@ -106,6 +102,6 @@ func (sender *Sender) sendEvent(eventName string, context interface{}) {
 		Context:   context,
 	})
 	if err != nil {
-		log.Warn(logPrefix, fmt.Sprintf(`Failed to send metric "%s". %s`, eventName, err))
+		log.Warnf("Failed to send metric %q. %s", eventName, err)
 	}
 }

--- a/core/service/log.go
+++ b/core/service/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package service
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	log "github.com/cihub/seelog"
 	"github.com/gofrs/uuid"
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/identity"

--- a/core/state/log.go
+++ b/core/state/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package state
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/state/event"
 	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
@@ -32,8 +31,6 @@ import (
 
 // DefaultDebounceDuration is the default time interval suggested for debouncing
 const DefaultDebounceDuration = time.Millisecond * 200
-
-const logPrefix = "[state keeper]"
 
 type natStatusProvider interface {
 	Status() nat.Status
@@ -120,7 +117,7 @@ func (k *Keeper) updateNatStatus(e interface{}) {
 
 	event, ok := e.(natEvent.Event)
 	if !ok {
-		log.Warn(logPrefix, "received a non nat event on nat status call - ignoring")
+		log.Warn("received a non nat event on nat status call - ignoring")
 		return
 	}
 

--- a/core/storage/boltdb/log.go
+++ b/core/storage/boltdb/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package boltdb
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/storage/boltdb/migrations/log.go
+++ b/core/storage/boltdb/migrations/log.go
@@ -15,12 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package migrations
 
-// Port (networking)
-type Port int
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
-}
+var log = logconfig.NewLogger()

--- a/core/storage/boltdb/migrations/session-to-history.go
+++ b/core/storage/boltdb/migrations/session-to-history.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/asdine/storm"
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/consumer"
 	consumer_session "github.com/mysteriumnetwork/node/consumer/session"
 	"github.com/mysteriumnetwork/node/identity"
@@ -84,7 +83,7 @@ func MigrateSessionToHistory(db *storm.DB) error {
 		if err != nil {
 			rollbackError := tx.Rollback()
 			if rollbackError != nil {
-				log.Critical("[migrateSessionToHistory] rollback failed!", err)
+				log.Critical("migrate session to history rollback failed!", err)
 			}
 			return err
 		}

--- a/core/storage/boltdb/migrator.go
+++ b/core/storage/boltdb/migrator.go
@@ -20,11 +20,9 @@ package boltdb
 import (
 	"sort"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb/migrations"
 )
 
-const migrationLogPrefix = "[migrator] "
 const migrationIndexBucketName = "migrations"
 
 // Migrator represents the component responsible for running migrations on bolt db
@@ -63,12 +61,12 @@ func (m *Migrator) migrate(migration migrations.Migration) error {
 	if err != nil || isRun {
 		return err
 	}
-	log.Info(migrationLogPrefix, "running migration ", migration.Name)
+	log.Info("running migration ", migration.Name)
 	err = migration.Migrate(m.db.db)
 	if err != nil {
 		return err
 	}
-	log.Info(migrationLogPrefix, "saving migration ", migration.Name)
+	log.Info("saving migration ", migration.Name)
 	return m.saveMigrationRun(migration)
 }
 

--- a/logconfig/call_info.go
+++ b/logconfig/call_info.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Tideland Go Library - Logger
+ * https://github.com/tideland/golib
+ *
+ * Copyright (C) 2012-2017 Frank Mueller / Tideland / Oldenburg / Germany
+ * All rights reserved. Use of this source code is governed by the new BSD license.
+ */
+
+package logconfig
+
+import (
+	"path"
+	"runtime"
+	"strings"
+)
+
+// callInfo bundles the info about the call environment
+// when a logging statement occurred.
+type callInfo struct {
+	packageName string
+	fileName    string
+	funcName    string
+	line        int
+}
+
+// retrieveCallInfo returns detailed information about
+// the call location.
+func retrieveCallInfo() *callInfo {
+	pc, file, line, _ := runtime.Caller(2)
+	_, fileName := path.Split(file)
+	parts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	pl := len(parts)
+	packageName := ""
+	funcName := parts[pl-1]
+
+	if parts[pl-2][0] == '(' {
+		funcName = parts[pl-2] + "." + funcName
+		packageName = strings.Join(parts[0:pl-2], ".")
+	} else {
+		packageName = strings.Join(parts[0:pl-1], ".")
+	}
+
+	return &callInfo{
+		packageName: packageName,
+		fileName:    fileName,
+		funcName:    funcName,
+		line:        line,
+	}
+}

--- a/logconfig/log.go
+++ b/logconfig/log.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,13 +18,86 @@
 package logconfig
 
 import (
+	"strings"
+
 	"github.com/cihub/seelog"
 )
 
-// ReplaceLogger replaces by disposing logger that was previously used
-func ReplaceLogger(loggerNew seelog.LoggerInterface) (loggerOld seelog.LoggerInterface) {
-	loggerOld = seelog.Current
-	seelog.ReplaceLogger(loggerNew)
+// Logger provides a ceelog logger with prefix
+type Logger struct {
+	prefix string
+}
 
-	return loggerOld
+// NewLogger provides a logger with prefix equal to package name of the caller
+func NewLogger() *Logger {
+	pkg := retrieveCallInfo().packageName
+	localPkg := strings.Replace(pkg, "github.com/mysteriumnetwork/node/", "", 1)
+	return &Logger{
+		prefix: "[" + localPkg + "] ",
+	}
+}
+
+// Tracef trace log fmt
+func (l Logger) Tracef(format string, params ...interface{}) {
+	seelog.Tracef(l.prefix+format, params...)
+}
+
+// Debugf debug log fmt
+func (l Logger) Debugf(format string, params ...interface{}) {
+	seelog.Debugf(l.prefix+format, params...)
+}
+
+// Infof info log fmt
+func (l Logger) Infof(format string, params ...interface{}) {
+	seelog.Infof(l.prefix+format, params...)
+}
+
+// Warnf warn log fmt
+func (l Logger) Warnf(format string, params ...interface{}) error {
+	return seelog.Warnf(l.prefix+format, params...)
+}
+
+// Errorf error log fmt
+func (l Logger) Errorf(format string, params ...interface{}) error {
+	return seelog.Errorf(l.prefix+format, params...)
+}
+
+// Criticalf critical log fmt
+func (l Logger) Criticalf(format string, params ...interface{}) error {
+	return seelog.Criticalf(l.prefix+format, params...)
+}
+
+// Trace trace log
+func (l Logger) Trace(v ...interface{}) {
+	seelog.Trace(append([]interface{}{l.prefix}, v...)...)
+}
+
+// Debug debug log
+func (l Logger) Debug(v ...interface{}) {
+	seelog.Debug(append([]interface{}{l.prefix}, v...)...)
+}
+
+// Info info log
+func (l Logger) Info(v ...interface{}) {
+	seelog.Info(append([]interface{}{l.prefix}, v...)...)
+}
+
+// Warn warn log
+func (l Logger) Warn(v ...interface{}) error {
+	return seelog.Warn(append([]interface{}{l.prefix}, v...)...)
+}
+
+// Error error log
+func (l Logger) Error(v ...interface{}) error {
+	return seelog.Error(append([]interface{}{l.prefix}, v...)...)
+}
+
+// Critical critical log
+func (l Logger) Critical(v ...interface{}) error {
+	return seelog.Critical(append([]interface{}{l.prefix}, v...)...)
+}
+
+// Flush flushes logs to output
+func (l Logger) Flush() {
+	seelog.Flush()
 }

--- a/logconfig/seelog.go
+++ b/logconfig/seelog.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2018 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,12 +15,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package port
+package logconfig
 
-// Port (networking)
-type Port int
+import (
+	"github.com/cihub/seelog"
+)
 
-// Num returns port's numeric value
-func (p Port) Num() int {
-	return int(p)
+// ReplaceLogger replaces by disposing logger that was previously used
+func ReplaceLogger(loggerNew seelog.LoggerInterface) (loggerOld seelog.LoggerInterface) {
+	loggerOld = seelog.Current
+	seelog.ReplaceLogger(loggerNew)
+
+	return loggerOld
 }


### PR DESCRIPTION
Motivation: error-prone playing around with log prefixes, inconsistent formatting

How to use: simply declare `var log = logconfig.NewLogger()` and use it in the package.

To avoid runtime cost, call information is resolved once at a declare time,
thus there is a need to declare a variable. If overhead (around 25k ns) is
acceptable, we can remove package `log` variables.

Migrated core package for starters.