### PR TITLE
Fixed proposal pinging

### DIFF
--- a/core/discovery/api/registry.go
+++ b/core/discovery/api/registry.go
@@ -46,5 +46,5 @@ func (registry *registryAPI) UnregisterProposal(proposal market.ServiceProposal,
 
 // PingProposal pings service proposal as being alive
 func (registry *registryAPI) PingProposal(proposal market.ServiceProposal, signer identity.Signer) error {
-	return registry.mysteriumAPI.RegisterProposal(proposal, signer)
+	return registry.mysteriumAPI.PingProposal(proposal, signer)
 }


### PR DESCRIPTION
Closes: #1196 

This fixes node availability issue where node availability is not stored in the database. Wrong call was being made.