### PR TITLE
Delay initial proposal fetch (until mobile DI is complete)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ package:linux-debian-arm:
 
 package:linux-raspberry-image:
   stage: build
-  tags: [go]
+  tags: [go,high_performance]
   script: go run mage.go -v PackageLinuxRaspberryImage
 
 package:osx-amd64:


### PR DESCRIPTION
Hack around custom mobile DI flow.
Ref: #1225

// FIXME: fix via mobile DI (remove override* methods and configure tunnels via node.Boostrap()?)
// Add 2 sec delay to complete service startup due to mobile DI flow being a bit different:
// service definitions are registered via `OverrideOpenvpnConnection`.
// Definitions must be available at the time of the fetch, otherwise valid proposals will be discarded
// and user will have to wait for another 30 seconds for them to be populated.