### PR TITLE
Correct debug level identifier

### DIFF
--- a/logconfig/config.go
+++ b/logconfig/config.go
@@ -68,7 +68,7 @@ func BootstrapWith(opts *LogOptions) {
 func Bootstrap() {
 	BootstrapWith(
 		&LogOptions{
-			LogLevel: "Debug",
+			LogLevel: log.DebugStr,
 		},
 	)
 }


### PR DESCRIPTION
No proper errors were being printed when pipeline fails.
