### PR TITLE
Wait for valid registered identity before starting services

### DIFF
--- a/blockchain/abi/abigen.go
+++ b/blockchain/abi/abigen.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -29,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/pkg/errors"
 )
 
 var pkgName = flag.String("pkg", "", "Same as abigen tool from ethereum project")
@@ -122,10 +122,10 @@ func loadFromGitRepo(githubRepo string, contractList []string) ([]truffleArtifac
 		url := fmt.Sprintf(smartContractRepoUrl, githubRepo, *githubRelease, contractName)
 		resp, err := httpClient.Get(url)
 		if err != nil {
-			return nil, fmt.Errorf("error executing GET: %s", err.Error())
+			return nil, errors.Wrap(err, "error executing GET")
 		}
 		if resp.StatusCode != 200 {
-			return nil, fmt.Errorf("unexpected status. GET %s response code: %d", url, resp.StatusCode)
+			return nil, errors.Errorf("unexpected status. GET %s response code: %d", url, resp.StatusCode)
 		}
 		artifact, err := parseTruffleArtifact(resp.Body)
 		if err != nil {

--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -20,12 +20,14 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/chzyer/readline"
+	"github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/cmd"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/metadata"
@@ -64,9 +66,18 @@ func NewCommand() *cli.Command {
 			}
 			cmd.RegisterSignalCallback(utils.SoftKiller(cmdCLI.Kill))
 
-			return cmdCLI.Run()
+			return describeQuit(cmdCLI.Run())
 		},
 	}
+}
+
+func describeQuit(err error) error {
+	if err == nil || err == io.EOF || err == readline.ErrInterrupt {
+		seelog.Info("stopping application")
+		return nil
+	}
+	seelog.Errorf("terminating application due to error: %+v\n", err)
+	return err
 }
 
 // cliApp describes CLI based Mysterium UI

--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -21,15 +21,15 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
+	stdlog "log"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/chzyer/readline"
-	"github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/cmd"
 	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/mysteriumnetwork/node/services/noop"
 	"github.com/mysteriumnetwork/node/services/openvpn"
@@ -53,6 +53,8 @@ const serviceHelp = `service <action> [args]
 
 	example: service start 0x7d5ee3557775aed0b85d691b036769c17349db23 openvpn --access-policy.list=mysterium --openvpn.port=1194 --openvpn.proto=UDP`
 
+var log = logconfig.NewLogger()
+
 // NewCommand constructs CLI based Mysterium UI with possibility to control quiting
 func NewCommand() *cli.Command {
 	return &cli.Command{
@@ -73,10 +75,10 @@ func NewCommand() *cli.Command {
 
 func describeQuit(err error) error {
 	if err == nil || err == io.EOF || err == readline.ErrInterrupt {
-		seelog.Info("stopping application")
+		log.Info("stopping application")
 		return nil
 	}
-	seelog.Errorf("terminating application due to error: %+v\n", err)
+	log.Errorf("terminating application due to error: %+v\n", err)
 	return err
 }
 
@@ -122,7 +124,7 @@ func (c *cliApp) Run() (err error) {
 		return err
 	}
 	// TODO Should overtake output of CommandRun
-	log.SetOutput(c.reader.Stderr())
+	stdlog.SetOutput(c.reader.Stderr())
 
 	for {
 		line, err := c.reader.Readline()

--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -18,7 +18,6 @@
 package cli
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -27,8 +26,6 @@ import (
 	"strings"
 
 	"github.com/chzyer/readline"
-	"github.com/urfave/cli"
-
 	"github.com/mysteriumnetwork/node/cmd"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/metadata"
@@ -39,6 +36,8 @@ import (
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	tequilapi_client "github.com/mysteriumnetwork/node/tequilapi/client"
 	"github.com/mysteriumnetwork/node/utils"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
 )
 
 const cliCommandName = "cli"

--- a/cmd/commands/daemon/command.go
+++ b/cmd/commands/daemon/command.go
@@ -18,10 +18,12 @@
 package daemon
 
 import (
-	"github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/cmd"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/urfave/cli"
 )
+
+var log = logconfig.NewLogger()
 
 // NewCommand function creates run command
 func NewCommand() *cli.Command {
@@ -50,9 +52,9 @@ func NewCommand() *cli.Command {
 
 func describeQuit(err error) error {
 	if err == nil {
-		seelog.Info("stopping application")
+		log.Info("stopping application")
 	} else {
-		seelog.Errorf("terminating application due to error: %+v\n", err)
+		log.Errorf("terminating application due to error: %+v\n", err)
 	}
 	return err
 }

--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -145,7 +145,7 @@ func (sc *serviceCommand) Run(ctx *cli.Context) (err error) {
 func (sc *serviceCommand) unlockIdentity(identityOptions service.OptionsIdentity) (*identity.Identity, error) {
 	id, err := sc.tequilapi.CurrentIdentity(identityOptions.Identity, identityOptions.Passphrase)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to unlock identity")
 	}
 
 	return &identity.Identity{Address: id.Address}, nil
@@ -166,7 +166,7 @@ func (sc *serviceCommand) runServices(ctx *cli.Context, providerID string, servi
 func (sc *serviceCommand) runService(providerID, serviceType string, options service.Options) {
 	_, err := sc.tequilapi.ServiceStart(providerID, serviceType, options, sc.ap)
 	if err != nil {
-		sc.errorChannel <- err
+		sc.errorChannel <- errors.Wrapf(err, "failed to run service %s", serviceType)
 	}
 }
 

--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -31,6 +31,7 @@ import (
 	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn/service"
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/mysteriumnetwork/node/tequilapi/client"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -194,7 +195,7 @@ func parseFlagsByServiceType(ctx *cli.Context, serviceType string) (service.Opti
 	if f, ok := serviceTypesFlagsParser[serviceType]; ok {
 		return f(ctx), nil
 	}
-	return service.OptionsIdentity{}, fmt.Errorf("unknown service type: %q", serviceType)
+	return service.OptionsIdentity{}, errors.Errorf("unknown service type: %q", serviceType)
 }
 
 func printTermWarning(licenseCommandName string) {

--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -143,9 +143,8 @@ func (sc *serviceCommand) Run(ctx *cli.Context) (err error) {
 	return <-sc.errorChannel
 }
 
-const retryRate = 10 * time.Second
-
 func (sc *serviceCommand) unlockIdentity(identityOptions service.OptionsIdentity) *identity.Identity {
+	const retryRate = 10 * time.Second
 	for {
 		id, err := sc.tequilapi.CurrentIdentity(identityOptions.Identity, identityOptions.Passphrase)
 		if err == nil {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -615,7 +615,7 @@ func (di *Dependencies) bootstrapDiscoveryComponents(options node.OptionsDiscove
 		sender := discovery_broker.NewSender(nats.NewConnectionMock())
 		registry = discovery_broker.NewRegistry(sender)
 	default:
-		return fmt.Errorf("unknown discovery provider: %s", options.Type)
+		return errors.Errorf("unknown discovery provider: %s", options.Type)
 	}
 
 	di.DiscoveryFactory = func() service.Discovery {
@@ -646,7 +646,7 @@ func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) 
 	case node.QualityTypeNone:
 		transport = quality.NewNoopTransport()
 	default:
-		err = fmt.Errorf("unknown Quality Oracle provider: %s", options.Type)
+		err = errors.Errorf("unknown Quality Oracle provider: %s", options.Type)
 	}
 	if err != nil {
 		return err
@@ -675,7 +675,7 @@ func (di *Dependencies) bootstrapLocationComponents(options node.OptionsLocation
 		}
 		resolver, err = location.NewOracleResolver(options.Address), nil
 	default:
-		err = fmt.Errorf("unknown location provider: %s", options.Type)
+		err = errors.Errorf("unknown location provider: %s", options.Type)
 	}
 	if err != nil {
 		return err

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -633,7 +633,7 @@ func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) 
 	if _, err := firewall.AllowURLAccess(di.NetworkDefinition.QualityOracle); err != nil {
 		return err
 	}
-	di.QualityClient = quality.NewMorqaClient(di.NetworkDefinition.QualityOracle, 30*time.Second)
+	di.QualityClient = quality.NewMorqaClient(di.NetworkDefinition.QualityOracle, 20*time.Second)
 
 	var transport quality.Transport
 	switch options.Type {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -657,7 +657,7 @@ func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) 
 
 func (di *Dependencies) bootstrapLocationComponents(options node.OptionsLocation, configDirectory string) (err error) {
 	if _, err = firewall.AllowURLAccess(options.IPDetectorURL); err != nil {
-		return err
+		return errors.Wrap(err, "failed to add firewall exception")
 	}
 	di.IPResolver = ip.NewResolver(options.IPDetectorURL)
 

--- a/communication/codec_bytes.go
+++ b/communication/codec_bytes.go
@@ -18,8 +18,9 @@
 package communication
 
 import (
-	"fmt"
 	"reflect"
+
+	"github.com/pkg/errors"
 )
 
 // NewCodecBytes returns codec which:
@@ -47,7 +48,7 @@ func (codec *codecBytes) Pack(payloadPtr interface{}) ([]byte, error) {
 		return []byte(payload), nil
 	}
 
-	return []byte{}, fmt.Errorf("Cant pack payload: %#v", payloadPtr)
+	return []byte{}, errors.Errorf("Cant pack payload: %#v", payloadPtr)
 }
 
 func (codec *codecBytes) Unpack(data []byte, payloadPtr interface{}) error {
@@ -58,6 +59,6 @@ func (codec *codecBytes) Unpack(data []byte, payloadPtr interface{}) error {
 
 	default:
 		payloadValue := reflect.ValueOf(payloadPtr)
-		return fmt.Errorf("Cant unpack to payload: %s", payloadValue.Type().String())
+		return errors.Errorf("Cant unpack to payload: %s", payloadValue.Type().String())
 	}
 }

--- a/communication/codec_bytes.go
+++ b/communication/codec_bytes.go
@@ -48,7 +48,7 @@ func (codec *codecBytes) Pack(payloadPtr interface{}) ([]byte, error) {
 		return []byte(payload), nil
 	}
 
-	return []byte{}, errors.Errorf("Cant pack payload: %#v", payloadPtr)
+	return []byte{}, errors.Errorf("can't pack payload: %#v", payloadPtr)
 }
 
 func (codec *codecBytes) Unpack(data []byte, payloadPtr interface{}) error {
@@ -59,6 +59,6 @@ func (codec *codecBytes) Unpack(data []byte, payloadPtr interface{}) error {
 
 	default:
 		payloadValue := reflect.ValueOf(payloadPtr)
-		return errors.Errorf("Cant unpack to payload: %s", payloadValue.Type().String())
+		return errors.Errorf("can't unpack to payload: %s", payloadValue.Type().String())
 	}
 }

--- a/communication/codec_bytes_test.go
+++ b/communication/codec_bytes_test.go
@@ -20,7 +20,7 @@ package communication
 import (
 	"testing"
 
-	assert2 "github.com/mysteriumnetwork/node/testkit/assert"
+	"github.com/mysteriumnetwork/node/testkit/assertkit"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,7 +43,7 @@ func TestCodecBytesPack(t *testing.T) {
 		data, err := codec.Pack(tt.payload)
 
 		assert.Exactly(t, tt.expectedData, data)
-		assert2.EqualOptionalError(t, err, tt.expectedErrorMsg)
+		assertkit.EqualOptionalError(t, err, tt.expectedErrorMsg)
 	}
 }
 

--- a/communication/codec_bytes_test.go
+++ b/communication/codec_bytes_test.go
@@ -18,9 +18,9 @@
 package communication
 
 import (
-	"errors"
 	"testing"
 
+	assert2 "github.com/mysteriumnetwork/node/testkit/assert"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,14 +28,14 @@ var _ Codec = &codecBytes{}
 
 func TestCodecBytesPack(t *testing.T) {
 	table := []struct {
-		payload       interface{}
-		expectedData  []byte
-		expectedError error
+		payload          interface{}
+		expectedData     []byte
+		expectedErrorMsg string
 	}{
-		{`hello`, []byte(`hello`), nil},
-		{`hello "name"`, []byte(`hello "name"`), nil},
-		{nil, []byte{}, nil},
-		{true, []byte{}, errors.New("Cant pack payload: true")},
+		{`hello`, []byte(`hello`), ""},
+		{`hello "name"`, []byte(`hello "name"`), ""},
+		{nil, []byte{}, ""},
+		{true, []byte{}, "can't pack payload: true"},
 	}
 
 	codec := codecBytes{}
@@ -43,7 +43,7 @@ func TestCodecBytesPack(t *testing.T) {
 		data, err := codec.Pack(tt.payload)
 
 		assert.Exactly(t, tt.expectedData, data)
-		assert.Exactly(t, tt.expectedError, err)
+		assert2.EqualOptionalError(t, err, tt.expectedErrorMsg)
 	}
 }
 
@@ -54,7 +54,7 @@ func TestCodecBytesUnpackToString(t *testing.T) {
 	err := codec.Unpack([]byte(`hello`), &payload)
 
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Cant unpack to payload: *string")
+	assert.EqualError(t, err, "can't unpack to payload: *string")
 }
 
 func TestCodecBytesUnpackToByte(t *testing.T) {
@@ -64,7 +64,7 @@ func TestCodecBytesUnpackToByte(t *testing.T) {
 	err := codec.Unpack([]byte(`hello`), payload)
 
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Cant unpack to payload: []uint8")
+	assert.EqualError(t, err, "can't unpack to payload: []uint8")
 }
 
 func TestCodecBytesUnpack(t *testing.T) {

--- a/communication/nats/connection_mock.go
+++ b/communication/nats/connection_mock.go
@@ -18,11 +18,10 @@
 package nats
 
 import (
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/nats-io/go-nats"
+	"github.com/pkg/errors"
 )
 
 // NewConnectionMock constructs new NATS connection
@@ -149,7 +148,7 @@ func (conn *ConnectionMock) Request(subject string, payload []byte, timeout time
 	case response := <-responseCh:
 		return response, nil
 	case <-time.After(timeout):
-		return nil, fmt.Errorf("request '%s' timeout", subject)
+		return nil, errors.Errorf("request '%s' timeout", subject)
 	}
 }
 

--- a/communication/nats/dialog/codec_secured.go
+++ b/communication/nats/dialog/codec_secured.go
@@ -19,10 +19,10 @@ package dialog
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/pkg/errors"
 )
 
 // NewCodecSecured returns codec which:
@@ -72,7 +72,7 @@ func (codec *codecSecured) Unpack(data []byte, payloadPtr interface{}) error {
 	}
 
 	if !codec.verifier.Verify(envelope.Payload, identity.SignatureBase64(envelope.Signature)) {
-		return fmt.Errorf("invalid message signature '%s'", envelope.Signature)
+		return errors.Errorf("invalid message signature '%s'", envelope.Signature)
 	}
 
 	return codec.codecPacker.Unpack(envelope.Payload, payloadPtr)

--- a/communication/nats/dialog/dialog_establisher.go
+++ b/communication/nats/dialog/dialog_establisher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/communication/nats/discovery"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/pkg/errors"
 )
 
 // NewDialogEstablisher constructs new DialogEstablisher which works thru NATS connection.
@@ -60,7 +61,7 @@ func (establisher *dialogEstablisher) EstablishDialog(
 	log.Info(establisherLogPrefix, fmt.Sprintf("Connecting to: %#v", peerContact))
 	peerAddress, err := establisher.peerAddressFactory(peerContact)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to: %#v. %s", peerContact, err)
+		return nil, errors.Errorf("failed to connect to: %#v. %s", peerContact, err)
 	}
 
 	peerCodec := establisher.newCodecForPeer(peerID)
@@ -86,10 +87,10 @@ func (establisher *dialogEstablisher) negotiateTopic(sender communication.Sender
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("dialog creation error. %s", err)
+		return "", errors.Errorf("dialog creation error. %s", err)
 	}
 	if response.(*dialogCreateResponse).Reason != 200 {
-		return "", fmt.Errorf("dialog creation rejected. %#v", response)
+		return "", errors.Errorf("dialog creation rejected. %#v", response)
 	}
 
 	return response.(*dialogCreateResponse).Topic, nil

--- a/communication/nats/dialog/dialog_establisher.go
+++ b/communication/nats/dialog/dialog_establisher.go
@@ -61,7 +61,7 @@ func (establisher *dialogEstablisher) EstablishDialog(
 	log.Info(establisherLogPrefix, fmt.Sprintf("Connecting to: %#v", peerContact))
 	peerAddress, err := establisher.peerAddressFactory(peerContact)
 	if err != nil {
-		return nil, errors.Errorf("failed to connect to: %#v. %s", peerContact, err)
+		return nil, errors.Wrapf(err, "failed to connect to: %#v", peerContact)
 	}
 
 	peerCodec := establisher.newCodecForPeer(peerID)
@@ -87,7 +87,7 @@ func (establisher *dialogEstablisher) negotiateTopic(sender communication.Sender
 		},
 	})
 	if err != nil {
-		return "", errors.Errorf("dialog creation error. %s", err)
+		return "", errors.Wrapf(err, "dialog creation error")
 	}
 	if response.(*dialogCreateResponse).Reason != 200 {
 		return "", errors.Errorf("dialog creation rejected. %#v", response)

--- a/communication/nats/dialog/dialog_establisher_test.go
+++ b/communication/nats/dialog/dialog_establisher_test.go
@@ -96,7 +96,7 @@ func TestDialogEstablisher_CreateDialogWhenResponseHijacked(t *testing.T) {
 
 	dialogInstance, err := establisher.EstablishDialog(peerID, market.Contact{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dialog creation error. failed to unpack response 'peer-topic.dialog-create'. invalid message signature ")
+	assert.Contains(t, err.Error(), "dialog creation error: failed to unpack response 'peer-topic.dialog-create': invalid message signature ")
 	assert.Nil(t, dialogInstance)
 }
 

--- a/communication/nats/dialog/dialog_waiter.go
+++ b/communication/nats/dialog/dialog_waiter.go
@@ -60,7 +60,7 @@ func (waiter *dialogWaiter) Start() (market.Contact, error) {
 
 	err := waiter.address.Connect()
 	if err != nil {
-		return market.Contact{}, fmt.Errorf("failed to start my connection with: %v", waiter.address.GetContact())
+		return market.Contact{}, errors.Errorf("failed to start my connection with: %v", waiter.address.GetContact())
 	}
 
 	return waiter.address.GetContact(), nil

--- a/communication/nats/discovery/address.go
+++ b/communication/nats/discovery/address.go
@@ -24,16 +24,16 @@ import (
 	"time"
 
 	"github.com/mysteriumnetwork/node/firewall"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/pkg/errors"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication/nats"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	nats_lib "github.com/nats-io/go-nats"
 )
 
-const natsLogPrefix = "[NATS] "
+var log = logconfig.NewLogger()
 
 // NewAddress creates NATS address to known host or cluster of hosts
 func NewAddress(topic string, addresses ...string) *AddressNATS {
@@ -108,8 +108,8 @@ func (address *AddressNATS) Connect() (err error) {
 	options.ReconnectWait = BrokerReconnectWait
 	options.Timeout = BrokerTimeout
 	options.PingInterval = 10 * time.Second
-	options.DisconnectedCB = func(nc *nats_lib.Conn) { log.Warn(natsLogPrefix, "Disconnected") }
-	options.ReconnectedCB = func(nc *nats_lib.Conn) { log.Warn(natsLogPrefix, "Reconnected") }
+	options.DisconnectedCB = func(nc *nats_lib.Conn) { log.Warn("disconnected") }
+	options.ReconnectedCB = func(nc *nats_lib.Conn) { log.Warn("reconnected") }
 
 	removeRules, err := firewall.AllowURLAccess(address.servers...)
 	if err != nil {

--- a/communication/nats/discovery/address.go
+++ b/communication/nats/discovery/address.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/mysteriumnetwork/node/firewall"
+	"github.com/pkg/errors"
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication/nats"
@@ -68,12 +69,12 @@ func NewAddressFromHostAndID(uri string, myID identity.Identity, serviceType str
 // NewAddressForContact extracts NATS address from given contact structure
 func NewAddressForContact(contact market.Contact) (*AddressNATS, error) {
 	if contact.Type != TypeContactNATSV1 {
-		return nil, fmt.Errorf("invalid contact type: %s", contact.Type)
+		return nil, errors.Errorf("invalid contact type: %s", contact.Type)
 	}
 
 	contactNats, ok := contact.Definition.(ContactNATSV1)
 	if !ok {
-		return nil, fmt.Errorf("invalid contact definition: %#v", contact.Definition)
+		return nil, errors.Errorf("invalid contact definition: %#v", contact.Definition)
 	}
 
 	return &AddressNATS{

--- a/communication/nats/receiver.go
+++ b/communication/nats/receiver.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
 	nats "github.com/nats-io/go-nats"
+	"github.com/pkg/errors"
 )
 
 const receiverLogPrefix = "[NATS.Receiver] "
@@ -57,14 +58,14 @@ func (receiver *receiverNATS) Receive(consumer communication.MessageConsumer) er
 		messagePtr := consumer.NewMessage()
 		err := receiver.codec.Unpack(msg.Data, messagePtr)
 		if err != nil {
-			err = fmt.Errorf("failed to unpack message '%s'. %s", messageTopic, err)
+			err = errors.Errorf("failed to unpack message '%s'. %s", messageTopic, err)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
 
 		err = consumer.Consume(messagePtr)
 		if err != nil {
-			err = fmt.Errorf("failed to process message '%s'. %s", messageTopic, err)
+			err = errors.Errorf("failed to process message '%s'. %s", messageTopic, err)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
@@ -75,7 +76,7 @@ func (receiver *receiverNATS) Receive(consumer communication.MessageConsumer) er
 
 	subscription, err := receiver.connection.Subscribe(messageTopic, messageHandler)
 	if err != nil {
-		err = fmt.Errorf("failed subscribe message '%s'. %s", messageTopic, err)
+		err = errors.Errorf("failed subscribe message '%s'. %s", messageTopic, err)
 		return err
 	}
 	receiver.subs[messageTopic] = subscription
@@ -102,21 +103,21 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 		requestPtr := consumer.NewRequest()
 		err := receiver.codec.Unpack(msg.Data, requestPtr)
 		if err != nil {
-			err = fmt.Errorf("failed to unpack request '%s'. %s", requestTopic, err)
+			err = errors.Errorf("failed to unpack request '%s'. %s", requestTopic, err)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
 
 		response, err := consumer.Consume(requestPtr)
 		if err != nil {
-			err = fmt.Errorf("failed to process request '%s'. %s", requestTopic, err)
+			err = errors.Errorf("failed to process request '%s'. %s", requestTopic, err)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
 
 		responseData, err := receiver.codec.Pack(response)
 		if err != nil {
-			err = fmt.Errorf("failed to pack response '%s'. %s", requestTopic, err)
+			err = errors.Errorf("failed to pack response '%s'. %s", requestTopic, err)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
@@ -124,7 +125,7 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 		log.Debug(receiverLogPrefix, fmt.Sprintf("Request '%s' response: %s", requestTopic, responseData))
 		err = receiver.connection.Publish(msg.Reply, responseData)
 		if err != nil {
-			err = fmt.Errorf("failed to send response '%s'. %s", requestTopic, err)
+			err = errors.Errorf("failed to send response '%s'. %s", requestTopic, err)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
@@ -142,7 +143,7 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 
 	subscription, err := receiver.connection.Subscribe(requestTopic, messageHandler)
 	if err != nil {
-		err = fmt.Errorf("failed subscribe request '%s'. %s", requestTopic, err)
+		err = errors.Errorf("failed subscribe request '%s'. %s", requestTopic, err)
 		return err
 	}
 

--- a/communication/nats/receiver.go
+++ b/communication/nats/receiver.go
@@ -23,7 +23,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
-	nats "github.com/nats-io/go-nats"
+	"github.com/nats-io/go-nats"
 	"github.com/pkg/errors"
 )
 
@@ -58,14 +58,14 @@ func (receiver *receiverNATS) Receive(consumer communication.MessageConsumer) er
 		messagePtr := consumer.NewMessage()
 		err := receiver.codec.Unpack(msg.Data, messagePtr)
 		if err != nil {
-			err = errors.Errorf("failed to unpack message '%s'. %s", messageTopic, err)
+			err = errors.Wrapf(err, "failed to unpack message '%s'", messageTopic)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
 
 		err = consumer.Consume(messagePtr)
 		if err != nil {
-			err = errors.Errorf("failed to process message '%s'. %s", messageTopic, err)
+			err = errors.Wrapf(err, "failed to process message '%s'", messageTopic)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
@@ -76,7 +76,7 @@ func (receiver *receiverNATS) Receive(consumer communication.MessageConsumer) er
 
 	subscription, err := receiver.connection.Subscribe(messageTopic, messageHandler)
 	if err != nil {
-		err = errors.Errorf("failed subscribe message '%s'. %s", messageTopic, err)
+		err = errors.Wrapf(err, "failed subscribe message '%s'", messageTopic)
 		return err
 	}
 	receiver.subs[messageTopic] = subscription
@@ -103,21 +103,21 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 		requestPtr := consumer.NewRequest()
 		err := receiver.codec.Unpack(msg.Data, requestPtr)
 		if err != nil {
-			err = errors.Errorf("failed to unpack request '%s'. %s", requestTopic, err)
+			err = errors.Wrapf(err, "failed to unpack request '%s'", requestTopic)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
 
 		response, err := consumer.Consume(requestPtr)
 		if err != nil {
-			err = errors.Errorf("failed to process request '%s'. %s", requestTopic, err)
+			err = errors.Wrapf(err, "failed to process request '%s'", requestTopic)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
 
 		responseData, err := receiver.codec.Pack(response)
 		if err != nil {
-			err = errors.Errorf("failed to pack response '%s'. %s", requestTopic, err)
+			err = errors.Wrapf(err, "failed to pack response '%s'", requestTopic)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
@@ -125,7 +125,7 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 		log.Debug(receiverLogPrefix, fmt.Sprintf("Request '%s' response: %s", requestTopic, responseData))
 		err = receiver.connection.Publish(msg.Reply, responseData)
 		if err != nil {
-			err = errors.Errorf("failed to send response '%s'. %s", requestTopic, err)
+			err = errors.Wrapf(err, "failed to send response '%s'", requestTopic)
 			log.Error(receiverLogPrefix, err)
 			return
 		}
@@ -143,7 +143,7 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 
 	subscription, err := receiver.connection.Subscribe(requestTopic, messageHandler)
 	if err != nil {
-		err = errors.Errorf("failed subscribe request '%s'. %s", requestTopic, err)
+		err = errors.Wrapf(err, "failed subscribe request '%s'", requestTopic)
 		return err
 	}
 

--- a/communication/nats/receiver.go
+++ b/communication/nats/receiver.go
@@ -18,16 +18,15 @@
 package nats
 
 import (
-	"fmt"
 	"sync"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/nats-io/go-nats"
 	"github.com/pkg/errors"
 )
 
-const receiverLogPrefix = "[NATS.Receiver] "
+var rlog = logconfig.NewNamespaceLogger("receiver")
 
 // NewReceiver constructs new Receiver's instance which works through NATS connection.
 // Codec packs/unpacks messages to byte payloads.
@@ -54,19 +53,19 @@ func (receiver *receiverNATS) Receive(consumer communication.MessageConsumer) er
 	messageTopic := receiver.messageTopic + string(consumer.GetMessageEndpoint())
 
 	messageHandler := func(msg *nats.Msg) {
-		log.Debug(receiverLogPrefix, fmt.Sprintf("Message '%s' received: %s", messageTopic, msg.Data))
+		rlog.Debugf("message %q received: %s", messageTopic, msg.Data)
 		messagePtr := consumer.NewMessage()
 		err := receiver.codec.Unpack(msg.Data, messagePtr)
 		if err != nil {
-			err = errors.Wrapf(err, "failed to unpack message '%s'", messageTopic)
-			log.Error(receiverLogPrefix, err)
+			err = errors.Wrapf(err, "failed to unpack message %q", messageTopic)
+			rlog.Error(err)
 			return
 		}
 
 		err = consumer.Consume(messagePtr)
 		if err != nil {
-			err = errors.Wrapf(err, "failed to process message '%s'", messageTopic)
-			log.Error(receiverLogPrefix, err)
+			err = errors.Wrapf(err, "failed to process message %q", messageTopic)
+			rlog.Error(err)
 			return
 		}
 	}
@@ -89,9 +88,9 @@ func (receiver *receiverNATS) Unsubscribe() {
 
 	for topic, s := range receiver.subs {
 		if err := s.Unsubscribe(); err != nil {
-			log.Error(receiverLogPrefix, "failed to unsubscribed from topic: ", topic)
+			rlog.Error("failed to unsubscribe from topic: ", topic)
 		}
-		log.Info(receiverLogPrefix, topic, " unsubscribed")
+		rlog.Infof(" unsubscribed from %s", topic)
 	}
 }
 
@@ -99,34 +98,34 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 	requestTopic := receiver.messageTopic + string(consumer.GetRequestEndpoint())
 
 	messageHandler := func(msg *nats.Msg) {
-		log.Debug(receiverLogPrefix, fmt.Sprintf("Request '%s' received: %s", requestTopic, msg.Data))
+		rlog.Debugf("request %q received: %s", requestTopic, msg.Data)
 		requestPtr := consumer.NewRequest()
 		err := receiver.codec.Unpack(msg.Data, requestPtr)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to unpack request '%s'", requestTopic)
-			log.Error(receiverLogPrefix, err)
+			rlog.Error(err)
 			return
 		}
 
 		response, err := consumer.Consume(requestPtr)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to process request '%s'", requestTopic)
-			log.Error(receiverLogPrefix, err)
+			rlog.Error(err)
 			return
 		}
 
 		responseData, err := receiver.codec.Pack(response)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to pack response '%s'", requestTopic)
-			log.Error(receiverLogPrefix, err)
+			rlog.Error(err)
 			return
 		}
 
-		log.Debug(receiverLogPrefix, fmt.Sprintf("Request '%s' response: %s", requestTopic, responseData))
+		rlog.Debugf("request %q response: %s", requestTopic, responseData)
 		err = receiver.connection.Publish(msg.Reply, responseData)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to send response '%s'", requestTopic)
-			log.Error(receiverLogPrefix, err)
+			rlog.Error(err)
 			return
 		}
 	}
@@ -135,11 +134,11 @@ func (receiver *receiverNATS) Respond(consumer communication.RequestConsumer) er
 	defer receiver.mu.Unlock()
 
 	if subscription, ok := receiver.subs[requestTopic]; ok && subscription.IsValid() {
-		log.Debug(receiverLogPrefix, fmt.Sprintf("Already subscribed to '%s' topic", requestTopic))
+		rlog.Debugf("already subscribed to %q topic", requestTopic)
 		return nil
 	}
 
-	log.Debug(receiverLogPrefix, fmt.Sprintf("Request '%s' topic has been subscribed to", requestTopic))
+	rlog.Debugf("request %q topic has been subscribed to", requestTopic)
 
 	subscription, err := receiver.connection.Subscribe(requestTopic, messageHandler)
 	if err != nil {

--- a/communication/nats/sender.go
+++ b/communication/nats/sender.go
@@ -18,15 +18,14 @@
 package nats
 
 import (
-	"fmt"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/pkg/errors"
 )
 
-const senderLogPrefix = "[NATS.Sender] "
+var slog = logconfig.NewNamespaceLogger("sender")
 
 // NewSender constructs new Sender's instance which works thru NATS connection.
 // Codec packs/unpacks messages to byte payloads.
@@ -57,10 +56,10 @@ func (sender *senderNATS) Send(producer communication.MessageProducer) error {
 	}
 
 	if err := sender.connection.Check(); err != nil {
-		log.Warn(senderLogPrefix, "Connection failed: ", err)
+		slog.Warn("connection failed: ", err)
 	}
 
-	log.Debug(senderLogPrefix, fmt.Sprintf("Message '%s' sending: %s", messageTopic, messageData))
+	slog.Debugf("Message %q sending: %s", messageTopic, messageData)
 	err = sender.connection.Publish(messageTopic, messageData)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to send message '%s'", messageTopic)
@@ -81,21 +80,21 @@ func (sender *senderNATS) Request(producer communication.RequestProducer) (respo
 	}
 
 	if err := sender.connection.Check(); err != nil {
-		log.Warn(senderLogPrefix, "Connection failed: ", err)
+		slog.Warn("connection failed: ", err)
 	}
 
-	log.Debug(senderLogPrefix, fmt.Sprintf("Request '%s' sending: %s", requestTopic, requestData))
+	slog.Debugf("request %q sending: %s", requestTopic, requestData)
 	msg, err := sender.connection.Request(requestTopic, requestData, sender.timeoutRequest)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to send request '%s'", requestTopic)
 		return
 	}
 
-	log.Debug(senderLogPrefix, fmt.Sprintf("Received response for '%s': %s", requestTopic, msg.Data))
+	slog.Debugf("received response for %q: %s", requestTopic, msg.Data)
 	err = sender.codec.Unpack(msg.Data, responsePtr)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to unpack response '%s'", requestTopic)
-		log.Error(receiverLogPrefix, err)
+		slog.Error(err)
 		return
 	}
 

--- a/communication/nats/sender.go
+++ b/communication/nats/sender.go
@@ -23,6 +23,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
+	"github.com/pkg/errors"
 )
 
 const senderLogPrefix = "[NATS.Sender] "
@@ -51,7 +52,7 @@ func (sender *senderNATS) Send(producer communication.MessageProducer) error {
 
 	messageData, err := sender.codec.Pack(producer.Produce())
 	if err != nil {
-		err = fmt.Errorf("failed to encode message '%s'. %s", messageTopic, err)
+		err = errors.Errorf("failed to encode message '%s'. %s", messageTopic, err)
 		return err
 	}
 
@@ -62,7 +63,7 @@ func (sender *senderNATS) Send(producer communication.MessageProducer) error {
 	log.Debug(senderLogPrefix, fmt.Sprintf("Message '%s' sending: %s", messageTopic, messageData))
 	err = sender.connection.Publish(messageTopic, messageData)
 	if err != nil {
-		err = fmt.Errorf("failed to send message '%s'. %s", messageTopic, err)
+		err = errors.Errorf("failed to send message '%s'. %s", messageTopic, err)
 		return err
 	}
 
@@ -75,7 +76,7 @@ func (sender *senderNATS) Request(producer communication.RequestProducer) (respo
 
 	requestData, err := sender.codec.Pack(producer.Produce())
 	if err != nil {
-		err = fmt.Errorf("failed to pack request '%s'. %s", requestTopic, err)
+		err = errors.Errorf("failed to pack request '%s'. %s", requestTopic, err)
 		return
 	}
 
@@ -86,14 +87,14 @@ func (sender *senderNATS) Request(producer communication.RequestProducer) (respo
 	log.Debug(senderLogPrefix, fmt.Sprintf("Request '%s' sending: %s", requestTopic, requestData))
 	msg, err := sender.connection.Request(requestTopic, requestData, sender.timeoutRequest)
 	if err != nil {
-		err = fmt.Errorf("failed to send request '%s'. %s", requestTopic, err)
+		err = errors.Errorf("failed to send request '%s'. %s", requestTopic, err)
 		return
 	}
 
 	log.Debug(senderLogPrefix, fmt.Sprintf("Received response for '%s': %s", requestTopic, msg.Data))
 	err = sender.codec.Unpack(msg.Data, responsePtr)
 	if err != nil {
-		err = fmt.Errorf("failed to unpack response '%s'. %s", requestTopic, err)
+		err = errors.Errorf("failed to unpack response '%s'. %s", requestTopic, err)
 		log.Error(receiverLogPrefix, err)
 		return
 	}

--- a/communication/nats/sender.go
+++ b/communication/nats/sender.go
@@ -52,7 +52,7 @@ func (sender *senderNATS) Send(producer communication.MessageProducer) error {
 
 	messageData, err := sender.codec.Pack(producer.Produce())
 	if err != nil {
-		err = errors.Errorf("failed to encode message '%s'. %s", messageTopic, err)
+		err = errors.Wrapf(err, "failed to encode message '%s'", messageTopic)
 		return err
 	}
 
@@ -63,7 +63,7 @@ func (sender *senderNATS) Send(producer communication.MessageProducer) error {
 	log.Debug(senderLogPrefix, fmt.Sprintf("Message '%s' sending: %s", messageTopic, messageData))
 	err = sender.connection.Publish(messageTopic, messageData)
 	if err != nil {
-		err = errors.Errorf("failed to send message '%s'. %s", messageTopic, err)
+		err = errors.Wrapf(err, "failed to send message '%s'", messageTopic)
 		return err
 	}
 
@@ -76,7 +76,7 @@ func (sender *senderNATS) Request(producer communication.RequestProducer) (respo
 
 	requestData, err := sender.codec.Pack(producer.Produce())
 	if err != nil {
-		err = errors.Errorf("failed to pack request '%s'. %s", requestTopic, err)
+		err = errors.Wrapf(err, "failed to pack request '%s'", requestTopic)
 		return
 	}
 
@@ -87,14 +87,14 @@ func (sender *senderNATS) Request(producer communication.RequestProducer) (respo
 	log.Debug(senderLogPrefix, fmt.Sprintf("Request '%s' sending: %s", requestTopic, requestData))
 	msg, err := sender.connection.Request(requestTopic, requestData, sender.timeoutRequest)
 	if err != nil {
-		err = errors.Errorf("failed to send request '%s'. %s", requestTopic, err)
+		err = errors.Wrapf(err, "failed to send request '%s'", requestTopic)
 		return
 	}
 
 	log.Debug(senderLogPrefix, fmt.Sprintf("Received response for '%s': %s", requestTopic, msg.Data))
 	err = sender.codec.Unpack(msg.Data, responsePtr)
 	if err != nil {
-		err = errors.Errorf("failed to unpack response '%s'. %s", requestTopic, err)
+		err = errors.Wrapf(err, "failed to unpack response '%s'", requestTopic)
 		log.Error(receiverLogPrefix, err)
 		return
 	}

--- a/consumer/statistics/reporter.go
+++ b/consumer/statistics/reporter.go
@@ -18,7 +18,6 @@
 package statistics
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market/mysterium"
 	"github.com/mysteriumnetwork/node/session"
+	"github.com/pkg/errors"
 )
 
 const statsSenderLogPrefix = "[session-stats-sender] "

--- a/core/auth/errors.go
+++ b/core/auth/errors.go
@@ -17,7 +17,7 @@
 
 package auth
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	// ErrUnauthorized unauthorized

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -19,7 +19,6 @@ package connection
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -34,6 +33,7 @@ import (
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/mysteriumnetwork/node/session/balance"
 	"github.com/mysteriumnetwork/node/session/promise"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/core/discovery/api/fetcher.go
+++ b/core/discovery/api/fetcher.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mysteriumnetwork/node/core/discovery"
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/pkg/errors"
 )
 
 // FetchCallback does real fetch of proposals through Mysterium API
@@ -51,7 +52,7 @@ func NewFetcher(proposalsStorage *discovery.ProposalStorage, callback FetchCallb
 // Start begins fetching proposals to storage
 func (fetcher *Fetcher) Start() error {
 	if err := fetcher.fetchDo(); err != nil {
-		return err
+		log.Warn(errors.Wrap(err, "initial proposal fetch failed, continuing"))
 	}
 
 	fetcher.fetchShutdown = make(chan bool, 1)

--- a/core/discovery/broker/messaging_register.go
+++ b/core/discovery/broker/messaging_register.go
@@ -18,11 +18,11 @@
 package broker
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/pkg/errors"
 )
 
 // registerMessage structure represents message that the Provider sends about newly announced Proposal
@@ -53,7 +53,7 @@ func (pmc *registerConsumer) NewMessage() (messagePtr interface{}) {
 func (pmc *registerConsumer) Consume(messagePtr interface{}) error {
 	msg, ok := messagePtr.(registerMessage)
 	if !ok {
-		return fmt.Errorf("consume received message of type %q, expected registerMessage instead", reflect.TypeOf(messagePtr))
+		return errors.Errorf("consume received message of type %q, expected registerMessage instead", reflect.TypeOf(messagePtr))
 	}
 
 	pmc.queue <- msg

--- a/core/discovery/broker/messaging_unregister.go
+++ b/core/discovery/broker/messaging_unregister.go
@@ -18,11 +18,11 @@
 package broker
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/pkg/errors"
 )
 
 // unregisterMessage structure represents message that the Provider sends about de-announced Proposal
@@ -53,7 +53,7 @@ func (pmc *unregisterConsumer) NewMessage() (messagePtr interface{}) {
 func (pmc *unregisterConsumer) Consume(messagePtr interface{}) error {
 	msg, ok := messagePtr.(unregisterMessage)
 	if !ok {
-		return fmt.Errorf("consume received message of type %q, expected unregisterMessage instead", reflect.TypeOf(messagePtr))
+		return errors.Errorf("consume received message of type %q, expected unregisterMessage instead", reflect.TypeOf(messagePtr))
 	}
 
 	pmc.queue <- msg

--- a/core/ip/rest_resolver.go
+++ b/core/ip/rest_resolver.go
@@ -27,7 +27,7 @@ const apiClient = "goclient-v0.1"
 
 // NewResolver creates new ip-detector resolver with default timeout of one minute
 func NewResolver(url string) Resolver {
-	return NewResolverWithTimeout(url, 1*time.Minute)
+	return NewResolverWithTimeout(url, 20*time.Second)
 }
 
 // NewResolverWithTimeout creates new ip-detector resolver with specified timeout

--- a/core/location/db_resolver_test.go
+++ b/core/location/db_resolver_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/mysteriumnetwork/node/core/ip"
+	assert2 "github.com/mysteriumnetwork/node/testkit/assert"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,10 +49,6 @@ func TestResolverResolveCountry(t *testing.T) {
 		fmt.Println(got, err)
 
 		assert.Equal(t, tt.want, got.Country, tt.ip)
-		if tt.wantErr != "" {
-			assert.EqualError(t, err, tt.wantErr, tt.ip)
-		} else {
-			assert.NoError(t, err, tt.ip)
-		}
+		assert2.EqualOptionalError(t, err, tt.wantErr, tt.ip)
 	}
 }

--- a/core/location/db_resolver_test.go
+++ b/core/location/db_resolver_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/mysteriumnetwork/node/core/ip"
-	assert2 "github.com/mysteriumnetwork/node/testkit/assert"
+	"github.com/mysteriumnetwork/node/testkit/assertkit"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,6 +49,6 @@ func TestResolverResolveCountry(t *testing.T) {
 		fmt.Println(got, err)
 
 		assert.Equal(t, tt.want, got.Country, tt.ip)
-		assert2.EqualOptionalError(t, err, tt.wantErr, tt.ip)
+		assertkit.EqualOptionalError(t, err, tt.wantErr, tt.ip)
 	}
 }

--- a/core/location/gendb/loader.go
+++ b/core/location/gendb/loader.go
@@ -20,9 +20,10 @@ package gendb
 import (
 	"compress/gzip"
 	"encoding/base64"
-	"errors"
 	"io/ioutil"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // EncodedDataLoader returns emmbeded database as byte array

--- a/core/location/generator/generator.go
+++ b/core/location/generator/generator.go
@@ -21,13 +21,14 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
+
+	"github.com/pkg/errors"
 )
 
 const undefinedDb = ""

--- a/core/location/oracle_resolver.go
+++ b/core/location/oracle_resolver.go
@@ -32,7 +32,7 @@ type oracleResolver struct {
 // NewOracleResolver returns new db resolver initialized from Location Oracle service
 func NewOracleResolver(address string) *oracleResolver {
 	return &oracleResolver{
-		requests.NewHTTPClient(1 * time.Minute),
+		requests.NewHTTPClient(20 * time.Second),
 		address,
 	}
 }

--- a/core/node/options_directory.go
+++ b/core/node/options_directory.go
@@ -19,6 +19,7 @@ package node
 
 import (
 	"os"
+
 	"github.com/pkg/errors"
 )
 

--- a/core/node/options_directory.go
+++ b/core/node/options_directory.go
@@ -18,8 +18,8 @@
 package node
 
 import (
-	"errors"
 	"os"
+	"github.com/pkg/errors"
 )
 
 // OptionsDirectory describes data structure holding directories as parameters

--- a/core/promise/methods/noop/dialog_mock.go
+++ b/core/promise/methods/noop/dialog_mock.go
@@ -18,13 +18,13 @@
 package noop
 
 import (
-	"errors"
 	"sync"
 	"time"
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/core/promise"
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/pkg/errors"
 )
 
 type fakeDialog struct {

--- a/core/promise/promise.go
+++ b/core/promise/promise.go
@@ -21,12 +21,12 @@ package promise
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
+	"github.com/pkg/errors"
 )
 
 const endpoint = "promise-create"

--- a/core/quality/elastic_search_transport.go
+++ b/core/quality/elastic_search_transport.go
@@ -53,7 +53,7 @@ func (transport *elasticSearchTransport) SendEvent(event Event) error {
 
 	bodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return errors.Errorf("error while reading response body: %v", err)
+		return errors.Wrapf(err, "error while reading response body")
 	}
 	body := string(bodyBytes)
 

--- a/core/quality/elastic_search_transport.go
+++ b/core/quality/elastic_search_transport.go
@@ -18,12 +18,12 @@
 package quality
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strings"
 	"time"
 
 	"github.com/mysteriumnetwork/node/requests"
+	"github.com/pkg/errors"
 )
 
 // NewElasticSearchTransport creates transport allowing to send events to ElasticSearch through HTTP
@@ -53,16 +53,16 @@ func (transport *elasticSearchTransport) SendEvent(event Event) error {
 
 	bodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return fmt.Errorf("error while reading response body: %v", err)
+		return errors.Errorf("error while reading response body: %v", err)
 	}
 	body := string(bodyBytes)
 
 	if response.StatusCode != 200 {
-		return fmt.Errorf("unexpected response status: %v, body: %v", response.Status, body)
+		return errors.Errorf("unexpected response status: %v, body: %v", response.Status, body)
 	}
 
 	if strings.ToUpper(body) != "OK" {
-		return fmt.Errorf("unexpected response body: %v", body)
+		return errors.Errorf("unexpected response body: %v", body)
 	}
 
 	return nil

--- a/core/service/access_policy.go
+++ b/core/service/access_policy.go
@@ -31,7 +31,7 @@ func fetchAllowedIDs(ap *[]market.AccessPolicy) (allowedIDs []identity.Identity,
 		return nil, nil
 	}
 
-	client := requests.NewHTTPClient(time.Minute)
+	client := requests.NewHTTPClient(20 * time.Second)
 
 	var ruleSet market.AccessPolicyRuleSet
 	for _, p := range *ap {

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -19,7 +19,6 @@ package service
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/mysteriumnetwork/node/communication"
@@ -27,6 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat/traversal"
 	"github.com/mysteriumnetwork/node/session"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -18,12 +18,12 @@
 package service
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/utils"
+	"github.com/pkg/errors"
 )
 
 // ID represent unique identifier of the running service.

--- a/e2e/contition_checker.go
+++ b/e2e/contition_checker.go
@@ -18,8 +18,9 @@
 package e2e
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 type conditionChecker func() (bool, error)
@@ -39,7 +40,7 @@ func waitForConditionFor(duration time.Duration, checkFunc conditionChecker) err
 		case state:
 			return nil
 		case durationWait > duration:
-			return fmt.Errorf("state was still false after %s", durationWait)
+			return errors.Errorf("state was still false after %s", durationWait)
 		case !state:
 			time.Sleep(1 * time.Second)
 		}

--- a/e2e/wallet_helper.go
+++ b/e2e/wallet_helper.go
@@ -19,7 +19,6 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"math/big"
 	"os"
@@ -36,6 +35,7 @@ import (
 	"github.com/mysteriumnetwork/payments/cli/helpers"
 	"github.com/mysteriumnetwork/payments/contracts/abigen"
 	"github.com/mysteriumnetwork/payments/mysttoken"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/firewall/firewall_windows.go
+++ b/firewall/firewall_windows.go
@@ -18,11 +18,11 @@
 package firewall
 
 import (
-	"errors"
 	"fmt"
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/utils"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/firewall/firewall_windows.go
+++ b/firewall/firewall_windows.go
@@ -20,14 +20,12 @@ package firewall
 import (
 	"fmt"
 
-	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
 )
 
-const (
-	firewallLogPrefix = "[firewall] "
-)
+var log = logconfig.NewLogger()
 
 // AddInboundRule adds new inbound rule to the platform specific firewall.
 func AddInboundRule(proto string, port int) error {
@@ -40,7 +38,7 @@ func AddInboundRule(proto string, port int) error {
 
 	_, err := utils.PowerShell(cmd)
 	if err != nil {
-		log.Trace(firewallLogPrefix, "Failed to add firewall rule: ", err)
+		log.Trace("failed to add firewall rule: ", err)
 		return err
 	}
 
@@ -58,7 +56,7 @@ func RemoveInboundRule(proto string, port int) error {
 
 	_, err := utils.PowerShell(cmd)
 	if err != nil {
-		log.Trace(firewallLogPrefix, "Failed to remove firewall rule: ", err)
+		log.Trace("failed to remove firewall rule: ", err)
 		return err
 	}
 
@@ -69,7 +67,7 @@ func inboundRuleExists(name string) bool {
 	cmd := fmt.Sprintf(`netsh advfirewall firewall show rule name="%s" dir=in`, name)
 
 	if _, err := utils.PowerShell(cmd); err != nil {
-		log.Trace(firewallLogPrefix, "Failed to get firewall rule: ", err)
+		log.Trace("failed to get firewall rule: ", err)
 		return false
 	}
 

--- a/firewall/noop_vendor.go
+++ b/firewall/noop_vendor.go
@@ -17,7 +17,7 @@
 
 package firewall
 
-import log "github.com/cihub/seelog"
+import "github.com/cihub/seelog"
 
 // NoopVendor is a Vendor implementation which only logs allow requests with no effects
 // used by default
@@ -27,25 +27,25 @@ type NoopVendor struct {
 
 // Reset noop vendor (just log call)
 func (nb NoopVendor) Reset() {
-	log.Info(nb.LogPrefix, "Rules reset was requested")
+	seelog.Info(nb.LogPrefix, "Rules reset was requested")
 }
 
 // BlockOutgoingTraffic just logs the call
 func (nb NoopVendor) BlockOutgoingTraffic() (RemoveRule, error) {
-	log.Info(nb.LogPrefix, "Outgoing traffic block requested")
+	seelog.Info(nb.LogPrefix, "Outgoing traffic block requested")
 	return nb.logRemoval("Outgoing traffic block removed"), nil
 }
 
 // AllowIPAccess logs ip for which access was requested
 func (nb NoopVendor) AllowIPAccess(ip string) (RemoveRule, error) {
-	log.Info(nb.LogPrefix, "Allow ", ip, " access")
+	seelog.Info(nb.LogPrefix, "Allow ", ip, " access")
 	return nb.logRemoval("Rule for ip: ", ip, " removed"), nil
 }
 
 func (nb NoopVendor) logRemoval(vals ...interface{}) RemoveRule {
 	return func() {
 		vals := append([]interface{}{nb.LogPrefix}, vals...)
-		log.Info(vals...)
+		seelog.Info(vals...)
 	}
 }
 

--- a/identity/cache.go
+++ b/identity/cache.go
@@ -19,10 +19,11 @@ package identity
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 type cacheData struct {

--- a/identity/cache_test.go
+++ b/identity/cache_test.go
@@ -18,7 +18,6 @@
 package identity
 
 import (
-	"errors"
 	"os"
 	"testing"
 
@@ -58,7 +57,7 @@ func TestIdentityCache_GetIdentityWithNoCache(t *testing.T) {
 
 	_, err := cache.GetIdentity()
 
-	assert.Equal(t, errors.New("cache file does not exist"), err)
+	assert.EqualError(t, err, "cache file does not exist")
 }
 
 func TestIdentityCache_cacheExists(t *testing.T) {

--- a/identity/extractor.go
+++ b/identity/extractor.go
@@ -18,9 +18,8 @@
 package identity
 
 import (
-	"errors"
-
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
 )
 
 // Extractor is able to message signer's identity

--- a/identity/keystore_fake.go
+++ b/identity/keystore_fake.go
@@ -18,10 +18,9 @@
 package identity
 
 import (
-	"errors"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 )
 
 type keyStoreFake struct {

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -21,10 +21,9 @@
 package identity
 
 import (
-	"errors"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 )
 
 type identityManager struct {

--- a/identity/manager_fake.go
+++ b/identity/manager_fake.go
@@ -17,7 +17,7 @@
 
 package identity
 
-import "errors"
+import "github.com/pkg/errors"
 
 type idmFake struct {
 	LastUnlockAddress    string

--- a/identity/selector/handler.go
+++ b/identity/selector/handler.go
@@ -18,9 +18,8 @@
 package selector
 
 import (
-	"errors"
-
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/pkg/errors"
 )
 
 // IdentityRegistry exposes identity registration method

--- a/identity/selector/handler.go
+++ b/identity/selector/handler.go
@@ -19,11 +19,15 @@ package selector
 
 import (
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/pkg/errors"
 )
 
+var log = logconfig.NewLogger()
+
 // IdentityRegistry exposes identity registration method
 type IdentityRegistry interface {
+	IdentityExists(identity.Identity, identity.Signer) (bool, error)
 	RegisterIdentity(identity.Identity, identity.Signer) error
 }
 
@@ -51,16 +55,19 @@ func NewHandler(
 
 func (h *handler) UseOrCreate(address, passphrase string) (id identity.Identity, err error) {
 	if len(address) > 0 {
+		log.Debug("using existing identity")
 		return h.useExisting(address, passphrase)
 	}
 
 	identities := h.manager.GetIdentities()
 	if len(identities) == 0 {
+		log.Debug("creating new identity")
 		return h.useNew(passphrase)
 	}
 
 	id, err = h.useLast(passphrase)
 	if err != nil || !h.manager.HasIdentity(id.Address) {
+		log.Debug("using existing identity")
 		return h.useExisting(identities[0].Address, passphrase)
 	}
 
@@ -70,15 +77,26 @@ func (h *handler) UseOrCreate(address, passphrase string) (id identity.Identity,
 func (h *handler) useExisting(address, passphrase string) (id identity.Identity, err error) {
 	id, err = h.manager.GetIdentity(address)
 	if err != nil {
-		return
+		return id, err
 	}
 
 	if err = h.manager.Unlock(id.Address, passphrase); err != nil {
-		return
+		return id, errors.Wrap(err, "failed to unlock identity")
+	}
+
+	registered, err := h.registry.IdentityExists(id, h.signerFactory(id))
+	if err != nil {
+		return id, errors.Wrap(err, "failed to verify registration status of local identity")
+	}
+	if !registered {
+		log.Info("existing identity is not registered, attempting to register")
+		if err = h.registry.RegisterIdentity(id, h.signerFactory(id)); err != nil {
+			return id, errors.Wrap(err, "failed to register identity")
+		}
 	}
 
 	err = h.cache.StoreIdentity(id)
-	return
+	return id, err
 }
 
 func (h *handler) useLast(passphrase string) (identity identity.Identity, err error) {
@@ -98,17 +116,17 @@ func (h *handler) useNew(passphrase string) (id identity.Identity, err error) {
 	// if all fails, create a new one
 	id, err = h.manager.CreateNewIdentity(passphrase)
 	if err != nil {
-		return
+		return id, errors.Wrap(err, "failed to create identity")
 	}
 
 	if err = h.manager.Unlock(id.Address, passphrase); err != nil {
-		return
+		return id, errors.Wrap(err, "failed to unlock identity")
 	}
 
 	if err = h.registry.RegisterIdentity(id, h.signerFactory(id)); err != nil {
-		return
+		return id, errors.Wrap(err, "failed to register identity")
 	}
 
 	err = h.cache.StoreIdentity(id)
-	return
+	return id, errors.Wrap(err, "failed to store identity in cache")
 }

--- a/identity/selector/handler_test.go
+++ b/identity/selector/handler_test.go
@@ -178,6 +178,10 @@ type mockRegistry struct {
 	registeredIdentity identity.Identity
 }
 
+func (mr *mockRegistry) IdentityExists(identity.Identity, identity.Signer) (bool, error) {
+	return true, nil
+}
+
 func (mr *mockRegistry) RegisterIdentity(ID identity.Identity, signer identity.Signer) error {
 	mr.registeredIdentity = ID
 	return nil

--- a/logconfig/log.go
+++ b/logconfig/log.go
@@ -18,6 +18,7 @@
 package logconfig
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cihub/seelog"
@@ -33,7 +34,17 @@ func NewLogger() *Logger {
 	pkg := retrieveCallInfo().packageName
 	localPkg := strings.Replace(pkg, "github.com/mysteriumnetwork/node/", "", 1)
 	return &Logger{
-		prefix: "[" + localPkg + "] ",
+		prefix: fmt.Sprintf("[%s] ", localPkg),
+	}
+}
+
+// NewNamespaceLogger provides a package name and a namespace prefix.
+// Should be used if there is a need for more than one logger in the package.
+func NewNamespaceLogger(ns string) *Logger {
+	pkg := retrieveCallInfo().packageName
+	localPkg := strings.Replace(pkg, "github.com/mysteriumnetwork/node/", "", 1)
+	return &Logger{
+		prefix: fmt.Sprintf("[%s:%s] ", localPkg, ns),
 	}
 }
 

--- a/market/mysterium/mysterium_api.go
+++ b/market/mysterium/mysterium_api.go
@@ -48,6 +48,19 @@ func NewClient(discoveryAPIAddress string) *MysteriumAPI {
 	}
 }
 
+// IdentityExists checks if given identity is registered in discovery
+func (mApi *MysteriumAPI) IdentityExists(id identity.Identity, signer identity.Signer) (bool, error) {
+	req, err := requests.NewSignedGetRequest(mApi.discoveryAPIAddress, fmt.Sprintf("identities/%s", id.Address), signer)
+	if err != nil {
+		return false, err
+	}
+	res, err := mApi.http.Do(req)
+	if err != nil {
+		return false, err
+	}
+	return res.StatusCode == 200, nil
+}
+
 // RegisterIdentity registers given identity to discovery service
 func (mApi *MysteriumAPI) RegisterIdentity(id identity.Identity, signer identity.Signer) error {
 	req, err := requests.NewSignedPostRequest(mApi.discoveryAPIAddress, "identities", CreateIdentityRequest{

--- a/market/mysterium/mysterium_api.go
+++ b/market/mysterium/mysterium_api.go
@@ -43,7 +43,7 @@ type MysteriumAPI struct {
 // NewClient creates Mysterium centralized api instance with real communication
 func NewClient(discoveryAPIAddress string) *MysteriumAPI {
 	return &MysteriumAPI{
-		requests.NewHTTPClient(1 * time.Minute),
+		requests.NewHTTPClient(20 * time.Second),
 		discoveryAPIAddress,
 	}
 }

--- a/mobile/mysterium/wireguard_tun_default.go
+++ b/mobile/mysterium/wireguard_tun_default.go
@@ -20,9 +20,8 @@
 package mysterium
 
 import (
-	"errors"
-
 	"github.com/mysteriumnetwork/wireguard-go/tun"
+	"github.com/pkg/errors"
 )
 
 func newDeviceFromFd(_ int) (tun.TUNDevice, error) {

--- a/nat/service_pfctl.go
+++ b/nat/service_pfctl.go
@@ -18,7 +18,6 @@
 package nat
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"os/exec"
@@ -27,6 +26,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/utils"
+	"github.com/pkg/errors"
 )
 
 type servicePFCtl struct {

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -290,12 +290,12 @@ func (p *Pinger) pingReceiver(conn *net.UDPConn, stop <-chan struct{}) error {
 
 		n, err := conn.Read(buf)
 		if err != nil {
-			log.Errorf("%sFailed to read remote peer: %s cause: %s - attempting to continue", prefix, conn.RemoteAddr().String(), err)
+			log.Errorf("%sfailed to read remote peer: %s cause: %s - attempting to continue", prefix, conn.RemoteAddr().String(), err)
 			continue
 		}
 
 		if n > 0 {
-			log.Infof(prefix, "%sRemote peer data received: %s, len: %d", string(buf[:n]), n)
+			log.Infof("%sremote peer data received: %s, len: %d", prefix, string(buf[:n]), n)
 			return nil
 		}
 	}

--- a/nat/upnp/discover.go
+++ b/nat/upnp/discover.go
@@ -24,14 +24,11 @@ import (
 
 	"github.com/mysteriumnetwork/node/firewall"
 
-	log "github.com/cihub/seelog"
 	"github.com/huin/goupnp"
 	"github.com/huin/goupnp/httpu"
 	"github.com/huin/goupnp/ssdp"
 	"github.com/pkg/errors"
 )
-
-const logPrefix = "[upnp]"
 
 // GatewayDevice represents a scanned gateway device
 type GatewayDevice struct {
@@ -57,9 +54,9 @@ func (device GatewayDevice) String() string {
 }
 
 func printGatewayInfo(gateways []GatewayDevice) {
-	log.Infof("%s UPnP gateways detected: %d", logPrefix, len(gateways))
+	log.Infof("UPnP gateways detected: %d", len(gateways))
 	for _, device := range gateways {
-		log.Infof("%s UPnP gateway detected %v", logPrefix, device)
+		log.Infof("UPnP gateway detected %v", device)
 	}
 }
 
@@ -85,11 +82,11 @@ func discoverGateways() ([]GatewayDevice, error) {
 	for _, response := range responses {
 		device, err := parseDiscoveryResponse(response)
 		if err != nil {
-			log.Warnf("%s error parsing discovery response %v", logPrefix, err)
+			log.Warnf("error parsing discovery response %v", err)
 			continue
 		}
 		if !isGateway(device) {
-			log.Debugf("%s not a gateway device: %v", logPrefix, device)
+			log.Debugf("not a gateway device: %v", device)
 			continue
 		}
 

--- a/nat/upnp/discover.go
+++ b/nat/upnp/discover.go
@@ -85,7 +85,7 @@ func discoverGateways() ([]GatewayDevice, error) {
 	for _, response := range responses {
 		device, err := parseDiscoveryResponse(response)
 		if err != nil {
-			_ = log.Warnf("%s error parsing discovery response %v", logPrefix, err)
+			log.Warnf("%s error parsing discovery response %v", logPrefix, err)
 			continue
 		}
 		if !isGateway(device) {

--- a/nat/upnp/loader.go
+++ b/nat/upnp/loader.go
@@ -51,7 +51,7 @@ func (gl *GatewayLoader) Get() []GatewayDevice {
 func (gl *GatewayLoader) load() {
 	gateways, err := discoverGateways()
 	if err != nil {
-		_ = log.Error(logPrefix, errors.Wrap(err, "error discovering UPnP devices"))
+		log.Error(logPrefix, errors.Wrap(err, "error discovering UPnP devices"))
 		return
 	}
 	gl.gateways = gateways

--- a/nat/upnp/loader.go
+++ b/nat/upnp/loader.go
@@ -19,9 +19,6 @@ package upnp
 
 import (
 	"sync"
-
-	log "github.com/cihub/seelog"
-	"github.com/pkg/errors"
 )
 
 // GatewayLoader fetches the gateways once and keeps them stored for further use
@@ -51,7 +48,7 @@ func (gl *GatewayLoader) Get() []GatewayDevice {
 func (gl *GatewayLoader) load() {
 	gateways, err := discoverGateways()
 	if err != nil {
-		log.Error(logPrefix, errors.Wrap(err, "error discovering UPnP devices"))
+		log.Error("error discovering UPnP devices: ", err)
 		return
 	}
 	gl.gateways = gateways

--- a/nat/upnp/log.go
+++ b/nat/upnp/log.go
@@ -15,15 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package assert
+package upnp
 
-import "github.com/stretchr/testify/assert"
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// EqualOptionalError follows semantics of `assert.EqualError` when errString is not empty.
-// Otherwise, `assert.NoError` is called.
-func EqualOptionalError(t assert.TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
-	if errString == "" {
-		return assert.NoError(t, theError, msgAndArgs)
-	}
-	return assert.EqualError(t, theError, errString, msgAndArgs)
-}
+var log = logconfig.NewLogger()

--- a/requests/client.go
+++ b/requests/client.go
@@ -19,10 +19,11 @@ package requests
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // HTTPTransport describes a client for performing HTTP requests.
@@ -90,7 +91,7 @@ func parseResponseJSON(response *http.Response, dto interface{}) error {
 
 func parseResponseError(response *http.Response) error {
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return fmt.Errorf("server response invalid: %s (%s)", response.Status, response.Request.URL)
+		return errors.Errorf("server response invalid: %s (%s)", response.Status, response.Request.URL)
 	}
 
 	return nil

--- a/services/noop/service.go
+++ b/services/noop/service.go
@@ -19,17 +19,16 @@ package noop
 
 import (
 	"encoding/json"
-	"errors"
 	"sync"
 
 	log "github.com/cihub/seelog"
-
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/nat/traversal"
 	"github.com/mysteriumnetwork/node/session"
+	"github.com/pkg/errors"
 )
 
 const logPrefix = "[service-noop] "

--- a/services/openvpn/config_validator.go
+++ b/services/openvpn/config_validator.go
@@ -22,10 +22,11 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // ValidateConfig is function which takes VPNConfig as argument, checks it and returns error if validation fails

--- a/services/openvpn/core/options_node.go
+++ b/services/openvpn/core/options_node.go
@@ -20,7 +20,7 @@ package core
 import (
 	"bufio"
 	"bytes"
-	"errors"
+
 	"io"
 	"net/textproto"
 	"os/exec"
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
 // NodeOptions describes possible parameters of Openvpn configuration

--- a/services/openvpn/core/options_node.go
+++ b/services/openvpn/core/options_node.go
@@ -20,14 +20,13 @@ package core
 import (
 	"bufio"
 	"bytes"
-
 	"io"
 	"net/textproto"
 	"os/exec"
 	"strconv"
 	"syscall"
 
-	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/pkg/errors"
 )
 
@@ -36,7 +35,7 @@ type NodeOptions struct {
 	BinaryPath string
 }
 
-const logPrefix = "[Openvpn check] "
+var log = logconfig.NewLogger()
 
 // Check function checks that openvpn is available, given path to openvpn binary
 func (options *NodeOptions) Check() error {
@@ -48,7 +47,7 @@ func (options *NodeOptions) Check() error {
 	}
 	//openvpn returns exit code 1 in case of --version parameter, if anything else is returned - treat as error
 	if exitCode != 1 {
-		log.Error(logPrefix, "Check failed. Output of executed command: ", string(outputBuffer))
+		log.Error("check failed. Output of executed command: ", string(outputBuffer))
 		return errors.New("unexpected openvpn exit code: " + strconv.Itoa(exitCode))
 	}
 
@@ -60,13 +59,13 @@ func (options *NodeOptions) Check() error {
 		if err != nil {
 			return err
 		}
-		log.Info(logPrefix, str)
+		log.Info(str)
 	}
 
 	//optional custom tag
 	str, err := stringReader.ReadLine()
 	if err == nil {
-		log.Info(logPrefix, "Custom tag: ", str)
+		log.Info("custom tag: ", str)
 	} else if err != io.EOF {
 		//EOF is expected here and it doesn't fail openvpn check
 		return err

--- a/services/openvpn/discovery/dto/bandwidth_test.go
+++ b/services/openvpn/discovery/dto/bandwidth_test.go
@@ -19,10 +19,10 @@ package dto
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/mysteriumnetwork/node/datasize"
+	assert2 "github.com/mysteriumnetwork/node/testkit/assert"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,29 +50,29 @@ func TestBandwidthSerialize(t *testing.T) {
 
 func TestBandwidthUnserialize(t *testing.T) {
 	var tests = []struct {
-		json          string
-		expectedModel Bandwidth
-		expectedError error
+		json             string
+		expectedModel    Bandwidth
+		expectedErrorMsg string
 	}{
-		{"1", Bandwidth(1 * datasize.Bit), nil},
-		{"8", Bandwidth(1 * datasize.Byte), nil},
-		{"4", Bandwidth(0.5 * datasize.Byte), nil},
-		{"8796093022208", Bandwidth(1 * datasize.Terabyte), nil},
-		{"17592186044416", Bandwidth(2 * datasize.Terabyte), nil},
+		{"1", Bandwidth(1 * datasize.Bit), ""},
+		{"8", Bandwidth(1 * datasize.Byte), ""},
+		{"4", Bandwidth(0.5 * datasize.Byte), ""},
+		{"8796093022208", Bandwidth(1 * datasize.Terabyte), ""},
+		{"17592186044416", Bandwidth(2 * datasize.Terabyte), ""},
 		{
 			"-1",
 			Bandwidth(0),
-			errors.New(`strconv.ParseUint: parsing "-1": invalid syntax`),
+			`strconv.ParseUint: parsing "-1": invalid syntax`,
 		},
 		{
 			"4.08",
 			Bandwidth(0),
-			errors.New(`strconv.ParseUint: parsing "4.08": invalid syntax`),
+			`strconv.ParseUint: parsing "4.08": invalid syntax`,
 		},
 		{
 			"1bit",
 			Bandwidth(0),
-			errors.New(`invalid character 'b' after top-level value`),
+			`invalid character 'b' after top-level value`,
 		},
 	}
 
@@ -81,10 +81,6 @@ func TestBandwidthUnserialize(t *testing.T) {
 		err := json.Unmarshal([]byte(test.json), &model)
 
 		assert.Equal(t, test.expectedModel, model)
-		if test.expectedError != nil {
-			assert.EqualError(t, err, test.expectedError.Error())
-		} else {
-			assert.NoError(t, err)
-		}
+		assert2.EqualOptionalError(t, err, test.expectedErrorMsg)
 	}
 }

--- a/services/openvpn/discovery/dto/bandwidth_test.go
+++ b/services/openvpn/discovery/dto/bandwidth_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/mysteriumnetwork/node/datasize"
-	assert2 "github.com/mysteriumnetwork/node/testkit/assert"
+	"github.com/mysteriumnetwork/node/testkit/assertkit"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -81,6 +81,6 @@ func TestBandwidthUnserialize(t *testing.T) {
 		err := json.Unmarshal([]byte(test.json), &model)
 
 		assert.Equal(t, test.expectedModel, model)
-		assert2.EqualOptionalError(t, err, test.expectedErrorMsg)
+		assertkit.EqualOptionalError(t, err, test.expectedErrorMsg)
 	}
 }

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -125,7 +125,7 @@ func (m *Manager) Serve(providerID identity.Identity) (err error) {
 	}
 	defer func() {
 		if err := firewall.RemoveInboundRule(m.serviceOptions.Protocol, m.vpnServerPort); err != nil {
-			_ = log.Error(logPrefix, "failed to delete firewall rule for OpenVPN", err)
+			log.Error(logPrefix, "failed to delete firewall rule for OpenVPN", err)
 		}
 	}()
 

--- a/services/openvpn/session/client_map.go
+++ b/services/openvpn/session/client_map.go
@@ -18,10 +18,10 @@
 package session
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/mysteriumnetwork/node/session"
+	"github.com/pkg/errors"
 )
 
 // SessionMap defines map of current sessions

--- a/services/wireguard/endpoint/kernelspace/client.go
+++ b/services/wireguard/endpoint/kernelspace/client.go
@@ -19,13 +19,13 @@ package kernelspace
 
 import (
 	"encoding/base64"
-	"errors"
 	"net"
 
 	log "github.com/cihub/seelog"
 	"github.com/jackpal/gateway"
 	wg "github.com/mysteriumnetwork/node/services/wireguard"
 	"github.com/mysteriumnetwork/node/utils"
+	"github.com/pkg/errors"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )

--- a/services/wireguard/key/key.go
+++ b/services/wireguard/key/key.go
@@ -46,7 +46,7 @@ func PrivateKeyToPublicKey(key string) (string, error) {
 func GeneratePrivateKey() (string, error) {
 	randomBytes := make([]byte, keyLength)
 	if _, err := rand.Read(randomBytes); err != nil {
-		return "", errors.Errorf("GeneratePrivateKey failed to read random bytes: %v", err)
+		return "", errors.Wrapf(err, "failed to generate random bytes for private key")
 	}
 
 	// https://cr.yp.to/ecdh.html

--- a/services/wireguard/key/key.go
+++ b/services/wireguard/key/key.go
@@ -20,8 +20,8 @@ package key
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/curve25519"
 )
 
@@ -46,7 +46,7 @@ func PrivateKeyToPublicKey(key string) (string, error) {
 func GeneratePrivateKey() (string, error) {
 	randomBytes := make([]byte, keyLength)
 	if _, err := rand.Read(randomBytes); err != nil {
-		return "", fmt.Errorf("GeneratePrivateKey failed to read random bytes: %v", err)
+		return "", errors.Errorf("GeneratePrivateKey failed to read random bytes: %v", err)
 	}
 
 	// https://cr.yp.to/ecdh.html

--- a/services/wireguard/resources/allocator_windows.go
+++ b/services/wireguard/resources/allocator_windows.go
@@ -18,11 +18,11 @@
 package resources
 
 import (
-	"errors"
 	"net"
 	"sync"
 
 	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/pkg/errors"
 )
 
 // MaxConnections sets the limit to the maximum number of wireguard connections.

--- a/session/create_producer.go
+++ b/session/create_producer.go
@@ -19,10 +19,10 @@ package session
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/session/promise"
+	"github.com/pkg/errors"
 )
 
 type createProducer struct {

--- a/session/destroy_producer.go
+++ b/session/destroy_producer.go
@@ -18,11 +18,11 @@
 package session
 
 import (
-	"errors"
 	"fmt"
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/communication"
+	"github.com/pkg/errors"
 )
 
 const sessionDestroyPrefix = "[session.DestroyProducer] "

--- a/session/manager.go
+++ b/session/manager.go
@@ -19,16 +19,15 @@ package session
 
 import (
 	"encoding/json"
-	"errors"
 	"sync"
 	"time"
 
 	log "github.com/cihub/seelog"
-
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat/event"
 	"github.com/mysteriumnetwork/node/nat/traversal"
+	"github.com/pkg/errors"
 	sevent "github.com/mysteriumnetwork/node/session/event"
 )
 

--- a/session/manager.go
+++ b/session/manager.go
@@ -27,8 +27,8 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat/event"
 	"github.com/mysteriumnetwork/node/nat/traversal"
-	"github.com/pkg/errors"
 	sevent "github.com/mysteriumnetwork/node/session/event"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/session/payment/session_balance.go
+++ b/session/payment/session_balance.go
@@ -20,8 +20,6 @@
 package payment
 
 import (
-	"errors"
-	"fmt"
 	"math"
 	"sync/atomic"
 	"time"
@@ -30,6 +28,7 @@ import (
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/session/balance"
 	"github.com/mysteriumnetwork/node/session/promise"
+	"github.com/pkg/errors"
 )
 
 // PromiseStorage stores the promises and issues new sequenceID's
@@ -229,7 +228,7 @@ func (sb *SessionBalance) sendBalance() error {
 
 	// if we're ever in a situation where the unconsumed amount is zero, but the balance is not - something is definitely not right
 	if p.UnconsumedAmount == 0 && currentBalance != 0 {
-		return fmt.Errorf("unconsumed amount is 0, while balance is %v", currentBalance)
+		return errors.Errorf("unconsumed amount is 0, while balance is %v", currentBalance)
 	}
 
 	err = sb.promiseStorage.Update(sb.issuerID, promise.StoredPromise{

--- a/session/payment/session_payments.go
+++ b/session/payment/session_payments.go
@@ -19,7 +19,6 @@ package payment
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/session/balance"
 	"github.com/mysteriumnetwork/node/session/promise"
 	"github.com/mysteriumnetwork/payments/promises"
+	"github.com/pkg/errors"
 )
 
 // PeerPromiseSender knows how to send a promise message to the peer

--- a/session/promise/storage.go
+++ b/session/promise/storage.go
@@ -18,7 +18,6 @@
 package promise
 
 import (
-	"errors"
 	"sort"
 	"strings"
 	"sync"
@@ -26,6 +25,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/pkg/errors"
 )
 
 const promiseBucketPrefix = "stored-promise-"

--- a/session/promise/storage_test.go
+++ b/session/promise/storage_test.go
@@ -18,8 +18,6 @@
 package promise
 
 import (
-	"errors"
-	"fmt"
 	"reflect"
 	"sort"
 	"sync"
@@ -27,6 +25,7 @@ import (
 	"time"
 
 	"github.com/mysteriumnetwork/node/identity"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -512,7 +511,7 @@ func (ms *mockStorage) Store(bucket string, object interface{}) error {
 	sp, ok := object.(*StoredPromise)
 	if !ok {
 		providedType := reflect.TypeOf(object)
-		return fmt.Errorf("mockStorage.Store expects *StoredPromise but got %v instead", providedType)
+		return errors.Errorf("mockStorage.Store expects *StoredPromise but got %v instead", providedType)
 	}
 
 	spToStore := *sp
@@ -531,7 +530,7 @@ func (ms *mockStorage) GetAllFrom(bucket string, array interface{}) error {
 	casted, ok := array.(*[]StoredPromise)
 	if !ok {
 		providedType := reflect.TypeOf(array)
-		return fmt.Errorf("mockStorage.Store expects *[]StoredPromise but got %v instead", providedType)
+		return errors.Errorf("mockStorage.Store expects *[]StoredPromise but got %v instead", providedType)
 	}
 
 	if _, ok := ms.inMemStorage[bucket]; ok {
@@ -547,7 +546,7 @@ func (ms *mockStorage) Update(bucket string, data interface{}) error {
 	casted, ok := data.(*StoredPromise)
 	if !ok {
 		providedType := reflect.TypeOf(data)
-		return fmt.Errorf("mockStorage.Update expects *StoredPromise but got %v instead", providedType)
+		return errors.Errorf("mockStorage.Update expects *StoredPromise but got %v instead", providedType)
 	}
 	if _, ok := ms.inMemStorage[bucket]; ok {
 		for i := range ms.inMemStorage[bucket] {
@@ -568,10 +567,10 @@ func (ms *mockStorage) GetOneByField(bucket string, fieldName string, key interf
 	casted, ok := to.(*StoredPromise)
 	if !ok {
 		providedType := reflect.TypeOf(to)
-		return fmt.Errorf("mockStorage.GetOneByField expects *StoredPromise but got %v instead", providedType)
+		return errors.Errorf("mockStorage.GetOneByField expects *StoredPromise but got %v instead", providedType)
 	}
 	if fieldName != "SequenceID" {
-		return fmt.Errorf("mockStorage.GetOneByField expects a fieldname of SequenceID but got %v instead", fieldName)
+		return errors.Errorf("mockStorage.GetOneByField expects a fieldname of SequenceID but got %v instead", fieldName)
 	}
 
 	if _, ok := ms.inMemStorage[bucket]; ok {
@@ -598,7 +597,7 @@ func (ms *mockStorage) GetLast(bucket string, to interface{}) error {
 	casted, ok := to.(*StoredPromise)
 	if !ok {
 		providedType := reflect.TypeOf(to)
-		return fmt.Errorf("mockStorage.GetLast expects *StoredPromise but got %v instead", providedType)
+		return errors.Errorf("mockStorage.GetLast expects *StoredPromise but got %v instead", providedType)
 	}
 	if _, ok := ms.inMemStorage[bucket]; ok {
 		copy := ms.inMemStorage[bucket][len(ms.inMemStorage[bucket])-1]

--- a/tequilapi/client/client_test.go
+++ b/tequilapi/client/client_test.go
@@ -18,7 +18,6 @@
 package client
 
 import (
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -85,7 +84,7 @@ func TestConnectionErrorIsReturnedByClientInsteadOfDoubleParsing(t *testing.T) {
 
 	_, err := client.Connect("consumer", "provider", "service", ConnectOptions{})
 	assert.Error(t, err)
-	assert.Equal(t, errors.New("server response invalid: Internal server error (http://test-api-whatever/connection). Possible error: me haz faild"), err)
+	assert.EqualError(t, err, "server response invalid: Internal server error (http://test-api-whatever/connection). Possible error: me haz faild")
 	//when doing http request, response body should always be closed by client - otherwise persistent connections are leaking
 	assert.True(t, responseBody.Closed)
 }

--- a/tequilapi/client/http_client.go
+++ b/tequilapi/client/http_client.go
@@ -44,7 +44,7 @@ func newHTTPClient(baseURL string, logPrefix string, ua string) *httpClient {
 	return &httpClient{
 		http: &http.Client{
 			Transport: &http.Transport{},
-			Timeout:   time.Second * 120,
+			Timeout:   100 * time.Second,
 		},
 		baseURL:   baseURL,
 		logPrefix: logPrefix,

--- a/tequilapi/client/http_client.go
+++ b/tequilapi/client/http_client.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
 type httpClientInterface interface {
@@ -136,7 +137,7 @@ func parseResponseError(response *http.Response) error {
 			message = parsedBody.Message
 		}
 		// TODO these errors are ugly long and hard to check against - consider return error structs or specific error constants
-		return fmt.Errorf("server response invalid: %s (%s). Possible error: %s", response.Status, response.Request.URL, message)
+		return errors.Errorf("server response invalid: %s (%s). Possible error: %s", response.Status, response.Request.URL, message)
 	}
 
 	return nil

--- a/tequilapi/endpoints/access_policies.go
+++ b/tequilapi/endpoints/access_policies.go
@@ -51,7 +51,7 @@ type accessPoliciesEndpoint struct {
 // NewAccessPoliciesEndpoint creates and returns access policies endpoint
 func NewAccessPoliciesEndpoint(accessPolicyEndpointURL string) *accessPoliciesEndpoint {
 	return &accessPoliciesEndpoint{
-		http:                    requests.NewHTTPClient(1 * time.Minute),
+		http:                    requests.NewHTTPClient(20 * time.Second),
 		accessPolicyEndpointURL: accessPolicyEndpointURL,
 	}
 }

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -19,7 +19,6 @@ package endpoints
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 	"github.com/mysteriumnetwork/node/tequilapi/validation"
+	"github.com/pkg/errors"
 )
 
 // statusConnectCancelled indicates that connect request was cancelled by user. Since there is no such concept in REST

--- a/tequilapi/http_api_server.go
+++ b/tequilapi/http_api_server.go
@@ -18,10 +18,11 @@
 package tequilapi
 
 import (
-	"errors"
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // APIServer interface represents control methods for underlying http api server

--- a/testkit/assert/error_assert.go
+++ b/testkit/assert/error_assert.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package assert
+
+import "github.com/stretchr/testify/assert"
+
+// EqualOptionalError follows semantics of `assert.EqualError` when errString is not empty.
+// Otherwise, `assert.NoError` is called.
+func EqualOptionalError(t assert.TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+	if errString == "" {
+		return assert.NoError(t, theError, msgAndArgs)
+	}
+	return assert.EqualError(t, theError, errString, msgAndArgs)
+}

--- a/testkit/assertkit/error_assert.go
+++ b/testkit/assertkit/error_assert.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package assertkit
+
+import "github.com/stretchr/testify/assert"
+
+// EqualOptionalError follows semantics of `assert.EqualError` when errString is not empty.
+// Otherwise, `assert.NoError` is called.
+func EqualOptionalError(t assert.TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+	if errString == "" {
+		return assert.NoError(t, theError, msgAndArgs)
+	}
+	return assert.EqualError(t, theError, errString, msgAndArgs)
+}

--- a/utils/command.go
+++ b/utils/command.go
@@ -18,9 +18,10 @@
 package utils
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // SplitCommand parses command arguments from string and returns command with split arguments
@@ -37,7 +38,7 @@ func SplitCommand(command string, commandArguments string) *exec.Cmd {
 // It returns an combined stderr and stdout output and exit code in case of error.
 func SudoExec(args ...string) error {
 	if out, err := exec.Command("sudo", args...).CombinedOutput(); err != nil {
-		return fmt.Errorf("'sudo %v': %v output: %s", strings.Join(args, " "), err, out)
+		return errors.Errorf("'sudo %v': %v output: %s", strings.Join(args, " "), err, out)
 	}
 	return nil
 }

--- a/utils/command_windows.go
+++ b/utils/command_windows.go
@@ -18,17 +18,17 @@
 package utils
 
 import (
-	"fmt"
 	"os/exec"
 
 	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
 func PowerShell(cmd string) ([]byte, error) {
 	log.Tracef("[powershell] executing: '%s'", cmd)
 	out, err := exec.Command("powershell", "-Command", cmd).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("'powershell -Command %v': %v output: %s", cmd, RemoveErrorsAndBOMUTF8(err.Error()), RemoveErrorsAndBOMUTF8Byte(out))
+		return nil, errors.Errorf("'powershell -Command %v': %v output: %s", cmd, RemoveErrorsAndBOMUTF8(err.Error()), RemoveErrorsAndBOMUTF8Byte(out))
 	}
 	log.Tracef("[powershell] done: '%s', raw output: '%s'", cmd, out)
 	return RemoveErrorsAndBOMUTF8Byte(out), nil

--- a/utils/error_collection.go
+++ b/utils/error_collection.go
@@ -18,9 +18,10 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // ErrorCollection knows how to combine multiple error strings


### PR DESCRIPTION
Fixes #1163

Functional changes:

- If initial proposal fetch fails, ignore it and continue (it will continuously attempt to fetch in a separate goroutine)
- Use [new discovery API endpoint](https://github.com/mysteriumnetwork/api/pull/138) to check if an existing identity is registered
- Proceed with node services startup only when the identity is valid and registered
  This also kind of solves 'app starting before the network is up' problem, since it will retry to get identity every 10s.
  To properly address network state issue, we should make separate node components react to network state events, but that's a 
  separate huge epic.

Additionally:

- Migrate "errors" to "github.com/pkg/errors" to retain stacktraces
- More error wraps
- Cut HTTP timeouts. _Note: leaving tequilapi timeout rather high, because of e2e test issues. Need to investigate further, perhaps containers are not yet healthy before running tests?_