### PR TITLE
remove the db mount from e2e

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - 1194
       - 4050
     volumes:
-      - ../../e2e/myst-provider:/var/lib/mysterium-node
+      - ../../e2e/myst-provider/keystore:/var/lib/mysterium-node/keystore
     command: >
       --ip-detector=http://ipify:3000/?format=json
       --location.type=manual

--- a/e2e/traversal/docker-compose.yml
+++ b/e2e/traversal/docker-compose.yml
@@ -228,7 +228,7 @@ services:
       - 1194
       - 4050
     volumes:
-      - ../../e2e/myst-provider:/var/lib/mysterium-node
+      - ../../e2e/myst-provider/keystore:/var/lib/mysterium-node/keystore
     command: >
       --ip-detector=http://ipify:3000/?format=json
       --location.type=manual


### PR DESCRIPTION
this should fix the issue where if a job is cancelled, we'll have a corrupted state in the runner