### PR TITLE
Report conn status

### DIFF
--- a/bin/localnet/docker-compose.yml
+++ b/bin/localnet/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   broker:
-    image: nats
+    image: nats:1.0.4
     expose:
       - 4222
       - 8222
@@ -20,11 +20,13 @@ services:
       MYSQL_PASSWORD: myst_api
 
   mysterium-api:
-    image: mysteriumnetwork/mysterium-api:0.5.9
+    image: mysteriumnetwork/mysterium-api:0.5.22
+    ports:
+      - 8001:8001
     expose:
-    - 80
+    - 8001
     environment:
-      APP_PORT: 80
+      APP_PORT: 8001
       DB_HOST: db
       DB_NAME: myst_api
       DB_USER: myst_api

--- a/bin/localnet/publish-ports.yml
+++ b/bin/localnet/publish-ports.yml
@@ -8,7 +8,7 @@ services:
 
   mysterium-api:
     ports:
-    - 80:80
+    - 8001:8001
 
   ganache:
     ports:

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -75,6 +75,7 @@ import (
 	"github.com/mysteriumnetwork/node/services/openvpn/discovery/dto"
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/mysteriumnetwork/node/session/balance"
+	"github.com/mysteriumnetwork/node/session/connectivity"
 	sessionevent "github.com/mysteriumnetwork/node/session/event"
 	session_payment "github.com/mysteriumnetwork/node/session/payment"
 	payment_factory "github.com/mysteriumnetwork/node/session/payment/factory"
@@ -133,9 +134,10 @@ type Dependencies struct {
 	IPResolver       ip.Resolver
 	LocationResolver *location.Cache
 
-	StatisticsTracker  *statistics.SessionStatisticsTracker
-	StatisticsReporter *statistics.SessionStatisticsReporter
-	SessionStorage     *consumer_session.Storage
+	StatisticsTracker                *statistics.SessionStatisticsTracker
+	StatisticsReporter               *statistics.SessionStatisticsReporter
+	SessionStorage                   *consumer_session.Storage
+	SessionConnectivityStatusStorage connectivity.StatusStorage
 
 	EventBus eventbus.EventBus
 
@@ -430,6 +432,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 	)
 	di.SessionStorage = consumer_session.NewSessionStorage(di.Storage, di.StatisticsTracker)
 	di.PromiseStorage = promise.NewStorage(di.Storage)
+	di.SessionConnectivityStatusStorage = connectivity.NewStatusStorage()
 
 	di.ConnectionRegistry = connection.NewRegistry()
 	di.ConnectionManager = connection.NewManager(
@@ -437,6 +440,8 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 		pingpong.BackwardsCompatibleExchangeFactoryFunc(di.Keystore, nodeOptions, di.SignerFactory),
 		di.ConnectionRegistry.CreateConnection,
 		di.EventBus,
+		connectivity.NewStatusSender(),
+		di.IPResolver,
 	)
 
 	di.Transactor = transactor.NewTransactor(
@@ -471,6 +476,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 	tequilapi_endpoints.AddRoutesForTransactor(router, di.Transactor)
 	tequilapi_endpoints.AddRoutesForConfig(router)
 	tequilapi_endpoints.AddRoutesForFeedback(router, di.Reporter)
+	tequilapi_endpoints.AddRoutesForDialogsStatus(nodeOptions.BindAddress, router, di.SessionConnectivityStatusStorage)
 
 	identity_registry.AddIdentityRegistrationEndpoint(router, di.IdentityRegistry)
 

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -476,7 +476,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 	tequilapi_endpoints.AddRoutesForTransactor(router, di.Transactor)
 	tequilapi_endpoints.AddRoutesForConfig(router)
 	tequilapi_endpoints.AddRoutesForFeedback(router, di.Reporter)
-	tequilapi_endpoints.AddRoutesForDialogsStatus(nodeOptions.BindAddress, router, di.SessionConnectivityStatusStorage)
+	tequilapi_endpoints.AddRoutesForConnectivityStatus(nodeOptions.BindAddress, router, di.SessionConnectivityStatusStorage)
 
 	identity_registry.AddIdentityRegistrationEndpoint(router, di.IdentityRegistry)
 

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -40,6 +40,7 @@ import (
 	wireguard_connection "github.com/mysteriumnetwork/node/services/wireguard/connection"
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/mysteriumnetwork/node/session"
+	"github.com/mysteriumnetwork/node/session/connectivity"
 	"github.com/mysteriumnetwork/node/ui"
 	uinoop "github.com/mysteriumnetwork/node/ui/noop"
 
@@ -243,7 +244,14 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 			di.NATTracker,
 			serviceID,
 			di.EventBus)
-		return session.NewDialogHandler(sessionManagerFactory, configProvider.ProvideConfig, di.PromiseStorage, identity.FromAddress(proposal.ProviderID)), nil
+
+		return session.NewDialogHandler(
+			sessionManagerFactory,
+			configProvider.ProvideConfig,
+			di.PromiseStorage,
+			identity.FromAddress(proposal.ProviderID),
+			connectivity.NewStatusSubscriber(di.SessionConnectivityStatusStorage),
+		), nil
 	}
 	di.ServicesManager = service.NewManager(
 		di.ServiceRegistry,

--- a/communication/dialog.go
+++ b/communication/dialog.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package communication
+
+import (
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/market"
+)
+
+// Dialog represent established connection between 2 peers in network.
+// Enables bidirectional communication with another peer.
+type Dialog interface {
+	PeerID() identity.Identity
+	Sender
+	Receiver
+	Close() error
+}
+
+// DialogWaiter defines server which:
+//   - waits and serves incoming dialog requests
+//   - negotiates with Dialog initiator
+//   - finally creates Dialog, when it is accepted
+type DialogWaiter interface {
+	Start() (market.Contact, error)
+	Stop() error
+	ServeDialogs(DialogHandler) error
+}
+
+// DialogHandler defines how to handle incoming Dialog
+type DialogHandler interface {
+	Handle(Dialog) error
+}
+
+// DialogEstablisher interface defines client which:
+//   - initiates Dialog requests to network
+//   - creates Dialog, when it is negotiated
+type DialogEstablisher interface {
+	EstablishDialog(peerID identity.Identity, peerContact market.Contact) (Dialog, error)
+}

--- a/communication/nats/dialog/codec_secured.go
+++ b/communication/nats/dialog/codec_secured.go
@@ -50,12 +50,12 @@ type codecSecured struct {
 func (codec *codecSecured) Pack(payloadPtr interface{}) ([]byte, error) {
 	payloadData, err := codec.codecPacker.Pack(payloadPtr)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, errors.Wrap(err, "could not pack payload data")
 	}
 
 	signature, err := codec.signer.Sign(payloadData)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, errors.Wrap(err, "could not sign payload data")
 	}
 
 	return codec.codecPacker.Pack(&messageEnvelope{

--- a/communication/nats/dialog/codec_secured_test.go
+++ b/communication/nats/dialog/codec_secured_test.go
@@ -88,7 +88,7 @@ func TestCodecSigner_PackError(t *testing.T) {
 	)
 
 	data, err := codec.Pack("data")
-	assert.EqualError(t, err, "Signing failed")
+	assert.EqualError(t, err, "could not sign payload data: Signing failed")
 	assert.Equal(t, []byte{}, data)
 }
 

--- a/communication/nats/dialog/dialog_waiter.go
+++ b/communication/nats/dialog/dialog_waiter.go
@@ -119,8 +119,7 @@ func (waiter *dialogWaiter) ServeDialogs(dialogHandler communication.DialogHandl
 	}
 	codec := NewCodecSecured(communication.NewCodecJSON(), waiter.signer, identity.NewVerifierSigned())
 	receiver := nats.NewReceiver(waiter.address.GetConnection(), codec, waiter.address.GetTopic())
-
-	return receiver.Respond(&dialogCreateConsumer{createDialog})
+	return receiver.Respond(&dialogCreateConsumer{Callback: createDialog})
 }
 
 func (waiter *dialogWaiter) newCodecForPeer(peerID identity.Identity) *codecSecured {

--- a/communication/receiver.go
+++ b/communication/receiver.go
@@ -17,4 +17,11 @@
 
 package communication
 
-// TODO: remove this file when done.
+// Receiver represents interface for:
+//   - listening for asynchronous messages
+//   - listening and serving HTTP-like requests
+type Receiver interface {
+	Receive(consumer MessageConsumer) error
+	Respond(consumer RequestConsumer) error
+	Unsubscribe()
+}

--- a/communication/sender.go
+++ b/communication/sender.go
@@ -17,4 +17,10 @@
 
 package communication
 
-// TODO: remove this file when done.
+// Sender represents interface for:
+//   - sending asynchronous messages
+//   - sending and HTTP-like request and waiting for response
+type Sender interface {
+	Send(producer MessageProducer) error
+	Request(producer RequestProducer) (responsePtr interface{}, err error)
+}

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -154,7 +154,7 @@ func (manager *connectionManager) Connect(consumerID identity.Identity, proposal
 		return err
 	}
 
-	currentPublicIP := manager.getPublicIP()
+	originalPublicIP := manager.getPublicIP()
 	// Try to establish connection with peer.
 	err = manager.startConnection(connection, consumerID, proposal, params, sessionDTO, stateChannel, statisticsChannel)
 	if err != nil {
@@ -165,15 +165,15 @@ func (manager *connectionManager) Connect(consumerID identity.Identity, proposal
 		return err
 	}
 
-	manager.checkSessionIP(dialog, sessionDTO.ID, currentPublicIP)
+	manager.checkSessionIP(dialog, sessionDTO.ID, originalPublicIP)
 	return nil
 }
 
 // checkSessionIP checks if ip was changed after connection is established and notify peer.
-func (manager *connectionManager) checkSessionIP(dialog communication.Dialog, sessionID session.ID, currentPublicIP string) {
+func (manager *connectionManager) checkSessionIP(dialog communication.Dialog, sessionID session.ID, originalPublicIP string) {
 	newPublicIP := manager.getPublicIP()
-	if currentPublicIP == newPublicIP {
-		manager.sendSessionStatus(dialog, sessionID, connectivity.StatusSessionIpNotChanged, nil)
+	if originalPublicIP == newPublicIP {
+		manager.sendSessionStatus(dialog, sessionID, connectivity.StatusSessionIPNotChanged, nil)
 		return
 	}
 

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -169,7 +169,7 @@ func (manager *connectionManager) Connect(consumerID identity.Identity, proposal
 	return nil
 }
 
-// checkSessionIP checks if ip was changed after connection is established and notify peer.
+// checkSessionIP checks if IP has changed after connection was established and notify peer.
 func (manager *connectionManager) checkSessionIP(dialog communication.Dialog, sessionID session.ID, originalPublicIP string) {
 	newPublicIP := manager.getPublicIP()
 	if originalPublicIP == newPublicIP {

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -161,7 +161,6 @@ func (manager *connectionManager) Connect(consumerID identity.Identity, proposal
 		if err == context.Canceled {
 			return ErrConnectionCancelled
 		}
-		// TODO: Here we need to extract mode detailed error if possible.
 		manager.sendSessionStatus(dialog, sessionDTO.ID, connectivity.StatusConnectionFailed, err)
 		return err
 	}

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -439,6 +439,6 @@ type mockStatusSender struct {
 	sentMsg *connectivity.StatusMessage
 }
 
-func (s mockStatusSender) Send(dialog communication.Dialog, msg *connectivity.StatusMessage) {
+func (s mockStatusSender) Send(dialog communication.Sender, msg *connectivity.StatusMessage) {
 	s.sentMsg = msg
 }

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/services/openvpn/discovery/dto"
 	"github.com/mysteriumnetwork/node/session"
+	"github.com/mysteriumnetwork/node/session/connectivity"
 	"github.com/mysteriumnetwork/node/session/promise"
 	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/stretchr/testify/assert"
@@ -130,6 +131,8 @@ func (tc *testContext) SetupTest() {
 		},
 		tc.fakeConnectionFactory.CreateConnection,
 		tc.stubPublisher,
+		newMockStatusSender(),
+		ip.NewResolverMock("ip"),
 	)
 }
 
@@ -426,4 +429,16 @@ func (mpm *MockPaymentIssuer) Stop() {
 	defer mpm.Unlock()
 	mpm.stopCalled = true
 	close(mpm.stopChan)
+}
+
+func newMockStatusSender() *mockStatusSender {
+	return &mockStatusSender{}
+}
+
+type mockStatusSender struct {
+	sentMsg *connectivity.StatusMessage
+}
+
+func (s mockStatusSender) Send(dialog communication.Dialog, msg *connectivity.StatusMessage) {
+	s.sentMsg = msg
 }

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       --experiment-identity-check
       --localnet
       --broker-address=broker
-      --api.address=http://mysterium-api/v1
+      --api.address=http://mysterium-api:8001/v1
       --ether.client.rpc=ws://ganache:8545
       --transactor.registry-address=0x241F6e1d0bB17f45767DC60A6Bd3D21Cdb543a0c
       --transactor.accountant-id=0x676b9a084aC11CEeF680AF6FFbE99b24106F47e7
@@ -58,7 +58,7 @@ services:
       --ip-detector=http://ipify:3000/?format=json
       --experiment-identity-check
       --localnet
-      --api.address=http://mysterium-api/v1
+      --api.address=http://mysterium-api:8001/v1
       --ether.client.rpc=ws://ganache:8545
       --keystore.lightweight
       --firewall.killSwitch.always

--- a/e2e/traversal/docker-compose.yml
+++ b/e2e/traversal/docker-compose.yml
@@ -108,7 +108,7 @@ services:
         ipv4_address: 172.31.0.203
 
   mysterium-api:
-    image: mysteriumnetwork/mysterium-api:0.5.9
+    image: mysteriumnetwork/mysterium-api:0.5.22
     expose:
       - 80
     cap_add:

--- a/logconfig/log.go
+++ b/logconfig/log.go
@@ -64,18 +64,18 @@ func (l Logger) Infof(format string, params ...interface{}) {
 }
 
 // Warnf warn log fmt
-func (l Logger) Warnf(format string, params ...interface{}) error {
-	return seelog.Warnf(l.prefix+format, params...)
+func (l Logger) Warnf(format string, params ...interface{}) {
+	_ = seelog.Warnf(l.prefix+format, params...)
 }
 
 // Errorf error log fmt
-func (l Logger) Errorf(format string, params ...interface{}) error {
-	return seelog.Errorf(l.prefix+format, params...)
+func (l Logger) Errorf(format string, params ...interface{}) {
+	_ = seelog.Errorf(l.prefix+format, params...)
 }
 
 // Criticalf critical log fmt
-func (l Logger) Criticalf(format string, params ...interface{}) error {
-	return seelog.Criticalf(l.prefix+format, params...)
+func (l Logger) Criticalf(format string, params ...interface{}) {
+	_ = seelog.Criticalf(l.prefix+format, params...)
 }
 
 // Trace trace log

--- a/session/connectivity/log.go
+++ b/session/connectivity/log.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package communication
+package connectivity
 
-// TODO: remove this file when done.
+import "github.com/mysteriumnetwork/node/logconfig"
+
+var log = logconfig.NewLogger()

--- a/session/connectivity/status_message.go
+++ b/session/connectivity/status_message.go
@@ -36,8 +36,8 @@ const (
 	// StatusSessionPaymentsFailed indicates that session payments failed.
 	StatusSessionPaymentsFailed StatusCode = 2001
 
-	// StatusSessionIpNotChanged indicates that session is established but ip is not changed.
-	StatusSessionIpNotChanged StatusCode = 2002
+	// StatusSessionIPNotChanged indicates that session is established but ip is not changed.
+	StatusSessionIPNotChanged StatusCode = 2002
 
 	// StatusConnectionFailed indicates unknown session connection error.
 	StatusConnectionFailed StatusCode = 2003

--- a/session/connectivity/status_message.go
+++ b/session/connectivity/status_message.go
@@ -40,7 +40,6 @@ const (
 	StatusSessionIpNotChanged StatusCode = 2002
 
 	// StatusConnectionFailed indicates unknown session connection error.
-	// TODO: Split this error to more detailed.
 	StatusConnectionFailed StatusCode = 2003
 )
 

--- a/session/connectivity/status_message.go
+++ b/session/connectivity/status_message.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connectivity
+
+import (
+	"github.com/mysteriumnetwork/node/communication"
+)
+
+const endpointConnectivityStatus = communication.MessageEndpoint("session-connectivity-status")
+
+// StatusCode is a connectivity status.
+type StatusCode uint32
+
+const (
+	// StatusConnectionOk indicates that session, payments, ip change are all working.
+	StatusConnectionOk StatusCode = 1000
+
+	// StatusSessionEstablishmentFailed indicates that session is failed to establish.
+	StatusSessionEstablishmentFailed StatusCode = 2000
+
+	// StatusSessionPaymentsFailed indicates that session payments failed.
+	StatusSessionPaymentsFailed StatusCode = 2001
+
+	// StatusSessionIpNotChanged indicates that session is established but ip is not changed.
+	StatusSessionIpNotChanged StatusCode = 2002
+
+	// StatusConnectionFailed indicates unknown session connection error.
+	// TODO: Split this error to more detailed.
+	StatusConnectionFailed StatusCode = 2003
+)
+
+// StatusMessage is a contract for message broker.
+type StatusMessage struct {
+	SessionID  string     `json:"sessionID"`
+	StatusCode StatusCode `json:"statusCode"`
+	Message    string     `json:"message"`
+}
+
+// Producer boilerplate.
+type statusProducer struct {
+	message *StatusMessage
+}
+
+func (p *statusProducer) GetMessageEndpoint() communication.MessageEndpoint {
+	return endpointConnectivityStatus
+}
+
+func (p *statusProducer) Produce() (messagePtr interface{}) {
+	return p.message
+}
+
+// Consumer boilerplate.
+type statusConsumer struct {
+	callback func(msg *StatusMessage)
+}
+
+func (c *statusConsumer) GetMessageEndpoint() communication.MessageEndpoint {
+	return endpointConnectivityStatus
+}
+
+func (c *statusConsumer) NewMessage() (messagePtr interface{}) {
+	return &StatusMessage{}
+}
+
+func (c *statusConsumer) Consume(messagePtr interface{}) error {
+	msg := messagePtr.(*StatusMessage)
+	c.callback(msg)
+	return nil
+}

--- a/session/connectivity/status_sender.go
+++ b/session/connectivity/status_sender.go
@@ -23,7 +23,7 @@ import (
 
 // StatusSender is responsible for sending session connectivity status to other peer.
 type StatusSender interface {
-	Send(dialog communication.Dialog, msg *StatusMessage)
+	Send(dialog communication.Sender, msg *StatusMessage)
 }
 
 // NewStatusSender creates StatusSender instance.
@@ -34,7 +34,7 @@ func NewStatusSender() StatusSender {
 type statusSender struct{}
 
 // Send sends status message to other peer via broker.
-func (s *statusSender) Send(dialog communication.Dialog, msg *StatusMessage) {
+func (s *statusSender) Send(dialog communication.Sender, msg *StatusMessage) {
 	producer := &statusProducer{
 		message: msg,
 	}

--- a/session/connectivity/status_sender.go
+++ b/session/connectivity/status_sender.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connectivity
+
+import (
+	"github.com/mysteriumnetwork/node/communication"
+)
+
+// StatusSender is responsible for sending session connectivity status to other peer.
+type StatusSender interface {
+	Send(dialog communication.Dialog, msg *StatusMessage)
+}
+
+// NewStatusSender creates StatusSender instance.
+func NewStatusSender() StatusSender {
+	return &statusSender{}
+}
+
+type statusSender struct{}
+
+// Send sends status message to other peer via broker.
+func (s *statusSender) Send(dialog communication.Dialog, msg *StatusMessage) {
+	producer := &statusProducer{
+		message: msg,
+	}
+	if err := dialog.Send(producer); err != nil {
+		log.Errorf("could not send connectivity status: %v", err)
+	}
+}

--- a/session/connectivity/status_storage.go
+++ b/session/connectivity/status_storage.go
@@ -19,11 +19,12 @@ package connectivity
 
 import (
 	"sync"
+	"time"
 
 	"github.com/mysteriumnetwork/node/identity"
 )
 
-//StatusStorage is status storage interface.
+// StatusStorage is responsible for status storage operations.
 type StatusStorage interface {
 	GetAllStatusEntries() []*StatusEntry
 	AddStatusEntry(msg *StatusEntry)
@@ -31,10 +32,11 @@ type StatusStorage interface {
 
 // StatusEntry describes status entry.
 type StatusEntry struct {
-	PeerID     identity.Identity
-	SessionID  string
-	StatusCode StatusCode
-	Message    string
+	PeerID       identity.Identity
+	SessionID    string
+	StatusCode   StatusCode
+	Message      string
+	CreatedAtUTC time.Time
 }
 
 // NewStatusStorage returns new StatusStorage instance.
@@ -50,6 +52,7 @@ type statusStorage struct {
 func (s *statusStorage) GetAllStatusEntries() []*StatusEntry {
 	s.entriesMux.RLock()
 	defer s.entriesMux.RUnlock()
+
 	return s.entries
 }
 
@@ -57,6 +60,5 @@ func (s *statusStorage) AddStatusEntry(msg *StatusEntry) {
 	s.entriesMux.Lock()
 	defer s.entriesMux.Unlock()
 
-	// TODO: Maintain only last x entries to possibly to big memory usage.
 	s.entries = append(s.entries, msg)
 }

--- a/session/connectivity/status_storage.go
+++ b/session/connectivity/status_storage.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connectivity
+
+import (
+	"sync"
+
+	"github.com/mysteriumnetwork/node/identity"
+)
+
+//StatusStorage is status storage interface.
+type StatusStorage interface {
+	GetAllStatusEntries() []*StatusEntry
+	AddStatusEntry(msg *StatusEntry)
+}
+
+// StatusEntry describes status entry.
+type StatusEntry struct {
+	PeerID     identity.Identity
+	SessionID  string
+	StatusCode StatusCode
+	Message    string
+}
+
+// NewStatusStorage returns new StatusStorage instance.
+func NewStatusStorage() StatusStorage {
+	return &statusStorage{}
+}
+
+type statusStorage struct {
+	entries    []*StatusEntry
+	entriesMux sync.RWMutex
+}
+
+func (s *statusStorage) GetAllStatusEntries() []*StatusEntry {
+	s.entriesMux.RLock()
+	defer s.entriesMux.RUnlock()
+	return s.entries
+}
+
+func (s *statusStorage) AddStatusEntry(msg *StatusEntry) {
+	s.entriesMux.Lock()
+	defer s.entriesMux.Unlock()
+
+	// TODO: Maintain only last x entries to possibly to big memory usage.
+	s.entries = append(s.entries, msg)
+}

--- a/session/connectivity/status_storage.go
+++ b/session/connectivity/status_storage.go
@@ -26,8 +26,8 @@ import (
 
 // StatusStorage is responsible for status storage operations.
 type StatusStorage interface {
-	GetAllStatusEntries() []*StatusEntry
-	AddStatusEntry(msg *StatusEntry)
+	GetAllStatusEntries() []StatusEntry
+	AddStatusEntry(msg StatusEntry)
 }
 
 // StatusEntry describes status entry.
@@ -45,18 +45,22 @@ func NewStatusStorage() StatusStorage {
 }
 
 type statusStorage struct {
-	entries    []*StatusEntry
+	entries    []StatusEntry
 	entriesMux sync.RWMutex
 }
 
-func (s *statusStorage) GetAllStatusEntries() []*StatusEntry {
+func (s *statusStorage) GetAllStatusEntries() []StatusEntry {
 	s.entriesMux.RLock()
 	defer s.entriesMux.RUnlock()
 
-	return s.entries
+	var res []StatusEntry
+	for _, entry := range s.entries {
+		res = append(res, entry)
+	}
+	return res
 }
 
-func (s *statusStorage) AddStatusEntry(msg *StatusEntry) {
+func (s *statusStorage) AddStatusEntry(msg StatusEntry) {
 	s.entriesMux.Lock()
 	defer s.entriesMux.Unlock()
 

--- a/session/connectivity/status_storage_test.go
+++ b/session/connectivity/status_storage_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package connectivity
 
 import (

--- a/session/connectivity/status_storage_test.go
+++ b/session/connectivity/status_storage_test.go
@@ -1,0 +1,52 @@
+package connectivity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusStorage_AddStatusEntry(t *testing.T) {
+	storage := NewStatusStorage()
+	e1 := StatusEntry{
+		PeerID:       identity.Identity{},
+		SessionID:    "1",
+		StatusCode:   StatusConnectionOk,
+		Message:      "Ok",
+		CreatedAtUTC: time.Time{},
+	}
+	e2 := StatusEntry{
+		PeerID:       identity.Identity{},
+		SessionID:    "",
+		StatusCode:   StatusConnectionFailed,
+		Message:      "Failed",
+		CreatedAtUTC: time.Time{},
+	}
+
+	storage.AddStatusEntry(e1)
+	storage.AddStatusEntry(e2)
+
+	entries := storage.GetAllStatusEntries()
+	assert.Len(t, entries, 2)
+	assert.Equal(t, e1, entries[0])
+	assert.Equal(t, e2, entries[1])
+}
+
+func TestStatusStorage_GetAllStatusEntries_Returns_Immutable_Data(t *testing.T) {
+	storage := NewStatusStorage()
+	e1 := StatusEntry{
+		PeerID:       identity.Identity{},
+		SessionID:    "1",
+		StatusCode:   StatusConnectionOk,
+		Message:      "Ok",
+		CreatedAtUTC: time.Time{},
+	}
+	storage.AddStatusEntry(e1)
+
+	entries := storage.GetAllStatusEntries()
+
+	entries[0].SessionID = "2"
+	assert.NotEqual(t, entries[0].SessionID, storage.(*statusStorage).entries[0].SessionID)
+}

--- a/session/connectivity/status_subscriber.go
+++ b/session/connectivity/status_subscriber.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connectivity
+
+import (
+	"github.com/mysteriumnetwork/node/communication"
+)
+
+// StatusSubscriber is responsible for handling status events for the peer.
+type StatusSubscriber interface {
+	Subscribe(dialog communication.Dialog)
+}
+
+// NewStatusSubscriber returns new StatusSubscriber instance.
+func NewStatusSubscriber(statusStorage StatusStorage) StatusSubscriber {
+	return &statusSubscriber{
+		statusStorage: statusStorage,
+	}
+}
+
+type statusSubscriber struct {
+	statusStorage StatusStorage
+}
+
+func (s *statusSubscriber) Subscribe(dialog communication.Dialog) {
+	consumer := &statusConsumer{
+		callback: func(msg *StatusMessage) {
+			log.Infof("session status dialog identity peerID: %s", dialog.PeerID())
+			log.Infof("session connectivity status: %v", msg)
+			entry := &StatusEntry{
+				PeerID:     dialog.PeerID(),
+				SessionID:  msg.SessionID,
+				StatusCode: msg.StatusCode,
+				Message:    msg.Message,
+			}
+			s.statusStorage.AddStatusEntry(entry)
+		},
+	}
+	if err := dialog.Receive(consumer); err != nil {
+		log.Errorf("could not receive connectivity status: %v", err)
+		return
+	}
+}

--- a/session/connectivity/status_subscriber.go
+++ b/session/connectivity/status_subscriber.go
@@ -42,7 +42,7 @@ type statusSubscriber struct {
 func (s *statusSubscriber) Subscribe(dialog communication.Dialog) {
 	consumer := &statusConsumer{
 		callback: func(msg *StatusMessage) {
-			entry := &StatusEntry{
+			entry := StatusEntry{
 				PeerID:       dialog.PeerID(),
 				SessionID:    msg.SessionID,
 				StatusCode:   msg.StatusCode,

--- a/session/connectivity/status_subscriber.go
+++ b/session/connectivity/status_subscriber.go
@@ -18,6 +18,8 @@
 package connectivity
 
 import (
+	"time"
+
 	"github.com/mysteriumnetwork/node/communication"
 )
 
@@ -40,13 +42,12 @@ type statusSubscriber struct {
 func (s *statusSubscriber) Subscribe(dialog communication.Dialog) {
 	consumer := &statusConsumer{
 		callback: func(msg *StatusMessage) {
-			log.Infof("session status dialog identity peerID: %s", dialog.PeerID())
-			log.Infof("session connectivity status: %v", msg)
 			entry := &StatusEntry{
-				PeerID:     dialog.PeerID(),
-				SessionID:  msg.SessionID,
-				StatusCode: msg.StatusCode,
-				Message:    msg.Message,
+				PeerID:       dialog.PeerID(),
+				SessionID:    msg.SessionID,
+				StatusCode:   msg.StatusCode,
+				Message:      msg.Message,
+				CreatedAtUTC: time.Now().UTC(),
 			}
 			s.statusStorage.AddStatusEntry(entry)
 		},

--- a/session/connectivity/status_subscriber_test.go
+++ b/session/connectivity/status_subscriber_test.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connectivity
+
+import (
+	"testing"
+
+	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusSubscriber_AddsNewEntry(t *testing.T) {
+	storage := &mockStatusStorage{}
+	subscriber := NewStatusSubscriber(storage)
+	dialog := &mockDialog{
+		peerAddress: "p1",
+		msg: &StatusMessage{
+			SessionID:  "s1",
+			StatusCode: StatusConnectionOk,
+			Message:    "OK",
+		},
+	}
+
+	subscriber.Subscribe(dialog)
+
+	assert.Equal(t, dialog.peerAddress, storage.addedEntry.PeerID.Address)
+	assert.Equal(t, dialog.msg.SessionID, storage.addedEntry.SessionID)
+	assert.Equal(t, dialog.msg.StatusCode, storage.addedEntry.StatusCode)
+	assert.Equal(t, dialog.msg.Message, storage.addedEntry.Message)
+}
+
+type mockDialog struct {
+	peerAddress string
+	msg         *StatusMessage
+}
+
+func (m *mockDialog) PeerID() identity.Identity {
+	return identity.Identity{Address: m.peerAddress}
+}
+
+func (m *mockDialog) Send(producer communication.MessageProducer) error {
+	panic("implement me")
+}
+
+func (m *mockDialog) Request(producer communication.RequestProducer) (responsePtr interface{}, err error) {
+	panic("implement me")
+}
+
+func (m *mockDialog) Receive(consumer communication.MessageConsumer) error {
+	return consumer.Consume(m.msg)
+}
+
+func (m *mockDialog) Respond(consumer communication.RequestConsumer) error {
+	panic("implement me")
+}
+
+func (m *mockDialog) Unsubscribe() {
+	panic("implement me")
+}
+
+func (m *mockDialog) Close() error {
+	panic("implement me")
+}
+
+type mockStatusStorage struct {
+	addedEntry StatusEntry
+}
+
+func (m *mockStatusStorage) GetAllStatusEntries() []StatusEntry {
+	panic("implement me")
+}
+
+func (m *mockStatusStorage) AddStatusEntry(msg StatusEntry) {
+	m.addedEntry = msg
+}

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -388,7 +388,7 @@ func validateServiceRequest(sr serviceRequest) *validation.FieldErrorMap {
 	return errors
 }
 
-// ServiceManager represents service manager that will be used for manipulation node services.
+// ServiceManager represents service manager that is used for manipulation node services.
 type ServiceManager interface {
 	Start(providerID identity.Identity, serviceType string, accessPolicies *[]market.AccessPolicy, options service.Options) (service.ID, error)
 	Stop(id service.ID) error

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -388,7 +388,7 @@ func validateServiceRequest(sr serviceRequest) *validation.FieldErrorMap {
 	return errors
 }
 
-// ServiceManager represents service manager that is used for manipulation node services.
+// ServiceManager represents service manager that is used for services management.
 type ServiceManager interface {
 	Start(providerID identity.Identity, serviceType string, accessPolicies *[]market.AccessPolicy, options service.Options) (service.ID, error)
 	Stop(id service.ID) error

--- a/tequilapi/endpoints/session_connectivity.go
+++ b/tequilapi/endpoints/session_connectivity.go
@@ -72,8 +72,8 @@ func (e *sessionConnectivityEndpoint) List(resp http.ResponseWriter, req *http.R
 	utils.WriteAsJSON(r, resp)
 }
 
-// AddRoutesForDialogsStatus attaches dialogs statuses to router.
-func AddRoutesForDialogsStatus(bindAddress string, router *httprouter.Router, statusStorage connectivity.StatusStorage) {
+// AddRoutesForConnectivityStatus attaches connectivity statuses endpoints to router.
+func AddRoutesForConnectivityStatus(bindAddress string, router *httprouter.Router, statusStorage connectivity.StatusStorage) {
 	e := &sessionConnectivityEndpoint{
 		http:          requests.NewHTTPClient(bindAddress, 20*time.Second),
 		statusStorage: statusStorage,

--- a/tequilapi/endpoints/session_connectivity.go
+++ b/tequilapi/endpoints/session_connectivity.go
@@ -54,10 +54,6 @@ type sessionConnectivityEndpoint struct {
 //     description: List of connectivity statuses
 //     schema:
 //       "$ref": "#/definitions/ConnectivityStatus"
-//   500:
-//     description: Internal server error
-//     schema:
-//       "$ref": "#/definitions/ErrorMessageDTO"
 func (e *sessionConnectivityEndpoint) List(resp http.ResponseWriter, req *http.Request, params httprouter.Params) {
 	r := sessionConnectivityStatusCollection{
 		Entries: []*sessionConnectivityStatus{},

--- a/tequilapi/endpoints/session_connectivity.go
+++ b/tequilapi/endpoints/session_connectivity.go
@@ -33,10 +33,11 @@ type sessionConnectivityStatusCollection struct {
 }
 
 type sessionConnectivityStatus struct {
-	PeerAddress string `json:"peer_address"`
-	SessionID   string `json:"session_id"`
-	Code        uint32 `json:"code"`
-	Message     string `json:"message"`
+	PeerAddress  string    `json:"peer_address"`
+	SessionID    string    `json:"session_id"`
+	Code         uint32    `json:"code"`
+	Message      string    `json:"message"`
+	CreatedAtUTC time.Time `json:"created_at_utc"`
 }
 
 type sessionConnectivityEndpoint struct {
@@ -64,10 +65,11 @@ func (e *sessionConnectivityEndpoint) List(resp http.ResponseWriter, req *http.R
 
 	for _, entry := range e.statusStorage.GetAllStatusEntries() {
 		r.Entries = append(r.Entries, &sessionConnectivityStatus{
-			PeerAddress: entry.PeerID.Address,
-			Code:        uint32(entry.StatusCode),
-			Message:     entry.Message,
-			SessionID:   entry.SessionID,
+			PeerAddress:  entry.PeerID.Address,
+			SessionID:    entry.SessionID,
+			Code:         uint32(entry.StatusCode),
+			Message:      entry.Message,
+			CreatedAtUTC: entry.CreatedAtUTC,
 		})
 	}
 

--- a/tequilapi/endpoints/session_connectivity.go
+++ b/tequilapi/endpoints/session_connectivity.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package endpoints
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/mysteriumnetwork/node/requests"
+	"github.com/mysteriumnetwork/node/session/connectivity"
+	"github.com/mysteriumnetwork/node/tequilapi/utils"
+)
+
+// swagger:model ConnectivityStatus
+type sessionConnectivityStatusCollection struct {
+	Entries []*sessionConnectivityStatus `json:"entries"`
+}
+
+type sessionConnectivityStatus struct {
+	PeerAddress string `json:"peer_address"`
+	SessionID   string `json:"session_id"`
+	Code        uint32 `json:"code"`
+	Message     string `json:"message"`
+}
+
+type sessionConnectivityEndpoint struct {
+	http          requests.HTTPTransport
+	statusStorage connectivity.StatusStorage
+}
+
+// swagger:operation GET /sessions-connectivity-status ConnectivityStatus
+// ---
+// summary: Returns session connectivity status
+// description: Returns list of session connectivity status
+// responses:
+//   200:
+//     description: List of connectivity statuses
+//     schema:
+//       "$ref": "#/definitions/ConnectivityStatus"
+//   500:
+//     description: Internal server error
+//     schema:
+//       "$ref": "#/definitions/ErrorMessageDTO"
+func (e *sessionConnectivityEndpoint) List(resp http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	r := sessionConnectivityStatusCollection{
+		Entries: []*sessionConnectivityStatus{},
+	}
+
+	for _, entry := range e.statusStorage.GetAllStatusEntries() {
+		r.Entries = append(r.Entries, &sessionConnectivityStatus{
+			PeerAddress: entry.PeerID.Address,
+			Code:        uint32(entry.StatusCode),
+			Message:     entry.Message,
+			SessionID:   entry.SessionID,
+		})
+	}
+
+	utils.WriteAsJSON(r, resp)
+}
+
+// AddRoutesForDialogsStatus attaches dialogs statuses to router.
+func AddRoutesForDialogsStatus(bindAddress string, router *httprouter.Router, statusStorage connectivity.StatusStorage) {
+	e := &sessionConnectivityEndpoint{
+		http:          requests.NewHTTPClient(bindAddress, 20*time.Second),
+		statusStorage: statusStorage,
+	}
+	router.GET("/sessions-connectivity-status", e.List)
+}


### PR DESCRIPTION
Closes https://github.com/mysteriumnetwork/node/issues/1297

- This PR adds ability to send session connectivity status via established dialog (message broker).
- When peer receives status it is inserted to in memory storage so it can be fetched via tequila API.