### PR TITLE
Option to limit openvpn bandwidth

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -499,7 +499,7 @@
   version = "0.0.23"
 
 [[projects]]
-  digest = "1:01ecb25c7a76df3c915d9786acaac94abc3dcf5eaa8a9d3fb2a7a53d48edd006"
+  digest = "1:076c66b46e3ff5ae5287bbb48109aa10009269e0370c1bb47f5978b3d18241a7"
   name = "github.com/mysteriumnetwork/go-openvpn"
   packages = [
     "openvpn",
@@ -515,8 +515,8 @@
     "openvpn3",
   ]
   pruneopts = "T"
-  revision = "22fe4c7b3f0fcbe822712db335fe96ef5d41723e"
-  version = "0.0.16"
+  revision = "75afeb4935e1555a3ed9c43115cab570d0ade57b"
+  version = "v0.0.17"
 
 [[projects]]
   digest = "1:92d9e4ed980f0b7981719cc8ec881ca36a8e7ef94097a54d8b6503fbff56da8f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@
 
 [[constraint]]
   name = "github.com/mysteriumnetwork/go-openvpn"
-  version = "0.0.16"
+  version = "0.0.17"
 
 [prune]
   go-tests = true

--- a/bin/package/raspberry/files/1-setup-node.sh
+++ b/bin/package/raspberry/files/1-setup-node.sh
@@ -24,7 +24,8 @@ apt-get update --allow-releaseinfo-change
 # Install myst dependencies
 apt-get -y install \
   wireguard \
-  openvpn
+  openvpn \
+  wondershaper
 
 # Setup unattended upgrades
 apt-get -y install \

--- a/bin/package_debian
+++ b/bin/package_debian
@@ -65,6 +65,7 @@ printf "Building Debian package '$PACKAGE_FILE' for architecture '$ARCH' ..\n" \
         --depends "sudo" \
         --depends "debconf" \
         --depends "wireguard" \
+        --depends "wondershaper" \
         --deb-templates bin/package/installation/templates \
         --before-install bin/package/installation/pre-install.sh \
         --after-install bin/package/installation/post-install.sh \

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -44,6 +44,7 @@ import (
 	nodevent "github.com/mysteriumnetwork/node/core/node/event"
 	"github.com/mysteriumnetwork/node/core/quality"
 	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/shaper"
 	"github.com/mysteriumnetwork/node/core/state"
 	statevent "github.com/mysteriumnetwork/node/core/state/event"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb"
@@ -221,6 +222,8 @@ type Dependencies struct {
 
 	LogCollector *logconfig.Collector
 	Reporter     *feedback.Reporter
+
+	Shaper shaper.Shaper
 }
 
 // Bootstrap initiates all container dependencies
@@ -271,6 +274,8 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	if err := di.bootstrapBandwidthTracker(); err != nil {
 		return err
 	}
+
+	di.Shaper = shaper.Bootstrap()
 
 	if err := di.bootstrapServices(nodeOptions); err != nil {
 		return err

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mysteriumnetwork/node/communication/nats"
 	nats_dialog "github.com/mysteriumnetwork/node/communication/nats/dialog"
 	nats_discovery "github.com/mysteriumnetwork/node/communication/nats/discovery"
+	appconfig "github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/consumer/bandwidth"
 	consumer_session "github.com/mysteriumnetwork/node/consumer/session"
 	"github.com/mysteriumnetwork/node/consumer/statistics"
@@ -275,7 +276,7 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 		return err
 	}
 
-	di.Shaper = shaper.Bootstrap()
+	di.Shaper = shaper.Bootstrap(di.EventBus)
 
 	if err := di.bootstrapServices(nodeOptions); err != nil {
 		return err
@@ -308,6 +309,8 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	if err := di.Node.Start(); err != nil {
 		return err
 	}
+
+	appconfig.Current.EnableEventPublishing(di.EventBus)
 
 	return nil
 }

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -162,6 +162,7 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 			di.NATTracker,
 			portPool,
 			di.EventBus,
+			di.Shaper,
 		)
 		return manager, proposal, nil
 	}

--- a/core/shaper/bootstrap.go
+++ b/core/shaper/bootstrap.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package shaper
+
+// Shaper shapes traffic on a network interface
+type Shaper interface {
+	// TargetInterface targets network interface for applying shaping configuration
+	TargetInterface(interfaceName string)
+	// Apply applies current shaping configuration to the target interface
+	Apply() error
+}
+
+// Bootstrap creates a shaper: either a wondershaper (linux-only, if binary exists), or a noop
+func Bootstrap() (shaper Shaper) {
+	shaper, err := newWonderShaper()
+	if err != nil {
+		log.Error("Could not create wonder shaper, using noop: ", err)
+		shaper = newNoopShaper()
+	}
+	return shaper
+}

--- a/core/shaper/bootstrap.go
+++ b/core/shaper/bootstrap.go
@@ -17,17 +17,18 @@
 
 package shaper
 
+import "github.com/mysteriumnetwork/node/eventbus"
+
 // Shaper shapes traffic on a network interface
 type Shaper interface {
-	// TargetInterface targets network interface for applying shaping configuration
-	TargetInterface(interfaceName string)
-	// Apply applies current shaping configuration to the target interface
-	Apply() error
+	// Start applies current shaping configuration for the specified interface
+	// and then continuously ensures it
+	Start(interfaceName string) error
 }
 
 // Bootstrap creates a shaper: either a wondershaper (linux-only, if binary exists), or a noop
-func Bootstrap() (shaper Shaper) {
-	shaper, err := newWonderShaper()
+func Bootstrap(eventBus eventbus.EventBus) (shaper Shaper) {
+	shaper, err := newWonderShaper(eventBus)
 	if err != nil {
 		log.Error("Could not create wonder shaper, using noop: ", err)
 		shaper = newNoopShaper()

--- a/core/shaper/shaper.go
+++ b/core/shaper/shaper.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package shaper
+
+import (
+	"net"
+	"os/exec"
+	"strconv"
+
+	"github.com/magefile/mage/sh"
+	"github.com/mysteriumnetwork/node/config"
+	"github.com/mysteriumnetwork/node/logconfig"
+	"github.com/mysteriumnetwork/node/services/shared"
+	"github.com/pkg/errors"
+)
+
+var log = logconfig.NewLogger()
+
+const (
+	limitKbps = 5000
+)
+
+// noopShaper does not apply to network interface
+type noopShaper struct {
+}
+
+func newNoopShaper() *noopShaper {
+	return &noopShaper{}
+}
+
+// TargetInterface noop
+func (noopShaper) TargetInterface(interfaceName string) {
+	_ = log.Errorf("target interface %s: noop", interfaceName)
+}
+
+// Apply noop
+func (noopShaper) Apply() error {
+	return errors.New("shaper is noop: apply will not take effect")
+}
+
+// cmd shell command to be executed with args
+type cmd func(args ...string) error
+
+// wonderShaper uses wondershaper utility to apply bandwidth limit to the network interface
+type wonderShaper struct {
+	runCmd          cmd
+	targetInterface string
+}
+
+func newWonderShaper() (*wonderShaper, error) {
+	path, err := healthcheck("wondershaper")
+	if err != nil {
+		return nil, errors.Wrap(err, "wondershaper healthcheck failed")
+	}
+	return &wonderShaper{runCmd: sh.RunCmd(path)}, nil
+}
+
+// healthcheck checks wondershaper status on the first network interface:
+// this works as a healthcheck considering that a compatible version of wondershaper is installed
+// If healthcheck passes, it returns an actual path of wondershaper binary.
+func healthcheck(cmd string) (path string, err error) {
+	log.Debug("Wondershaper healthcheck: starting")
+
+	path, err = exec.LookPath(cmd)
+	if err != nil {
+		return path, errors.Wrap(err, "wondershaper executable not found")
+	}
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return path, errors.Wrap(err, "failed to lookup network interfaces")
+	}
+	testInterface := interfaces[0].Name
+
+	wondershaperOut, err := sh.Output(path, testInterface)
+	if err != nil {
+		return path, errors.Wrapf(err, "failed to invoke wondershaper on %s", testInterface)
+	}
+
+	log.Debugf("Wondershaper healthcheck success. Status on %s: %s", testInterface, wondershaperOut)
+	return path, nil
+}
+
+// TargetInterface targets specific network interface
+func (s *wonderShaper) TargetInterface(interfaceName string) {
+	s.targetInterface = interfaceName
+}
+
+// Apply applies current shaping rules
+func (s *wonderShaper) Apply() error {
+	enabled := config.Current.GetBool(shared.ShaperEnabledFlag.Name)
+	if enabled {
+		log.Info("Shaper enabled, limiting bandwidth")
+		return s.limitBandwidth()
+	}
+	log.Info("Shaper disabled, removing bandwidth limit")
+	return s.unlimitBandwidth()
+}
+
+func (s *wonderShaper) limitBandwidth() error {
+	iface := "tun0"
+	err := s.runCmd(iface, strconv.Itoa(limitKbps), strconv.Itoa(limitKbps))
+	return errors.Wrap(err, "could not limit bandwidth on "+iface)
+}
+
+func (s *wonderShaper) unlimitBandwidth() error {
+	iface := "tun0"
+	err := s.runCmd("clear", iface)
+	return errors.Wrap(err, "could not unlimit bandwidth on "+iface)
+}

--- a/core/shaper/shaper.go
+++ b/core/shaper/shaper.go
@@ -100,6 +100,9 @@ func healthcheck(cmd string) (path string, err error) {
 // Start applies current shaping configuration for the specified interface
 // and then continuously ensures it by listening to configuration updates
 func (s *wonderShaper) Start(interfaceName string) error {
+	if interfaceName == "" {
+		return errors.New("interface name is empty")
+	}
 	s.targetInterface = interfaceName
 	err := s.eventBus.SubscribeAsync(config.Topic(shared.ShaperEnabledFlag.Name), s.apply)
 	if err != nil {
@@ -119,13 +122,11 @@ func (s *wonderShaper) apply() error {
 }
 
 func (s *wonderShaper) limitBandwidth() error {
-	iface := "tun0"
-	err := s.runCmd(iface, strconv.Itoa(limitKbps), strconv.Itoa(limitKbps))
-	return errors.Wrap(err, "could not limit bandwidth on "+iface)
+	err := s.runCmd(s.targetInterface, strconv.Itoa(limitKbps), strconv.Itoa(limitKbps))
+	return errors.Wrap(err, "could not limit bandwidth on "+s.targetInterface)
 }
 
 func (s *wonderShaper) unlimitBandwidth() error {
-	iface := "tun0"
-	err := s.runCmd("clear", iface)
-	return errors.Wrap(err, "could not unlimit bandwidth on "+iface)
+	err := s.runCmd("clear", s.targetInterface)
+	return errors.Wrap(err, "could not unlimit bandwidth on "+s.targetInterface)
 }

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/core/shaper"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/nat"
 	"github.com/mysteriumnetwork/node/nat/traversal"
@@ -55,6 +56,7 @@ func NewManager(nodeOptions node.Options,
 	natEventGetter NATEventGetter,
 	portPool port.ServicePortSupplier,
 	publisher eventPublisher,
+	shaper shaper.Shaper,
 ) *Manager {
 	clientMap := openvpn_session.NewClientMap(sessionMap)
 
@@ -89,6 +91,7 @@ func NewManager(nodeOptions node.Options,
 		mapPort:                        mapPort,
 		natEventGetter:                 natEventGetter,
 		ports:                          portPool,
+		shaper:                         shaper,
 	}
 }
 

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -151,10 +151,9 @@ func (m *Manager) Serve(providerID identity.Identity) (err error) {
 		}
 	}()
 
-	m.shaper.TargetInterface(m.vpnServer.DeviceName())
-	err = m.shaper.Apply()
+	err = m.shaper.Start(m.vpnServer.DeviceName())
 	if err != nil {
-		log.Error("Could not apply traffic shaper: ", err)
+		log.Error("Could not start traffic shaper: ", err)
 	}
 
 	log.Info("OpenVPN server waiting")

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mysteriumnetwork/go-openvpn/openvpn"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/tls"
 	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/core/shaper"
 	"github.com/mysteriumnetwork/node/dns"
 	"github.com/mysteriumnetwork/node/firewall"
 	"github.com/mysteriumnetwork/node/identity"
@@ -72,6 +73,7 @@ type Manager struct {
 	natPinger      NATPinger
 	natEventGetter NATEventGetter
 	dnsServer      *dns.Server
+	shaper         shaper.Shaper
 
 	sessionConfigNegotiatorFactory SessionConfigNegotiatorFactory
 	consumerConfig                 openvpn_service.ConsumerConfig
@@ -148,6 +150,12 @@ func (m *Manager) Serve(providerID identity.Identity) (err error) {
 			log.Error("failed to start DNS server: ", err)
 		}
 	}()
+
+	m.shaper.TargetInterface(m.vpnServer.DeviceName())
+	err = m.shaper.Apply()
+	if err != nil {
+		log.Error("Could not apply traffic shaper: ", err)
+	}
 
 	log.Info("OpenVPN server waiting")
 	return m.vpnServer.Wait()

--- a/services/shared/options.go
+++ b/services/shared/options.go
@@ -28,6 +28,7 @@ import (
 // Options describes options shared among multiple services
 type Options struct {
 	AccessPolicies []string
+	ShaperEnabled  bool
 }
 
 var (
@@ -36,11 +37,19 @@ var (
 		Usage: "Comma separated list that determines the allowed identities on our service.",
 		Value: "",
 	}
+	// ShaperEnabledFlag reflects configuration setting of shaper being enabled
+	ShaperEnabledFlag = cli.BoolFlag{
+		Name:  "shaper.enabled",
+		Usage: "Limit service bandwidth",
+	}
 )
 
 // RegisterFlags registers shared service CLI flags
 func RegisterFlags(flags *[]cli.Flag) {
-	*flags = append(*flags, accessPoliciesFlag)
+	*flags = append(*flags,
+		accessPoliciesFlag,
+		ShaperEnabledFlag,
+	)
 }
 
 // Configure parses shared service CLI flags and registers values to the configuration
@@ -50,11 +59,13 @@ func Configure(ctx *cli.Context) {
 }
 
 func configureDefaults() {
-	config.Current.SetDefault("access-policy.list", "")
+	config.Current.SetDefault(accessPoliciesFlag.Name, "")
+	config.Current.SetDefault(ShaperEnabledFlag.Name, false)
 }
 
 func configureCLI(ctx *cli.Context) {
 	cliflags.SetString(config.Current, accessPoliciesFlag.Name, ctx)
+	cliflags.SetBool(config.Current, ShaperEnabledFlag.Name, ctx)
 }
 
 // ConfiguredOptions returns effective shared service options
@@ -68,5 +79,6 @@ func ConfiguredOptions() Options {
 	}
 	return Options{
 		AccessPolicies: policies,
+		ShaperEnabled:  config.Current.GetBool(ShaperEnabledFlag.Name),
 	}
 }


### PR DESCRIPTION
Fixes #1273 

* Based on https://github.com/magnific0/wondershaper ; it'll work on linux machines, specifically on raspbian based mystberry image.
* Enabled by config flag `shaper.enabled` (bool); off by default
* Limits to 5000Kbps
* Shaper starts when openvpn service is started (on the tunnel interface)
* It reacts to configuration updates live, thus API for setting user configuration can be re-used

Still some final testing needed on a physical raspberry (todo tomorrow)