### PR TITLE
Add go 1.13.1 for ios and android builds

### DIFF
--- a/bin/package_android
+++ b/bin/package_android
@@ -28,7 +28,8 @@ docker run --rm \
     -e FLAG_BUILDMODE=default \
     -e TARGETS=android/. \
     -e EXT_GOPATH=/ext-go/1 \
-    mysteriumnetwork/xgo:1.11 github.com/mysteriumnetwork/node/mobile/mysterium
+    -e GO111MODULE=off \
+    mysteriumnetwork/xgo:1.13.1 github.com/mysteriumnetwork/node/mobile/mysterium
 
 print_success "Android package '$PACKAGE_FILE' complete!"
 exit 0

--- a/bin/package_ios
+++ b/bin/package_ios
@@ -33,7 +33,8 @@ docker run --rm \
     -e FLAG_BUILDMODE=default \
     -e TARGETS=ios/. \
     -e EXT_GOPATH=/ext-go/1 \
-    mysteriumnetwork/xgo:1.11 github.com/mysteriumnetwork/node/mobile/mysterium
+    -e GO111MODULE=off \
+    mysteriumnetwork/xgo:1.13.1 github.com/mysteriumnetwork/node/mobile/mysterium
 
 me=`whoami`
 sudo chown -R $me ${DIR_FRAMEWORK}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
-	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dsnet/compress v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,7 +55,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -244,7 +243,6 @@ github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karalabe/hid v1.0.0 h1:+/CIMNXhSU/zIJgnIvBD2nKHxS/bnRHhhs9xBryLpPo=
 github.com/karalabe/hid v1.0.0/go.mod h1:Vr51f8rUOLYrfrWDFlV12GGQgM5AT8sVh+2fY4MPeu8=
-github.com/karalabe/xgo v0.0.0-20190301120235-2d6d1848fb02/go.mod h1:iYGcTYIPUvEWhFo6aKUuLchs+AV4ssYdyuBbQJZGcBk=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e h1:RgQk53JHp/Cjunrr1WlsXSZpqXn+uREuHvUVcK82CV8=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -264,7 +262,6 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/magefile/mage v1.6.2/go.mod h1:IUDi13rsHje59lecXokTfGX0QIzO45uVPlXnJYsXepA=
 github.com/magefile/mage v1.8.0 h1:mzL+xIopvPURVBwHG9A50JcjBO+xV3b5iZ7khFRI+5E=
 github.com/magefile/mage v1.8.0/go.mod h1:IUDi13rsHje59lecXokTfGX0QIzO45uVPlXnJYsXepA=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -313,8 +310,6 @@ github.com/mysteriumnetwork/go-ci v0.0.0-20190912064927-c54e2b0b3b5c h1:Tt24qNve
 github.com/mysteriumnetwork/go-ci v0.0.0-20190912064927-c54e2b0b3b5c/go.mod h1:GlJmsQDFyRmV9psEs/Mt/humLALu8xmZ7blXQ6Rc9Rs=
 github.com/mysteriumnetwork/go-dvpn-web v0.0.0-20191007132044-c746550858a5 h1:WSBdhsGx3uxvQ8RndEKlKJby7z0H+N/ldoPvK3xMZHc=
 github.com/mysteriumnetwork/go-dvpn-web v0.0.0-20191007132044-c746550858a5/go.mod h1:FEqNvtMX+3ZRAk6EVBS5xSdC2Bkm4CmHb4umlysr1KM=
-github.com/mysteriumnetwork/go-openvpn v0.0.17 h1:qkiOr/7r0BOx0LbHbUfmSfeTdlC910MBHGMBy3uY3Wo=
-github.com/mysteriumnetwork/go-openvpn v0.0.17/go.mod h1:fhyWcWM0buAbJYo84PZODfy/6HBnt+NZkdcIZcr87Ow=
 github.com/mysteriumnetwork/go-openvpn v0.0.18 h1:ZZp5R1n8bBjmk4z5BL3VYerF7yTbkJloFAlXASJfNBM=
 github.com/mysteriumnetwork/go-openvpn v0.0.18/go.mod h1:fhyWcWM0buAbJYo84PZODfy/6HBnt+NZkdcIZcr87Ow=
 github.com/mysteriumnetwork/metrics v0.0.0-20191002053948-084a00d6c6b2 h1:+MzoNo1V8raIWae/+6ivIOubglAqvAc9gTwICDf+ONk=


### PR DESCRIPTION
This PR adds updated [xgo](https://github.com/mysteriumnetwork/xgo/pull/13) with go.1.13.1 support so iOS and Android.