### PR TITLE
Bump dvpn web UI to 0.0.10

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -468,15 +468,15 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:b72a26b49e54e8ebd4a77e893f010502de53b0e4f8633935daeec7e8b562261c"
+  digest = "1:8e0bd4c6f8009ce58b1565a6ca804615c6d17667a0aafe664db76f1c476b45ae"
   name = "github.com/mysteriumnetwork/go-dvpn-web"
   packages = [
     ".",
     "ci/command",
   ]
   pruneopts = "UT"
-  revision = "6eab8b482efdebaa38a1bca088f42174e278649d"
-  version = "0.0.9"
+  revision = "ab804bdf0f91109b0ae02735b5e147f59be3eebd"
+  version = "0.0.10"
 
 [[projects]]
   digest = "1:4d5402ba3b77f26c810297827842889cf315bfc7a64ff7a0e6a477e2bf1823ce"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -123,7 +123,7 @@
   name = "github.com/gin-gonic/gin"
 
 [[constraint]]
-  version = "=0.0.9"
+  version = "=0.0.10"
   name = "github.com/mysteriumnetwork/go-dvpn-web"
 
 [[constraint]]


### PR DESCRIPTION
Fixes in this release https://github.com/mysteriumnetwork/dvpn-web/releases/tag/0.0.10
Notably, changing to access tequilapi via proxy instead of `:4050` https://github.com/mysteriumnetwork/dvpn-web/pull/37