### PR TITLE
Connection attempts are now counted on provider side

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -305,7 +305,7 @@ func (di *Dependencies) bootstrapStateKeeper(options node.Options) error {
 	if err != nil {
 		return err
 	}
-	err = di.EventBus.SubscribeAsync(sessionevent.Topic, di.StateKeeper.ConsumeSessionEvent)
+	err = di.EventBus.SubscribeAsync(sessionevent.Topic, di.StateKeeper.ConsumeSessionStateEvent)
 	if err != nil {
 		return err
 	}
@@ -485,6 +485,7 @@ func newSessionManagerFactory(
 	natPingerChan func(*traversal.Params),
 	natTracker NatEventTracker,
 	serviceID string,
+	eventbus eventbus.EventBus,
 ) session.ManagerFactory {
 	return func(dialog communication.Dialog) *session.Manager {
 		providerBalanceTrackerFactory := func(consumerID, receiverID, issuerID identity.Identity) (session.BalanceTracker, error) {
@@ -519,6 +520,7 @@ func newSessionManagerFactory(
 			natPingerChan,
 			natTracker,
 			serviceID,
+			eventbus,
 		)
 	}
 }

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -238,7 +238,8 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 			di.PromiseStorage,
 			di.NATPinger.PingTarget,
 			di.NATTracker,
-			serviceID)
+			serviceID,
+			di.EventBus)
 		return session.NewDialogHandler(sessionManagerFactory, configProvider.ProvideConfig, di.PromiseStorage, identity.FromAddress(proposal.ProviderID))
 	}
 	di.ServicesManager = service.NewManager(

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -40,16 +40,23 @@ type NATStatus struct {
 	Error  string `json:"error"`
 }
 
+// ConnectionStatistics shows the successful and attempted connection count
+type ConnectionStatistics struct {
+	Attempted  int `json:"attempted"`
+	Successful int `json:"successful"`
+}
+
 // ServiceInfo stores the information about a service
 type ServiceInfo struct {
-	ID             string                 `json:"id"`
-	ProviderID     string                 `json:"providerId"`
-	Type           string                 `json:"type"`
-	Options        interface{}            `json:"options"`
-	Status         string                 `json:"status"`
-	Proposal       market.ServiceProposal `json:"proposal"`
-	AccessPolicies *[]market.AccessPolicy `json:"accessPolicies,omitempty"`
-	Sessions       []ServiceSession       `json:"serviceSession,omitempty"`
+	ID                   string                 `json:"id"`
+	ProviderID           string                 `json:"providerId"`
+	Type                 string                 `json:"type"`
+	Options              interface{}            `json:"options"`
+	Status               string                 `json:"status"`
+	Proposal             market.ServiceProposal `json:"proposal"`
+	AccessPolicies       *[]market.AccessPolicy `json:"accessPolicies,omitempty"`
+	Sessions             []ServiceSession       `json:"serviceSession,omitempty"`
+	ConnectionStatistics ConnectionStatistics   `json:"connectionStatistics"`
 }
 
 // ServiceSession represents the session object
@@ -65,4 +72,6 @@ type ServiceSession struct {
 	BytesOut int64 `json:"bytesOut"`
 	// example: 23451
 	BytesIn int64 `json:"bytesIn"`
+	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
+	ServiceID string `json:"serviceId"`
 }

--- a/session/acknowledge_messaging.go
+++ b/session/acknowledge_messaging.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package session
+
+import (
+	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/identity"
+)
+
+// AcknowledgeRequest represents the acknowledge request
+type AcknowledgeRequest struct {
+	AcknowledgeMessage AcknowledgeMessage `json:"acknowledgeMessage"`
+}
+
+// AcknowledgeMessage represents the acknowledge payload
+type AcknowledgeMessage struct {
+	SessionID string `json:"sessionId"`
+}
+
+// Acknowledger performs the actual acknowledging
+type Acknowledger interface {
+	Acknowledge(cID identity.Identity, sessionID string) error
+}
+
+const endpointAcknowledge = "session-aknowledge"
+const acknowledgeEndpoint = communication.MessageEndpoint(endpointAcknowledge)
+
+// AcknowledgeSender sends session acknowledge messages
+type AcknowledgeSender struct {
+	sender communication.Sender
+}
+
+// NewAcknowledgeSender creates a new instance of acknowledge sender
+func NewAcknowledgeSender(sender communication.Sender) *AcknowledgeSender {
+	return &AcknowledgeSender{
+		sender: sender,
+	}
+}
+
+// Send sends the acknowledge message
+func (as *AcknowledgeSender) Send(am AcknowledgeMessage) error {
+	return as.sender.Send(&acknowledgeMessageProducer{AcknowledgeMessage: am})
+}
+
+// AcknowledgeListener allows us to listen for acknowledge messages from consumers
+type AcknowledgeListener struct {
+	acknowledgeMessageConsumer *acknowledgeMessageConsumer
+}
+
+// NewListener returns a new instance of AcknowledgeListener
+func NewListener() *AcknowledgeListener {
+	return &AcknowledgeListener{
+		acknowledgeMessageConsumer: &acknowledgeMessageConsumer{},
+	}
+}
+
+// GetConsumer boilerplate for communication
+func (al *AcknowledgeListener) GetConsumer() *acknowledgeMessageConsumer {
+	return al.acknowledgeMessageConsumer
+}
+
+// Consume handles requests from endpoint and replies with response
+func (amc *acknowledgeMessageConsumer) Consume(requestPtr interface{}) (err error) {
+	request := requestPtr.(*AcknowledgeRequest)
+
+	err = amc.Acknowledger.Acknowledge(amc.PeerID, request.AcknowledgeMessage.SessionID)
+	return err
+}
+
+// Dialog boilerplate below, please ignore
+
+type acknowledgeMessageConsumer struct {
+	Acknowledger Acknowledger
+	PeerID       identity.Identity
+}
+
+// GetMessageEndpoint returns endpoint where to receive messages
+func (amc *acknowledgeMessageConsumer) GetMessageEndpoint() communication.MessageEndpoint {
+	return acknowledgeEndpoint
+}
+
+// NewRequest creates struct where request from endpoint will be serialized
+func (amc *acknowledgeMessageConsumer) NewMessage() (requestPtr interface{}) {
+	return &AcknowledgeRequest{}
+}
+
+// balanceMessageProducer
+type acknowledgeMessageProducer struct {
+	AcknowledgeMessage AcknowledgeMessage
+}
+
+// GetMessageEndpoint returns endpoint where to receive messages
+func (amp *acknowledgeMessageProducer) GetMessageEndpoint() communication.MessageEndpoint {
+	return acknowledgeEndpoint
+}
+
+// Produce produces a request message
+func (amp *acknowledgeMessageProducer) Produce() (requestPtr interface{}) {
+	return &AcknowledgeRequest{
+		AcknowledgeMessage: amp.AcknowledgeMessage,
+	}
+}
+
+// NewResponse returns a new response object
+func (amp *acknowledgeMessageProducer) NewResponse() (responsePtr interface{}) {
+	return nil
+}

--- a/session/create_producer.go
+++ b/session/create_producer.go
@@ -78,3 +78,11 @@ func RequestSessionCreate(sender communication.Sender, proposalID int, config in
 	}
 	return
 }
+
+// AcknowledgeSession lets the provider know we've successfully established a connection
+func AcknowledgeSession(sender communication.Sender, sessionID string) error {
+	ack := NewAcknowledgeSender(sender)
+	return ack.Send(AcknowledgeMessage{
+		SessionID: sessionID,
+	})
+}

--- a/session/create_producer_test.go
+++ b/session/create_producer_test.go
@@ -52,6 +52,12 @@ func TestProducer_RequestSessionCreate(t *testing.T) {
 	assert.Nil(t, paymentInfo)
 }
 
+func TestProducer_SessionAcknowledge(t *testing.T) {
+	sender := &fakeSender{}
+	err := AcknowledgeSession(sender, string(successfullSessionID))
+	assert.NoError(t, err)
+}
+
 type fakeSender struct {
 	lastRequest communication.RequestProducer
 }

--- a/session/dialog_handler.go
+++ b/session/dialog_handler.go
@@ -40,6 +40,7 @@ type handler struct {
 	configProvider        ConfigProvider
 	promiseLoader         PromiseLoader
 	receiverID            identity.Identity
+	publisher             publisher
 }
 
 // Handle starts serving services in given Dialog instance
@@ -57,7 +58,14 @@ func (handler *handler) subscribeSessionRequests(dialog communication.Dialog) er
 			receiverID:     handler.receiverID,
 		},
 	)
+	if err != nil {
+		return err
+	}
 
+	err = dialog.Receive(&acknowledgeMessageConsumer{
+		PeerID:       dialog.PeerID(),
+		Acknowledger: handler.sessionManagerFactory(dialog),
+	})
 	if err != nil {
 		return err
 	}

--- a/session/dto.go
+++ b/session/dto.go
@@ -42,7 +42,7 @@ type Session struct {
 	ID             ID
 	ConsumerID     identity.Identity
 	Config         ServiceConfiguration
-	serviceID      string
+	ServiceID      string
 	CreatedAt      time.Time
 	DataTransfered DataTransfered
 	Last           bool

--- a/session/event/event.go
+++ b/session/event/event.go
@@ -39,6 +39,8 @@ const (
 	Removed Action = "Removed"
 	// Updated indicates a session has been updated
 	Updated Action = "Updated"
+	// Acknowledged indicates a session has been reported as a success from consumer side
+	Acknowledged Action = "Acknowledged"
 )
 
 // Payload represents the event payload

--- a/session/storage_memory.go
+++ b/session/storage_memory.go
@@ -98,7 +98,7 @@ func (storage *StorageMemory) Remove(id ID) {
 func (storage *StorageMemory) RemoveForService(serviceID string) {
 	sessions := storage.GetAll()
 	for _, session := range sessions {
-		if session.serviceID == serviceID {
+		if session.ServiceID == serviceID {
 			storage.Remove(session.ID)
 		}
 	}


### PR DESCRIPTION
After a successful connection, the consumer will now send an ACK to the provider. On provider side, this ack is then published as an event.

The state keeper will also listen to session creation event to count the attempts.