### PR TITLE
New payment pingpong scaffold

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -75,6 +75,7 @@ import (
 	sessionevent "github.com/mysteriumnetwork/node/session/event"
 	session_payment "github.com/mysteriumnetwork/node/session/payment"
 	payment_factory "github.com/mysteriumnetwork/node/session/payment/factory"
+	"github.com/mysteriumnetwork/node/session/pingpong"
 	"github.com/mysteriumnetwork/node/session/promise"
 	"github.com/mysteriumnetwork/node/session/promise/validators"
 	"github.com/mysteriumnetwork/node/tequilapi"
@@ -482,6 +483,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 	di.ConnectionManager = connection.NewManager(
 		dialogFactory,
 		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory),
+		pingpong.ExchangeMessageFactoryCreator(di.Keystore),
 		di.ConnectionRegistry.CreateConnection,
 		di.EventBus,
 	)
@@ -529,7 +531,7 @@ func newSessionManagerFactory(
 	eventbus eventbus.EventBus,
 ) session.ManagerFactory {
 	return func(dialog communication.Dialog) *session.Manager {
-		providerBalanceTrackerFactory := func(consumerID, receiverID, issuerID identity.Identity) (session.BalanceTracker, error) {
+		providerBalanceTrackerFactory := func(consumerID, receiverID, issuerID identity.Identity) (session.PaymentEngine, error) {
 			timeTracker := session.NewTracker(time.Now)
 			// TODO: set the time and proper payment info
 			payment := dto.PaymentPerTime{
@@ -553,11 +555,14 @@ func newSessionManagerFactory(
 			validator := validators.NewIssuedPromiseValidator(consumerID, receiverID, issuerID)
 			return session_payment.NewSessionBalance(sender, tracker, promiseChan, payment_factory.BalanceSendPeriod, payment_factory.PromiseWaitTimeout, validator, promiseStorage, consumerID, receiverID, issuerID), nil
 		}
+
+		paymentEngineFactory := pingpong.InvoiceFactoryCreator(dialog, payment_factory.BalanceSendPeriod, payment_factory.PromiseWaitTimeout)
 		return session.NewManager(
 			proposal,
 			session.GenerateUUID,
 			sessionStorage,
 			providerBalanceTrackerFactory,
+			paymentEngineFactory,
 			natPingerChan,
 			natTracker,
 			serviceID,

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -482,8 +482,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 	di.ConnectionRegistry = connection.NewRegistry()
 	di.ConnectionManager = connection.NewManager(
 		dialogFactory,
-		payment_factory.PaymentIssuerFactoryFunc(nodeOptions, di.SignerFactory),
-		pingpong.ExchangeMessageFactoryCreator(di.Keystore),
+		pingpong.BackwardsCompatibleExchangeFactoryFunc(di.Keystore, nodeOptions, di.SignerFactory),
 		di.ConnectionRegistry.CreateConnection,
 		di.EventBus,
 	)

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -231,7 +231,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 			allowedIdentityValidator,
 		), nil
 	}
-	newDialogHandler := func(proposal market.ServiceProposal, configProvider session.ConfigNegotiator, serviceID string) communication.DialogHandler {
+	newDialogHandler := func(proposal market.ServiceProposal, configProvider session.ConfigNegotiator, serviceID string) (communication.DialogHandler, error) {
 		sessionManagerFactory := newSessionManagerFactory(
 			proposal,
 			di.ServiceSessionStorage,
@@ -240,7 +240,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 			di.NATTracker,
 			serviceID,
 			di.EventBus)
-		return session.NewDialogHandler(sessionManagerFactory, configProvider.ProvideConfig, di.PromiseStorage, identity.FromAddress(proposal.ProviderID))
+		return session.NewDialogHandler(sessionManagerFactory, configProvider.ProvideConfig, di.PromiseStorage, identity.FromAddress(proposal.ProviderID)), nil
 	}
 	di.ServicesManager = service.NewManager(
 		di.ServiceRegistry,

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/mysteriumnetwork/node/session/balance"
 	"github.com/mysteriumnetwork/node/session/promise"
+	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -46,6 +47,12 @@ type testContext struct {
 	mockStatistics        consumer.SessionStatistics
 	fakeResolver          ip.Resolver
 	sync.RWMutex
+}
+
+func mockPaymentEngineFactory(invoice chan crypto.Invoice, dialog communication.Dialog, consumer identity.Identity) (PaymentIssuer, error) {
+	return &MockPaymentIssuer{
+		stopChan: make(chan struct{}),
+	}, nil
 }
 
 var (
@@ -123,6 +130,7 @@ func (tc *testContext) SetupTest() {
 	tc.connManager = NewManager(
 		dialogCreator,
 		mockPaymentFactory,
+		mockPaymentEngineFactory,
 		tc.fakeConnectionFactory.CreateConnection,
 		tc.stubPublisher,
 	)

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -47,7 +47,7 @@ type Service interface {
 type DialogWaiterFactory func(providerID identity.Identity, serviceType string, allowedIDs []identity.Identity) (communication.DialogWaiter, error)
 
 // DialogHandlerFactory initiates instance which is able to handle incoming dialogs
-type DialogHandlerFactory func(market.ServiceProposal, session.ConfigNegotiator, string) communication.DialogHandler
+type DialogHandlerFactory func(market.ServiceProposal, session.ConfigNegotiator, string) (communication.DialogHandler, error)
 
 // DiscoveryFactory initiates instance which is able announce service discoverability
 type DiscoveryFactory func() Discovery
@@ -125,7 +125,11 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 		return id, err
 	}
 
-	dialogHandler := manager.dialogHandlerFactory(proposal, service, string(id))
+	dialogHandler, err := manager.dialogHandlerFactory(proposal, service, string(id))
+	if err != nil {
+		return id, err
+	}
+
 	if err = dialogWaiter.ServeDialogs(dialogHandler); err != nil {
 		return id, err
 	}

--- a/core/service/stub_service.go
+++ b/core/service/stub_service.go
@@ -90,8 +90,8 @@ func (mdh *mockDialogHandler) Handle(communication.Dialog) error {
 }
 
 // MockDialogHandlerFactory creates a new mock dialog handler
-func MockDialogHandlerFactory(market.ServiceProposal, session.ConfigNegotiator, string) communication.DialogHandler {
-	return &mockDialogHandler{}
+func MockDialogHandlerFactory(market.ServiceProposal, session.ConfigNegotiator, string) (communication.DialogHandler, error) {
+	return &mockDialogHandler{}, nil
 }
 
 type mockDiscovery struct {

--- a/session/create_consumer.go
+++ b/session/create_consumer.go
@@ -71,7 +71,7 @@ func (consumer *createConsumer) Consume(requestPtr interface{}) (response interf
 	issuerID := consumer.peerID
 	if request.ConsumerInfo != nil {
 		issuerID = request.ConsumerInfo.IssuerID
-		if request.ConsumerInfo.Supports == PaymentVersionV2 {
+		if request.ConsumerInfo.PaymentVersion == PaymentVersionV2 {
 			indicateNewVersion = true
 		}
 	} else {

--- a/session/create_consumer_test.go
+++ b/session/create_consumer_test.go
@@ -142,9 +142,9 @@ type managerFake struct {
 }
 
 // Create function creates and returns fake session
-func (manager *managerFake) Create(consumerID, issuerID identity.Identity, proposalID int, config ServiceConfiguration, pingParams *traversal.Params) (Session, error) {
+func (manager *managerFake) Create(consumerID identity.Identity, consumerInfo ConsumerInfo, proposalID int, config ServiceConfiguration, pingParams *traversal.Params) (Session, error) {
 	manager.lastConsumerID = consumerID
-	manager.lastIssuerID = issuerID
+	manager.lastIssuerID = consumerInfo.IssuerID
 	manager.lastProposalID = proposalID
 	return manager.returnSession, manager.returnError
 }

--- a/session/create_dto.go
+++ b/session/create_dto.go
@@ -54,7 +54,14 @@ type SessionDto struct {
 	Config json.RawMessage `json:"config"`
 }
 
+// PaymentVersion represents the different payment versions we have
+type PaymentVersion string
+
+// PaymentVersionV2 represents the new pingpong version
+const PaymentVersionV2 PaymentVersion = "v2"
+
 // ConsumerInfo represents the consumer related information
 type ConsumerInfo struct {
 	IssuerID identity.Identity `json:"issuerID"`
+	Supports PaymentVersion    `json:"supports"`
 }

--- a/session/create_dto.go
+++ b/session/create_dto.go
@@ -62,6 +62,6 @@ const PaymentVersionV2 PaymentVersion = "v2"
 
 // ConsumerInfo represents the consumer related information
 type ConsumerInfo struct {
-	IssuerID identity.Identity `json:"issuerID"`
-	Supports PaymentVersion    `json:"supports"`
+	IssuerID       identity.Identity `json:"issuerID"`
+	PaymentVersion PaymentVersion    `json:"paymentVersion"`
 }

--- a/session/dto.go
+++ b/session/dto.go
@@ -26,8 +26,8 @@ import (
 // ID represents session id type
 type ID string
 
-// BalanceTracker is responsible for interacting with the consumer in regards to payments
-type BalanceTracker interface {
+// PaymentEngine is responsible for interacting with the consumer in regards to payments
+type PaymentEngine interface {
 	Start() error
 	Stop()
 }

--- a/session/manager.go
+++ b/session/manager.go
@@ -84,6 +84,8 @@ type Storage interface {
 
 // BalanceTrackerFactory returns a new instance of balance tracker
 type BalanceTrackerFactory func(consumer, provider, issuer identity.Identity) (PaymentEngine, error)
+
+// PaymentEngineFactory creates a new instance of payment engine
 type PaymentEngineFactory func() (PaymentEngine, error)
 
 // NATEventGetter lets us access the last known traversal event

--- a/session/manager.go
+++ b/session/manager.go
@@ -157,7 +157,7 @@ func (manager *Manager) Create(consumerID identity.Identity, consumerInfo Consum
 
 	// TODO: this whole block needs to go when we deprecate the old payment pingpong
 	var paymentEngine PaymentEngine
-	if consumerInfo.Supports == PaymentVersionV2 {
+	if consumerInfo.PaymentVersion == PaymentVersionV2 {
 		log.Info("using new payments")
 		engine, err := manager.paymentEngineFactory()
 		if err != nil {

--- a/session/pingpong/exchange_message_tracker.go
+++ b/session/pingpong/exchange_message_tracker.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/pkg/errors"
+)
+
+// PeerExchangeMessageSender allows for sending of exchange messages
+type PeerExchangeMessageSender interface {
+	Send(crypto.ExchangeMessage) error
+}
+
+// ExchangeMessageTracker keeps track of exchange messages and sends them to the provider
+type ExchangeMessageTracker struct {
+	stop                      chan struct{}
+	invoiceChan               chan crypto.Invoice
+	peerExchangeMessageSender PeerExchangeMessageSender
+	once                      sync.Once
+	keystore                  *keystore.KeyStore
+	identity                  identity.Identity
+}
+
+// NewExchangeMessageTracker returns a new instance of exchange message tracker
+func NewExchangeMessageTracker(invoiceChan chan crypto.Invoice, peerExchangeMessageSender PeerExchangeMessageSender, ks *keystore.KeyStore, identity identity.Identity) *ExchangeMessageTracker {
+	return &ExchangeMessageTracker{
+		stop:                      make(chan struct{}),
+		peerExchangeMessageSender: peerExchangeMessageSender,
+		invoiceChan:               invoiceChan,
+		keystore:                  ks,
+		identity:                  identity,
+	}
+}
+
+// ErrInvoiceMissmatch represents an error that occurs when invoices do not match
+var ErrInvoiceMissmatch = errors.New("invoice missmatch")
+
+// Start starts the message exchange tracker. Blocks.
+func (emt *ExchangeMessageTracker) Start() error {
+	for {
+		select {
+		case <-emt.stop:
+			return nil
+		case balance := <-emt.invoiceChan:
+			err := emt.issueExchangeMessage(balance)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (emt *ExchangeMessageTracker) issueExchangeMessage(invoice crypto.Invoice) error {
+	msg, err := crypto.CreateExchangeMessage(invoice, 10, "", emt.keystore, common.HexToAddress(emt.identity.Address))
+	if err != nil {
+		return errors.Wrap(err, "could not create exchange message")
+	}
+	err = emt.peerExchangeMessageSender.Send(*msg)
+	if err != nil {
+		log.Warn("Failed to send exchange message: ", err)
+	}
+
+	return nil
+}
+
+// Stop stops the message tracker
+func (emt *ExchangeMessageTracker) Stop() {
+	emt.once.Do(func() {
+		close(emt.stop)
+	})
+}

--- a/session/pingpong/exchange_message_tracker.go
+++ b/session/pingpong/exchange_message_tracker.go
@@ -54,16 +54,18 @@ func NewExchangeMessageTracker(invoiceChan chan crypto.Invoice, peerExchangeMess
 }
 
 // ErrInvoiceMissmatch represents an error that occurs when invoices do not match
-var ErrInvoiceMissmatch = errors.New("invoice missmatch")
+var ErrInvoiceMissmatch = errors.New("invoice mismatch")
 
 // Start starts the message exchange tracker. Blocks.
 func (emt *ExchangeMessageTracker) Start() error {
+	log.Debug("Starting...")
 	for {
 		select {
 		case <-emt.stop:
 			return nil
-		case balance := <-emt.invoiceChan:
-			err := emt.issueExchangeMessage(balance)
+		case invoice := <-emt.invoiceChan:
+			log.Debug("Invoice received", invoice)
+			err := emt.issueExchangeMessage(invoice)
 			if err != nil {
 				return err
 			}
@@ -76,6 +78,7 @@ func (emt *ExchangeMessageTracker) issueExchangeMessage(invoice crypto.Invoice) 
 	if err != nil {
 		return errors.Wrap(err, "could not create exchange message")
 	}
+	log.Debug("Sending message", *msg)
 	err = emt.peerExchangeMessageSender.Send(*msg)
 	if err != nil {
 		log.Warn("Failed to send exchange message: ", err)
@@ -87,6 +90,7 @@ func (emt *ExchangeMessageTracker) issueExchangeMessage(invoice crypto.Invoice) 
 // Stop stops the message tracker
 func (emt *ExchangeMessageTracker) Stop() {
 	emt.once.Do(func() {
+		log.Debug("Stopping...")
 		close(emt.stop)
 	})
 }

--- a/session/pingpong/exchange_message_tracker_test.go
+++ b/session/pingpong/exchange_message_tracker_test.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockPeerExchangeMessageSender struct {
+	mockError     error
+	chanToWriteTo chan crypto.ExchangeMessage
+}
+
+func (mpems *MockPeerExchangeMessageSender) Send(em crypto.ExchangeMessage) error {
+	if mpems.chanToWriteTo != nil {
+		mpems.chanToWriteTo <- em
+	}
+	return mpems.mockError
+}
+
+func Test_ExchangeMessageTracker_Start_Stop(t *testing.T) {
+	dir, err := ioutil.TempDir("", "exchange_message_tracker_test")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	acc, err := ks.NewAccount("")
+	assert.Nil(t, err)
+
+	mockSender := &MockPeerExchangeMessageSender{
+		chanToWriteTo: make(chan crypto.ExchangeMessage, 10),
+	}
+
+	invoiceChan := make(chan crypto.Invoice)
+	exchangeMessageTracker := NewExchangeMessageTracker(
+		invoiceChan,
+		mockSender,
+		ks,
+		identity.FromAddress(acc.Address.Hex()),
+	)
+
+	go func() {
+		time.Sleep(time.Nanosecond * 10)
+		exchangeMessageTracker.Stop()
+	}()
+
+	err = exchangeMessageTracker.Start()
+	assert.Nil(t, err)
+}
+
+func Test_ExchangeMessageTracker_SendsMessage(t *testing.T) {
+	dir, err := ioutil.TempDir("", "exchange_message_tracker_test")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	acc, err := ks.NewAccount("")
+	assert.Nil(t, err)
+
+	err = ks.Unlock(acc, "")
+	assert.Nil(t, err)
+
+	mockSender := &MockPeerExchangeMessageSender{
+		chanToWriteTo: make(chan crypto.ExchangeMessage, 10),
+	}
+
+	invoiceChan := make(chan crypto.Invoice)
+	exchangeMessageTracker := NewExchangeMessageTracker(
+		invoiceChan,
+		mockSender,
+		ks,
+		identity.FromAddress(acc.Address.Hex()),
+	)
+
+	mockInvoice := crypto.Invoice{
+		AgreementID:    1,
+		AgreementTotal: 1,
+		Fee:            1,
+		Hashlock:       "lock",
+		Provider:       "provider",
+	}
+
+	defer exchangeMessageTracker.Stop()
+	go exchangeMessageTracker.Start()
+
+	invoiceChan <- mockInvoice
+
+	exchangeMessage := <-mockSender.chanToWriteTo
+	addr, err := exchangeMessage.RecoverConsumerIdentity()
+	assert.Nil(t, err)
+
+	assert.Equal(t, acc.Address.Hex(), addr.Hex())
+}
+
+func Test_ExchangeMessageTracker_BubblesErrors(t *testing.T) {
+	dir, err := ioutil.TempDir("", "exchange_message_tracker_test")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	acc, err := ks.NewAccount("")
+	assert.Nil(t, err)
+
+	mockSender := &MockPeerExchangeMessageSender{
+		chanToWriteTo: make(chan crypto.ExchangeMessage, 10),
+	}
+
+	invoiceChan := make(chan crypto.Invoice)
+	exchangeMessageTracker := NewExchangeMessageTracker(
+		invoiceChan,
+		mockSender,
+		ks,
+		identity.FromAddress(acc.Address.Hex()),
+	)
+
+	defer exchangeMessageTracker.Stop()
+	errChan := make(chan error)
+	go func() { errChan <- exchangeMessageTracker.Start() }()
+
+	invoiceChan <- crypto.Invoice{}
+
+	err = <-errChan
+	assert.Error(t, err)
+}

--- a/session/pingpong/exchange_messaging.go
+++ b/session/pingpong/exchange_messaging.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/payments/crypto"
+)
+
+// ExchangeRequest structure represents message from service consumer to send a an exchange message
+type ExchangeRequest struct {
+	Message crypto.ExchangeMessage `json:"exchangeMessage"`
+}
+
+const endpointExchange = "session-exchange"
+const messageEndpointExchange = communication.MessageEndpoint(endpointExchange)
+
+// ExchangeSender is responsible for sending the exchange messages
+type ExchangeSender struct {
+	sender communication.Sender
+}
+
+// NewExchangeSender returns a new instance of exchange message sender
+func NewExchangeSender(sender communication.Sender) *ExchangeSender {
+	return &ExchangeSender{
+		sender: sender,
+	}
+}
+
+// Send send the given exchange message
+func (es *ExchangeSender) Send(em crypto.ExchangeMessage) error {
+	return es.sender.Send(&ExchangeMessageProducer{Message: em})
+}
+
+// ExchangeListener listens for exchange messages
+type ExchangeListener struct {
+	MessageConsumer *ExchangeMessageConsumer
+}
+
+// NewExchangeListener returns a new instance of exchange message listener
+func NewExchangeListener(exchangeChan chan crypto.ExchangeMessage) *ExchangeListener {
+	return &ExchangeListener{
+		MessageConsumer: &ExchangeMessageConsumer{
+			queue: exchangeChan,
+		},
+	}
+}
+
+// GetConsumer gets the underlying consumer from the listener
+func (el *ExchangeListener) GetConsumer() *ExchangeMessageConsumer {
+	return el.MessageConsumer
+}
+
+// Consume handles requests from endpoint and replies with response
+func (emc *ExchangeMessageConsumer) Consume(requestPtr interface{}) (err error) {
+	request := requestPtr.(*ExchangeRequest)
+	emc.queue <- request.Message
+	return nil
+}
+
+// Dialog boilerplate below, please ignore
+
+// ExchangeMessageConsumer is responsible for consuming the exchange messages
+type ExchangeMessageConsumer struct {
+	queue chan crypto.ExchangeMessage
+}
+
+// GetMessageEndpoint returns endpoint where to receive messages
+func (emc *ExchangeMessageConsumer) GetMessageEndpoint() communication.MessageEndpoint {
+	return messageEndpointExchange
+}
+
+// NewMessage creates struct where request from endpoint will be serialized
+func (emc *ExchangeMessageConsumer) NewMessage() (requestPtr interface{}) {
+	return &ExchangeRequest{}
+}
+
+// ExchangeMessageProducer handles the production of messages from the consumer side
+type ExchangeMessageProducer struct {
+	Message crypto.ExchangeMessage
+}
+
+// GetMessageEndpoint returns endpoint where to receive messages
+func (emp *ExchangeMessageProducer) GetMessageEndpoint() communication.MessageEndpoint {
+	return messageEndpointExchange
+}
+
+// Produce creates the actual message
+func (emp *ExchangeMessageProducer) Produce() (requestPtr interface{}) {
+	return &ExchangeRequest{
+		Message: emp.Message,
+	}
+}
+
+// NewResponse creates a new empty response
+func (emp *ExchangeMessageProducer) NewResponse() (responsePtr interface{}) {
+	return nil
+}

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/core/connection"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/session"
+	"github.com/mysteriumnetwork/payments/crypto"
+)
+
+// InvoiceFactoryCreator returns a payment engine factory
+func InvoiceFactoryCreator(dialog communication.Dialog, balanceSendPeriod, promiseTimeout time.Duration) func() (session.PaymentEngine, error) {
+	return func() (session.PaymentEngine, error) {
+		exchangeChan := make(chan crypto.ExchangeMessage, 1)
+		listener := NewExchangeListener(exchangeChan)
+		invoiceSender := NewInvoiceSender(dialog)
+		err := dialog.Receive(listener.GetConsumer())
+		if err != nil {
+			return nil, err
+		}
+		paymentEngine := NewInvoiceTracker(dialog.PeerID(), invoiceSender, balanceSendPeriod, exchangeChan, promiseTimeout)
+		return paymentEngine, nil
+	}
+}
+
+// ExchangeMessageFactoryCreator returns a payment engine factory
+func ExchangeMessageFactoryCreator(keystore *keystore.KeyStore) connection.PaymentEngineFactory {
+	return func(invoice chan crypto.Invoice, dialog communication.Dialog, consumer identity.Identity) (connection.PaymentIssuer, error) {
+		sender := NewExchangeSender(dialog)
+		listener := NewInvoiceListener(invoice)
+		err := dialog.Receive(listener.GetConsumer())
+		if err != nil {
+			return nil, err
+		}
+		return NewExchangeMessageTracker(invoice, sender, keystore, consumer), nil
+	}
+}

--- a/session/pingpong/invoice_messaging.go
+++ b/session/pingpong/invoice_messaging.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/payments/crypto"
+)
+
+// InvoiceRequest structure represents the invoice message that the provider sends to the consumer
+type InvoiceRequest struct {
+	Invoice crypto.Invoice `json:"invoice"`
+}
+
+const endpointInvoice = "session-invoice"
+const messageEndpointInvoice = communication.MessageEndpoint(endpointInvoice)
+
+// InvoiceSender is responsible for sending the invoice messages
+type InvoiceSender struct {
+	sender communication.Sender
+}
+
+// NewInvoiceSender returns a new instance of the invoice sender
+func NewInvoiceSender(sender communication.Sender) *InvoiceSender {
+	return &InvoiceSender{
+		sender: sender,
+	}
+}
+
+// Send sends the given invoice
+func (is *InvoiceSender) Send(invoice crypto.Invoice) error {
+	return is.sender.Send(&invoiceMessageProducer{Invoice: invoice})
+}
+
+// InvoiceListener listens for invoices
+type InvoiceListener struct {
+	invoiceMessageConsumer *invoiceMessageConsumer
+}
+
+// NewInvoiceListener returns a new instance of the invoice listener
+func NewInvoiceListener(messageChan chan crypto.Invoice) *InvoiceListener {
+	return &InvoiceListener{
+		invoiceMessageConsumer: &invoiceMessageConsumer{
+			queue: messageChan,
+		},
+	}
+}
+
+// GetConsumer returns the underlying invoice message consumer. Mostly here for the communication to work.
+func (il *InvoiceListener) GetConsumer() *invoiceMessageConsumer {
+	return il.invoiceMessageConsumer
+}
+
+// Consume handles requests from endpoint and replies with response
+func (imc *invoiceMessageConsumer) Consume(requestPtr interface{}) (err error) {
+	request := requestPtr.(*InvoiceRequest)
+	imc.queue <- request.Invoice
+	return nil
+}
+
+// Dialog boilerplate below, please ignore
+
+type invoiceMessageConsumer struct {
+	queue chan crypto.Invoice
+}
+
+// GetMessageEndpoint returns endpoint where to receive messages
+func (imc *invoiceMessageConsumer) GetMessageEndpoint() communication.MessageEndpoint {
+	return messageEndpointInvoice
+}
+
+// NewRequest creates struct where request from endpoint will be serialized
+func (imc *invoiceMessageConsumer) NewMessage() (requestPtr interface{}) {
+	return &InvoiceRequest{}
+}
+
+// invoiceMessageProducer
+type invoiceMessageProducer struct {
+	Invoice crypto.Invoice
+}
+
+// GetMessageEndpoint returns endpoint where to receive messages
+func (imp *invoiceMessageProducer) GetMessageEndpoint() communication.MessageEndpoint {
+	return messageEndpointInvoice
+}
+
+// Produce produces a request message
+func (imp *invoiceMessageProducer) Produce() (requestPtr interface{}) {
+	return &InvoiceRequest{
+		Invoice: imp.Invoice,
+	}
+}
+
+// NewResponse returns a new response object
+func (imp *invoiceMessageProducer) NewResponse() (responsePtr interface{}) {
+	return nil
+}

--- a/session/pingpong/invoice_messaging.go
+++ b/session/pingpong/invoice_messaging.go
@@ -27,8 +27,8 @@ type InvoiceRequest struct {
 	Invoice crypto.Invoice `json:"invoice"`
 }
 
-const endpointInvoice = "session-invoice"
-const messageEndpointInvoice = communication.MessageEndpoint(endpointInvoice)
+const invoiceEndpoint = "session-invoice"
+const invoiceMessageEndpoint = communication.MessageEndpoint(invoiceEndpoint)
 
 // InvoiceSender is responsible for sending the invoice messages
 type InvoiceSender struct {
@@ -81,7 +81,7 @@ type invoiceMessageConsumer struct {
 
 // GetMessageEndpoint returns endpoint where to receive messages
 func (imc *invoiceMessageConsumer) GetMessageEndpoint() communication.MessageEndpoint {
-	return messageEndpointInvoice
+	return invoiceMessageEndpoint
 }
 
 // NewRequest creates struct where request from endpoint will be serialized
@@ -96,7 +96,7 @@ type invoiceMessageProducer struct {
 
 // GetMessageEndpoint returns endpoint where to receive messages
 func (imp *invoiceMessageProducer) GetMessageEndpoint() communication.MessageEndpoint {
-	return messageEndpointInvoice
+	return invoiceMessageEndpoint
 }
 
 // Produce produces a request message

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/pkg/errors"
+)
+
+// PeerInvoiceSender allows to send invoices
+type PeerInvoiceSender interface {
+	Send(crypto.Invoice) error
+}
+
+// ErrExchangeWaitTimeout indicates that we did not get an exchange message in time
+var ErrExchangeWaitTimeout = errors.New("did not get a new exchange message")
+
+// ErrExchangeValidationFailed indicates that there was an error with the exchange signature
+var ErrExchangeValidationFailed = errors.New("exchange validation failed")
+
+// errBoltNotFound indicates that bolt did not find a record
+var errBoltNotFound = errors.New("not found")
+
+const chargePeriodLeeway = time.Hour * 2
+
+// InvoiceTracker keeps tab of invoices and sends them to the consumer
+type InvoiceTracker struct {
+	peer                            identity.Identity
+	stop                            chan struct{}
+	peerInvoiceSender               PeerInvoiceSender
+	exchangeMessageChan             chan crypto.ExchangeMessage
+	chargePeriod                    time.Duration
+	exchangeMessageWaitTimeout      time.Duration
+	notReceivedExchangeMessageCount uint64
+	maxNotReceivedExchangeMessages  uint64
+}
+
+// NewInvoiceTracker creates a new instancec of invoice tracker
+func NewInvoiceTracker(
+	peer identity.Identity,
+	peerInvoiceSender PeerInvoiceSender,
+	chargePeriod time.Duration,
+	exchangeMessageChan chan crypto.ExchangeMessage,
+	exchangeMessageWaitTimeout time.Duration) *InvoiceTracker {
+	return &InvoiceTracker{
+		peer:                           peer,
+		stop:                           make(chan struct{}),
+		peerInvoiceSender:              peerInvoiceSender,
+		exchangeMessageChan:            exchangeMessageChan,
+		exchangeMessageWaitTimeout:     exchangeMessageWaitTimeout,
+		chargePeriod:                   chargePeriod,
+		maxNotReceivedExchangeMessages: calculateMaxNotReceivedexchangeMessageCount(chargePeriodLeeway, chargePeriod),
+	}
+}
+
+func calculateMaxNotReceivedexchangeMessageCount(chargeLeeway, chargePeriod time.Duration) uint64 {
+	return uint64(math.Round(float64(chargeLeeway) / float64(chargePeriod)))
+}
+
+// Start stars the invoice tracker
+func (it *InvoiceTracker) Start() error {
+	// give the consumer a second to start up his payments before sending the first request
+	firstSend := time.After(time.Second)
+	for {
+		select {
+		case <-firstSend:
+			err := it.sendInvoiceExpectExchangeMessage()
+			if err != nil {
+				return err
+			}
+		case <-it.stop:
+			return nil
+		case <-time.After(it.chargePeriod):
+			err := it.sendInvoiceExpectExchangeMessage()
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (it *InvoiceTracker) markExchangeMessageNotReceived() {
+	atomic.AddUint64(&it.notReceivedExchangeMessageCount, 1)
+}
+
+func (it *InvoiceTracker) resetNotReceivedExchangeMessageCount() {
+	atomic.SwapUint64(&it.notReceivedExchangeMessageCount, 0)
+}
+
+func (it *InvoiceTracker) getNotReceivedExchangeMessageCount() uint64 {
+	return atomic.LoadUint64(&it.notReceivedExchangeMessageCount)
+}
+
+func (it *InvoiceTracker) sendInvoiceExpectExchangeMessage() error {
+	err := it.sendInvoice()
+	if err != nil {
+		return err
+	}
+
+	err = it.receiveExchangeMessageOrTimeout()
+	if err != nil {
+		handlerErr := it.handleExchangeMessageReceiveError(err)
+		if handlerErr != nil {
+			return err
+		}
+	} else {
+		it.resetNotReceivedExchangeMessageCount()
+	}
+	return nil
+}
+
+func (it *InvoiceTracker) handleExchangeMessageReceiveError(err error) error {
+	// if it's a timeout, we'll want to ignore it if we're not exceeding maxNotReceivedexchangeMessages
+	if err == ErrExchangeWaitTimeout {
+		it.markExchangeMessageNotReceived()
+		if it.getNotReceivedExchangeMessageCount() >= it.maxNotReceivedExchangeMessages {
+			return err
+		}
+		log.Warn("Failed to receive exchangeMessage: ", err)
+		return nil
+	}
+	return err
+}
+
+func (it *InvoiceTracker) sendInvoice() error {
+	// TODO: a ton of actions should go here
+
+	// TODO: fill the fields
+	return it.peerInvoiceSender.Send(crypto.Invoice{AgreementID: 1234})
+}
+
+func (it *InvoiceTracker) receiveExchangeMessageOrTimeout() error {
+	select {
+	case pm := <-it.exchangeMessageChan:
+		if res := pm.ValidateExchangeMessage(common.HexToAddress(it.peer.Address)); !res {
+			return ErrExchangeValidationFailed
+		}
+	case <-time.After(it.exchangeMessageWaitTimeout):
+		return ErrExchangeWaitTimeout
+	}
+	return nil
+}
+
+// Stop stops the invoice tracker
+func (it *InvoiceTracker) Stop() {
+	close(it.stop)
+}

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -40,9 +40,6 @@ var ErrExchangeWaitTimeout = errors.New("did not get a new exchange message")
 // ErrExchangeValidationFailed indicates that there was an error with the exchange signature
 var ErrExchangeValidationFailed = errors.New("exchange validation failed")
 
-// errBoltNotFound indicates that bolt did not find a record
-var errBoltNotFound = errors.New("not found")
-
 const chargePeriodLeeway = time.Hour * 2
 
 // InvoiceTracker keeps tab of invoices and sends them to the consumer
@@ -58,7 +55,7 @@ type InvoiceTracker struct {
 	once                            sync.Once
 }
 
-// NewInvoiceTracker creates a new instancec of invoice tracker
+// NewInvoiceTracker creates a new instance of invoice tracker
 func NewInvoiceTracker(
 	peer identity.Identity,
 	peerInvoiceSender PeerInvoiceSender,

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockPeerInvoiceSender struct {
+	mockError     error
+	chanToWriteTo chan crypto.Invoice
+}
+
+func (mpis *MockPeerInvoiceSender) Send(invoice crypto.Invoice) error {
+	if mpis.chanToWriteTo != nil {
+		mpis.chanToWriteTo <- invoice
+	}
+	return mpis.mockError
+}
+
+func Test_InvoiceTracker_Start_Stop(t *testing.T) {
+	dir, err := ioutil.TempDir("", "invoice_tracker_test")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	acc, err := ks.NewAccount("")
+	assert.Nil(t, err)
+
+	mockSender := &MockPeerInvoiceSender{
+		chanToWriteTo: make(chan crypto.Invoice, 10),
+	}
+
+	exchangeMessageChan := make(chan crypto.ExchangeMessage)
+	invoiceTracker := NewInvoiceTracker(
+		identity.FromAddress(acc.Address.Hex()),
+		mockSender,
+		time.Nanosecond,
+		exchangeMessageChan,
+		time.Second,
+	)
+
+	go func() {
+		time.Sleep(time.Nanosecond * 10)
+		invoiceTracker.Stop()
+	}()
+
+	err = invoiceTracker.Start()
+	assert.Nil(t, err)
+}
+
+func Test_InvoiceTracker_BubblesErrors(t *testing.T) {
+	dir, err := ioutil.TempDir("", "invoice_tracker_test")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	acc, err := ks.NewAccount("")
+	assert.Nil(t, err)
+
+	mockSender := &MockPeerInvoiceSender{
+		chanToWriteTo: make(chan crypto.Invoice, 10),
+	}
+
+	exchangeMessageChan := make(chan crypto.ExchangeMessage)
+	invoiceTracker := NewInvoiceTracker(
+		identity.FromAddress(acc.Address.Hex()),
+		mockSender,
+		time.Nanosecond,
+		exchangeMessageChan,
+		time.Nanosecond*10,
+	)
+
+	defer invoiceTracker.Stop()
+
+	errChan := make(chan error)
+	go func() { errChan <- invoiceTracker.Start() }()
+
+	exchangeMessageChan <- crypto.ExchangeMessage{}
+
+	err = <-errChan
+	assert.Error(t, err)
+}
+
+func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
+	dir, err := ioutil.TempDir("", "invoice_tracker_test")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	acc, err := ks.NewAccount("")
+	assert.Nil(t, err)
+
+	mockSender := &MockPeerInvoiceSender{
+		chanToWriteTo: make(chan crypto.Invoice, 10),
+	}
+
+	exchangeMessageChan := make(chan crypto.ExchangeMessage)
+	invoiceTracker := NewInvoiceTracker(
+		identity.FromAddress(acc.Address.Hex()),
+		mockSender,
+		time.Nanosecond,
+		exchangeMessageChan,
+		time.Second,
+	)
+
+	defer invoiceTracker.Stop()
+
+	errChan := make(chan error)
+	go func() { errChan <- invoiceTracker.Start() }()
+
+	invoice := <-mockSender.chanToWriteTo
+	assert.Equal(t, crypto.Invoice{AgreementID: 1234}, invoice)
+}
+
+func Test_calculateMaxNotReceivedExchangeMessageCount(t *testing.T) {
+	res := calculateMaxNotReceivedExchangeMessageCount(time.Minute*5, time.Second*240)
+	assert.Equal(t, uint64(1), res)
+	res = calculateMaxNotReceivedExchangeMessageCount(time.Minute*5, time.Second*20)
+	assert.Equal(t, uint64(15), res)
+	res = calculateMaxNotReceivedExchangeMessageCount(time.Hour*2, time.Second*20)
+	assert.Equal(t, uint64(360), res)
+}

--- a/session/pingpong/log.go
+++ b/session/pingpong/log.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import "github.com/mysteriumnetwork/node/logconfig"
+
+var log = logconfig.NewLogger()

--- a/session/promise/promise_messaging.go
+++ b/session/promise/promise_messaging.go
@@ -37,6 +37,7 @@ type Message struct {
 type PaymentInfo struct {
 	LastPromise LastPromise `json:"lastPromise"`
 	FreeCredit  uint64      `json:"freeCredit"`
+	Supports    string      `json:"supported"`
 }
 
 // LastPromise represents the last known promise to the provider


### PR DESCRIPTION
Initial scaffold of the new pingpong between the consumer and provider for the upcoming payments.

Should be backwards compatible, as I've tested conencting to an older node, as well as had this session while running in provider mode: https://testnet.mysterium.network/session/2f822bd5-c5ff-4ccb-a921-c5ee7255790a 