### PR TITLE
Allow users to report node issues via Tequilapi

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -467,6 +467,14 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:9deb68c9db68b22052a30fe5cf89f4eb1a3eb3df86d13e3e96edf68dd3d1a9fc"
+  name = "github.com/mysteriumnetwork/feedback"
+  packages = ["client"]
+  pruneopts = "UT"
+  revision = "56edce8b45948049265f664b8a07b43cc0b80fb8"
+  version = "v1.1.1"
+
+[[projects]]
   branch = "master"
   digest = "1:99107f962731360fa2f26b2241e2ed66d597044d2f999008965bbe25746ba4ce"
   name = "github.com/mysteriumnetwork/go-ci"
@@ -1066,6 +1074,7 @@
     "github.com/mholt/archiver",
     "github.com/miekg/dns",
     "github.com/mitchellh/go-homedir",
+    "github.com/mysteriumnetwork/feedback/client",
     "github.com/mysteriumnetwork/go-ci/env",
     "github.com/mysteriumnetwork/go-ci/github",
     "github.com/mysteriumnetwork/go-ci/shell",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -168,3 +168,7 @@
 [[constraint]]
   name = "github.com/miekg/dns"
   version = "1.0.12"
+
+[[constraint]]
+  name = "github.com/mysteriumnetwork/feedback"
+  version = "1.1.1"

--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -45,6 +45,11 @@ var (
 		Usage: "IP address to bind to",
 		Value: "0.0.0.0",
 	})
+	feedbackURLFlag = cli.StringFlag{
+		Name:  "feedback.url",
+		Usage: "URL of Feedback API",
+		Value: "https://feedback.mysterium.network",
+	}
 )
 
 // ParseKeystoreFlags parses the keystore options for node
@@ -60,7 +65,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		return err
 	}
 
-	*flags = append(*flags, tequilapiAddressFlag, tequilapiPortFlag, keystoreLightweightFlag, bindAddressFlag)
+	*flags = append(*flags, tequilapiAddressFlag, tequilapiPortFlag, keystoreLightweightFlag, bindAddressFlag, feedbackURLFlag)
 
 	RegisterFlagsNetwork(flags)
 	RegisterFlagsDiscovery(flags)
@@ -85,6 +90,7 @@ func ParseFlagsNode(ctx *cli.Context) node.Options {
 		TequilapiPort:    ctx.GlobalInt(tequilapiPortFlag.Name),
 		UI:               ParseFlagsUI(ctx),
 		BindAddress:      ctx.GlobalString(bindAddressFlag.Name),
+		FeedbackURL:      ctx.GlobalString(feedbackURLFlag.Name),
 
 		Keystore: ParseKeystoreFlags(ctx),
 

--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -76,9 +76,10 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 
 // ParseFlagsNode function fills in node options from CLI context
 func ParseFlagsNode(ctx *cli.Context) node.Options {
+	dirs := ParseFlagsDirectory(ctx)
 	return node.Options{
-		LogOptions:  logconfig.ParseFlags(ctx),
-		Directories: ParseFlagsDirectory(ctx),
+		LogOptions:  logconfig.ParseFlags(ctx, dirs.Data),
+		Directories: dirs,
 
 		TequilapiAddress: ctx.GlobalString(tequilapiAddressFlag.Name),
 		TequilapiPort:    ctx.GlobalInt(tequilapiPortFlag.Name),

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	TequilapiPort    int
 	BindAddress      string
 	UI               OptionsUI
+	FeedbackURL      string
 
 	DisableMetrics bool
 	MetricsAddress string

--- a/feedback/reporter.go
+++ b/feedback/reporter.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package feedback
+
+import (
+	"github.com/mysteriumnetwork/feedback/client"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/logconfig"
+	"github.com/pkg/errors"
+)
+
+var log = logconfig.NewLogger()
+
+// Reporter reports issues from users
+type Reporter struct {
+	logCollector     logCollector
+	identityProvider identityProvider
+	feedbackAPI      *client.FeedbackAPI
+}
+
+// NewReporter constructs a new Reporter
+func NewReporter(
+	logCollector logCollector,
+	identityProvider identityProvider,
+	feedbackURL string,
+) (*Reporter, error) {
+	log.Info("Using feedback API at: " + feedbackURL)
+	api, err := client.NewFeedbackAPI(feedbackURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Reporter{
+		logCollector:     logCollector,
+		identityProvider: identityProvider,
+		feedbackAPI:      api,
+	}, nil
+}
+
+type logCollector interface {
+	Archive() (filepath string, err error)
+}
+
+type identityProvider interface {
+	GetIdentities() []identity.Identity
+}
+
+// UserReport represents user input when submitting an issue report
+type UserReport struct {
+	Email       string `json:"email"`
+	Description string `json:"description"`
+}
+
+// NewIssue sends node logs, Identity and UserReport to the feedback service
+func (r *Reporter) NewIssue(report UserReport) (result *client.CreateGithubIssueResult, err error) {
+	userID := r.currentIdentity()
+
+	archiveFilepath, err := r.logCollector.Archive()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create log archive")
+	}
+
+	result, err = r.feedbackAPI.CreateGithubIssue(client.CreateGithubIssueRequest{
+		UserId:      userID,
+		Description: report.Description,
+		Email:       report.Email,
+		Filepath:    archiveFilepath,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create github issue")
+	}
+	return result, nil
+}
+
+func (r *Reporter) currentIdentity() (identity string) {
+	identities := r.identityProvider.GetIdentities()
+	if len(identities) > 0 {
+		return identities[0].Address
+	}
+	return "unknown_identity"
+}

--- a/logconfig/collector.go
+++ b/logconfig/collector.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package logconfig
+
+import (
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/mholt/archiver"
+	"github.com/pkg/errors"
+)
+
+// Collector collects node logs
+type Collector struct {
+	options *LogOptions
+}
+
+// NewCollector creates a Collector instance
+func NewCollector(options *LogOptions) *Collector {
+	return &Collector{options: options}
+}
+
+// Archive creates ZIP archive containing all node log files
+func (c *Collector) Archive() (outputFilepath string, err error) {
+	filepaths, err := c.logFilepaths()
+	if err != nil {
+		return "", err
+	}
+
+	zip := archiver.NewZip()
+	zip.OverwriteExisting = true
+
+	zipFilepath := c.options.Filepath + ".zip"
+	err = zip.Archive(filepaths, zipFilepath)
+	if err != nil {
+		return "", errors.Wrap(err, "could not create log archive")
+	}
+
+	return zipFilepath, nil
+}
+
+func (c *Collector) logFilepaths() (result []string, err error) {
+	filename := path.Base(c.options.Filepath)
+	dir := path.Dir(c.options.Filepath)
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read directory: "+dir)
+	}
+	for _, f := range files {
+		if strings.Contains(f.Name(), filename) {
+			result = append(result, path.Join(dir, f.Name()))
+		}
+	}
+	return result, nil
+}

--- a/logconfig/collector_test.go
+++ b/logconfig/collector_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package logconfig
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollector_List_ListsAllLogFilesMatchingPattern(t *testing.T) {
+	assert := assert.New(t)
+
+	// given
+	baseName := "mysterium-test.log"
+	fn1 := NewTempFileName(t, baseName)
+	defer func() { _ = os.Remove(fn1) }()
+	fn2 := NewTempFileName(t, baseName)
+	defer func() { _ = os.Remove(fn2) }()
+
+	opts := LogOptions{
+		LogLevel: "Debug",
+		Filepath: path.Join(path.Dir(fn1), baseName),
+	}
+	collector := NewCollector(&opts)
+
+	// when
+	logFiles, err := collector.logFilepaths()
+
+	// then
+	assert.NoError(err)
+	assert.Contains(logFiles, fn1)
+	assert.Contains(logFiles, fn2)
+}
+
+func TestCollector_Archive(t *testing.T) {
+	assert := assert.New(t)
+
+	// given
+	baseName := "mysterium-test.log"
+	fn1 := NewTempFileName(t, baseName)
+	defer func() { _ = os.Remove(fn1) }()
+	fn2 := NewTempFileName(t, baseName)
+	defer func() { _ = os.Remove(fn2) }()
+
+	opts := LogOptions{
+		LogLevel: "Debug",
+		Filepath: path.Join(path.Dir(fn1), baseName),
+	}
+	collector := NewCollector(&opts)
+
+	// when
+	zipFilename, err := collector.Archive()
+	defer func() { _ = os.Remove(zipFilename) }()
+
+	// then
+	assert.NoError(err)
+	assert.NotEmpty(zipFilename)
+}
+
+func NewTempFileName(t *testing.T, pattern string) string {
+	file, err := ioutil.TempFile("", pattern)
+	assert.NoError(t, err)
+	return file.Name()
+}

--- a/logconfig/config.go
+++ b/logconfig/config.go
@@ -28,6 +28,15 @@ const seewayLogXMLConfigTemplate = `
 <seelog minlevel="{{.LogLevel}}">
 	<outputs formatid="main">
 		<console/>
+		{{ if (ne .Filepath "") }}
+		<rollingfile
+			formatid="main"
+			filename="{{.Filepath}}"
+			maxrolls="7"
+			type="date"
+			datepattern="2006.01.02"
+		/>
+		{{ end }}
 	</outputs>
 	<formats>
 		<format id="main" format="%UTCDate(2006-01-02T15:04:05.999999999) [%Level] %Msg%n"/>
@@ -54,14 +63,17 @@ func BootstrapWith(opts *LogOptions) {
 	}
 	newLogger, err := log.LoggerFromConfigAsString(buildXmlConfig(CurrentLogOptions))
 	if err != nil {
-		log.Warn("error parsing log configuration", err)
+		log.Warn("Error parsing log configuration", err)
 		return
 	}
 	err = log.UseLogger(newLogger)
 	if err != nil {
-		log.Warn("error setting new logger for log", err)
+		log.Warn("Error setting new logger for log", err)
 	}
-	log.Infof("log level: %s", CurrentLogOptions.LogLevel)
+	log.Infof("Log level: %s", CurrentLogOptions.LogLevel)
+	if CurrentLogOptions.Filepath != "" {
+		log.Infof("Log file path: %s", CurrentLogOptions.Filepath)
+	}
 }
 
 // Bootstrap loads log package into the overall system with debug defaults

--- a/logconfig/options.go
+++ b/logconfig/options.go
@@ -19,6 +19,7 @@ package logconfig
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	log "github.com/cihub/seelog"
@@ -30,6 +31,7 @@ import (
 type LogOptions struct {
 	logLevelInt log.LogLevel
 	LogLevel    string
+	Filepath    string
 }
 
 // CurrentLogOptions current log options
@@ -58,7 +60,7 @@ func RegisterFlags(flags *[]cli.Flag) {
 }
 
 // ParseFlags parses logger CLI flags from context
-func ParseFlags(ctx *cli.Context) LogOptions {
+func ParseFlags(ctx *cli.Context, logDir string) LogOptions {
 	level := ctx.GlobalString("log-level")
 	levelInt, found := log.LogLevelFromString(level)
 	if !found {
@@ -68,5 +70,6 @@ func ParseFlags(ctx *cli.Context) LogOptions {
 	return LogOptions{
 		logLevelInt: levelInt,
 		LogLevel:    level,
+		Filepath:    path.Join(logDir, "mysterium-node.log"),
 	}
 }

--- a/tequilapi/endpoints/feedback.go
+++ b/tequilapi/endpoints/feedback.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package endpoints
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/mysteriumnetwork/node/feedback"
+	"github.com/mysteriumnetwork/node/tequilapi/utils"
+	"github.com/pkg/errors"
+)
+
+type feedbackAPI struct {
+	reporter *feedback.Reporter
+}
+
+func newFeedbackAPI(reporter *feedback.Reporter) *feedbackAPI {
+	return &feedbackAPI{reporter: reporter}
+}
+
+// ReportIssueRequest params for issue report
+// swagger:model
+type ReportIssueRequest struct {
+	Email       string `json:"email"`
+	Description string `json:"description"`
+}
+
+// ReportIssueSuccess successful issue report
+// swagger:model
+type ReportIssueSuccess struct {
+	IssueID string `json:"issueId"`
+}
+
+// ReportIssueError issue report error
+// swagger:model
+type ReportIssueError struct {
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// ReportIssue reports user issue
+// swagger:operation POST /feedback/issue Feedback reportIssue
+// ---
+// summary: Reports user issue
+// description: Reports user issue
+// parameters:
+//   - in: body
+//     name: body
+//     description: Report issue request
+//     schema:
+//       $ref: "#/definitions/ReportIssueRequest"
+// responses:
+//   200:
+//     description: Issue reported
+//     schema:
+//       "$ref": "#/definitions/ReportIssueSuccess"
+//   400:
+//     description: Bad request
+//     schema:
+//       "$ref": "#/definitions/ReportIssueError"
+//   429:
+//     description: Too many requests (max. 1/minute)
+//     schema:
+//       "$ref": "#/definitions/ReportIssueError"
+//   500:
+//     description: Internal server error
+//     schema:
+//       "$ref": "#/definitions/ReportIssueError"
+func (api *feedbackAPI) ReportIssue(httpRes http.ResponseWriter, httpReq *http.Request, params httprouter.Params) {
+	req := feedback.UserReport{}
+	err := json.NewDecoder(httpReq.Body).Decode(&req)
+	if err != nil {
+		utils.SendError(httpRes, errors.Wrap(err, "could not read message body"), http.StatusBadRequest)
+		return
+	}
+
+	result, err := api.reporter.NewIssue(req)
+	if err != nil {
+		utils.SendError(httpRes, err, http.StatusInternalServerError)
+		return
+	}
+
+	if !result.Success {
+		utils.SendErrorBody(httpRes, result.Errors, result.HTTPResponse.StatusCode)
+		return
+	}
+
+	utils.WriteAsJSON(result.Response, httpRes)
+}
+
+// AddRoutesForFeedback registers feedback routes
+func AddRoutesForFeedback(
+	router *httprouter.Router,
+	reporter *feedback.Reporter,
+) {
+	api := newFeedbackAPI(reporter)
+	router.POST("/feedback/issue", api.ReportIssue)
+}


### PR DESCRIPTION
Closes: #1251 

Sample usage:
```
curl -v -X POST http://localhost:4050/feedback/issue -d '{ "description": "this is very wrong" }'
```

Issues are reported to an undisclosed github repository.