### PR TITLE
Fix bootstrap order for SSE

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -272,16 +272,17 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 		return err
 	}
 
-	if err := di.bootstrapSSEHandler(); err != nil {
-		return err
-	}
-
-	di.bootstrapNATComponents(nodeOptions)
 	if err := di.bootstrapServices(nodeOptions); err != nil {
 		return err
 	}
 
+	di.bootstrapNATComponents(nodeOptions)
+
 	if err := di.bootstrapStateKeeper(nodeOptions); err != nil {
+		return err
+	}
+
+	if err := di.bootstrapSSEHandler(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Put the state keeper bootstrap before the sse bootstrap.

Closes #1309 