### PR TITLE
CI tweaks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,7 +171,6 @@ remove-bucket:
   stage: post-release
   tags: [go]
   script: go run mage.go -v RemoveBucket
-  when: always
 
 docker-prune:
   stage: post-release


### PR DESCRIPTION
1. Remove bucket for node build artifacts only upon successful completion (was: always). This allows us to retry the pipeline from the failed step instead of the whole pipe;
2. Fix android SDK [tag] release to maven central by passing through required envs from gitlab to the release shell script.