### PR TITLE
Wait for proposals in tests longer

### DIFF
--- a/core/discovery/api/fetcher_test.go
+++ b/core/discovery/api/fetcher_test.go
@@ -130,7 +130,7 @@ func waitForProposal(t *testing.T, proposalsChan chan market.ServiceProposal) ma
 	select {
 	case proposal := <-proposalsChan:
 		return proposal
-	case <-time.After(2 * time.Millisecond):
+	case <-time.After(20 * time.Millisecond):
 		t.Log("Proposal not fetched")
 		return market.ServiceProposal{}
 	}


### PR DESCRIPTION
We were waiting just 2ms. Way too short time. 1/2 time pipeline was failing. 