### PR TITLE
Enable cookies in UI reverse proxy

### DIFF
--- a/ui/reverse_proxy.go
+++ b/ui/reverse_proxy.go
@@ -52,9 +52,11 @@ func buildReverseProxy(bindAddress string, transport *http.Transport, tequilapiP
 			req.URL.Path = strings.TrimRight(req.URL.Path, "/")
 		},
 		ModifyResponse: func(res *http.Response) error {
-			res.Header.Set("Access-Control-Allow-Origin", "*")
-			res.Header.Set("Access-Control-Allow-Headers", "*")
-			res.Header.Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+			// remove TequilAPI CORS headers
+			// these will be overwritten by Gin middleware
+			res.Header.Del("Access-Control-Allow-Origin")
+			res.Header.Del("Access-Control-Allow-Headers")
+			res.Header.Del("Access-Control-Allow-Methods")
 			return nil
 		},
 		Transport: transport,

--- a/ui/server.go
+++ b/ui/server.go
@@ -45,13 +45,29 @@ type jwtAuthenticator interface {
 	ValidateToken(token string) (bool, error)
 }
 
+var corsConfig = cors.Config{
+	AllowMethods: []string{"*"},
+	AllowHeaders: []string{
+		"Origin",
+		"Content-Length",
+		"Content-Type",
+		"Cache-Control",
+		"X-XSRF-TOKEN",
+		"X-CSRF-TOKEN",
+	},
+	AllowCredentials: true,
+	AllowOriginFunc: func(origin string) bool {
+		return true
+	},
+}
+
 // NewServer creates a new instance of the server for the given port
 func NewServer(bindAddress string, port int, tequilapiPort int, authenticator jwtAuthenticator) *Server {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.Use(cors.Default())
 	r.NoRoute(ReverseTequilapiProxy(bindAddress, tequilapiPort, authenticator))
+	r.Use(cors.New(corsConfig))
 
 	r.StaticFS("/", godvpnweb.Assets)
 


### PR DESCRIPTION
This PR enables CORS cookies. Problem was that ModifyResponse was setting additional headers so the CORS origin header had multiple entries. Another problem was that Gin CORS middleware was using a wildcard for the Access-Control-Allow-Origin and that doesn't work for CORS calls with cookies, it has to be set explicit.

This wasn't an issue before since UI is running on the exact same host:port as the reverse proxy.