### PR TITLE
Avoid repeated unlocks of the same identity

### DIFF
--- a/identity/log.go
+++ b/identity/log.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,17 +17,6 @@
 
 package identity
 
-import (
-	"github.com/ethereum/go-ethereum/accounts/keystore"
-)
+import "github.com/mysteriumnetwork/node/logconfig"
 
-// NewKeystoreFilesystem create new keystore, which keeps keys in filesystem
-func NewKeystoreFilesystem(directory string, lightweight bool) *keystore.KeyStore {
-	if lightweight {
-		log.Trace("using lightweight keystore")
-		return keystore.NewKeyStore(directory, keystore.LightScryptN, keystore.LightScryptP)
-	}
-
-	log.Trace("using heavyweight keystore")
-	return keystore.NewKeyStore(directory, keystore.StandardScryptN, keystore.StandardScryptP)
-}
+var log = logconfig.NewLogger()

--- a/identity/selector/handler.go
+++ b/identity/selector/handler.go
@@ -75,6 +75,7 @@ func (h *handler) UseOrCreate(address, passphrase string) (id identity.Identity,
 }
 
 func (h *handler) useExisting(address, passphrase string) (id identity.Identity, err error) {
+	log.Trace("attempting to use existing identity")
 	id, err = h.manager.GetIdentity(address)
 	if err != nil {
 		return id, err
@@ -100,19 +101,23 @@ func (h *handler) useExisting(address, passphrase string) (id identity.Identity,
 }
 
 func (h *handler) useLast(passphrase string) (identity identity.Identity, err error) {
+	log.Trace("attempting to use last identity")
 	identity, err = h.cache.GetIdentity()
 	if err != nil || !h.manager.HasIdentity(identity.Address) {
 		return identity, errors.New("identity not found in cache")
 	}
+	log.Tracef("found identity in cache: %s", identity.Address)
 
 	if err = h.manager.Unlock(identity.Address, passphrase); err != nil {
-		return
+		return identity, errors.Wrap(err, "failed to unlock identity")
 	}
+	log.Tracef("unlocked identity: %s", identity.Address)
 
 	return identity, nil
 }
 
 func (h *handler) useNew(passphrase string) (id identity.Identity, err error) {
+	log.Trace("attempting to use new identity")
 	// if all fails, create a new one
 	id, err = h.manager.CreateNewIdentity(passphrase)
 	if err != nil {


### PR DESCRIPTION
Fixes #697 

Cache unlocked addresses, skip ethereum keystore when cache is hit

This avoids unlocking same (already unlocked) identity over and over.
With heavyweight keystore, each key weighs 256M and it accumulates very
quickly, causing crash on raspberry just by refreshing web UI a few times (web calls `identities/current`). 