### PR TITLE
Send consumer connection metrics

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -499,7 +499,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 	tequilapi_endpoints.AddRoutesForTransactor(router, di.Transactor)
 	tequilapi_endpoints.AddRoutesForConfig(router)
 	tequilapi_endpoints.AddRoutesForFeedback(router, di.Reporter)
-	tequilapi_endpoints.AddRoutesForConnectivityStatus(nodeOptions.BindAddress, router, di.SessionConnectivityStatusStorage)
+	tequilapi_endpoints.AddRoutesForConnectivityStatus(router, di.SessionConnectivityStatusStorage)
 
 	identity_registry.AddIdentityRegistrationEndpoint(router, di.IdentityRegistry)
 

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -449,6 +449,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, listen
 		di.EventBus,
 		connectivity.NewStatusSender(),
 		di.IPResolver,
+		connection.DefaultIPCheckParams(),
 	)
 
 	// TODO: switch this to channel implementation from params after #1325 is merged

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -404,7 +404,7 @@ func (di *Dependencies) subscribeEventConsumers() error {
 	}
 
 	// Quality metrics
-	err = di.EventBus.SubscribeAsync(connection.StateEventTopic, di.QualityMetricsSender.SendSessionEvent)
+	err = di.EventBus.SubscribeAsync(connection.StateEventTopic, di.QualityMetricsSender.SendConnStateEvent)
 	if err != nil {
 		return err
 	}

--- a/consumer/bandwidth/tracker.go
+++ b/consumer/bandwidth/tracker.go
@@ -60,10 +60,10 @@ func (t *Tracker) Get() CurrentSpeed {
 }
 
 // ConsumeStatisticsEvent handles the connection statistics changes
-func (t *Tracker) ConsumeStatisticsEvent(stats consumer.SessionStatistics) {
+func (t *Tracker) ConsumeStatisticsEvent(e connection.SessionStatsEvent) {
 	t.lock.Lock()
 	defer func() {
-		t.previous = stats
+		t.previous = e.Stats
 		t.lock.Unlock()
 	}()
 
@@ -76,8 +76,8 @@ func (t *Tracker) ConsumeStatisticsEvent(stats consumer.SessionStatistics) {
 	secondsSince := currentTime.Sub(t.previousTime).Seconds()
 	t.previousTime = currentTime
 
-	byteDownDiff := stats.BytesReceived - t.previous.BytesReceived
-	byteUpDiff := stats.BytesSent - t.previous.BytesSent
+	byteDownDiff := e.Stats.BytesReceived - t.previous.BytesReceived
+	byteUpDiff := e.Stats.BytesSent - t.previous.BytesSent
 
 	t.currentSpeed = CurrentSpeed{
 		Up:   Throughput{BitsPerSecond: float64(byteUpDiff) / secondsSince * bitsInByte},

--- a/consumer/bandwidth/tracker_test.go
+++ b/consumer/bandwidth/tracker_test.go
@@ -114,9 +114,11 @@ func Test_ConsumeStatisticsEvent_CalculatesCorrectly(t *testing.T) {
 		previousTime: startTime,
 	}
 
-	tracker.ConsumeStatisticsEvent(consumer.SessionStatistics{
-		BytesReceived: bytesTransfered,
-		BytesSent:     bytesTransfered,
+	tracker.ConsumeStatisticsEvent(connection.SessionStatsEvent{
+		Stats:       consumer.SessionStatistics{
+			BytesReceived: bytesTransfered,
+			BytesSent:     bytesTransfered,
+		},
 	})
 
 	assert.NotEqual(t, tracker.previousTime, startTime)
@@ -128,13 +130,15 @@ func Test_ConsumeStatisticsEvent_CalculatesCorrectly(t *testing.T) {
 
 func Test_ConsumeStatisticsEvent_SkipsOnZero(t *testing.T) {
 	tracker := Tracker{}
-	input := consumer.SessionStatistics{
-		BytesReceived: 1,
-		BytesSent:     2,
+	e := connection.SessionStatsEvent{
+		Stats:       consumer.SessionStatistics{
+			BytesReceived: 1,
+			BytesSent:     2,
+		},
 	}
-	tracker.ConsumeStatisticsEvent(input)
+	tracker.ConsumeStatisticsEvent(e)
 	assert.False(t, tracker.previousTime.IsZero())
-	assert.Equal(t, input.BytesReceived, tracker.previous.BytesReceived)
-	assert.Equal(t, input.BytesSent, tracker.previous.BytesSent)
+	assert.Equal(t, e.Stats.BytesReceived, tracker.previous.BytesReceived)
+	assert.Equal(t, e.Stats.BytesSent, tracker.previous.BytesSent)
 	assert.Zero(t, tracker.Get().Down.BitsPerSecond)
 }

--- a/consumer/bandwidth/tracker_test.go
+++ b/consumer/bandwidth/tracker_test.go
@@ -115,7 +115,7 @@ func Test_ConsumeStatisticsEvent_CalculatesCorrectly(t *testing.T) {
 	}
 
 	tracker.ConsumeStatisticsEvent(connection.SessionStatsEvent{
-		Stats:       consumer.SessionStatistics{
+		Stats: consumer.SessionStatistics{
 			BytesReceived: bytesTransfered,
 			BytesSent:     bytesTransfered,
 		},
@@ -131,7 +131,7 @@ func Test_ConsumeStatisticsEvent_CalculatesCorrectly(t *testing.T) {
 func Test_ConsumeStatisticsEvent_SkipsOnZero(t *testing.T) {
 	tracker := Tracker{}
 	e := connection.SessionStatsEvent{
-		Stats:       consumer.SessionStatistics{
+		Stats: consumer.SessionStatistics{
 			BytesReceived: 1,
 			BytesSent:     2,
 		},

--- a/consumer/statistics/tracker.go
+++ b/consumer/statistics/tracker.go
@@ -71,9 +71,9 @@ func (sst *SessionStatisticsTracker) markSessionEnd() {
 }
 
 // ConsumeStatisticsEvent handles the connection statistics changes
-func (sst *SessionStatisticsTracker) ConsumeStatisticsEvent(stats consumer.SessionStatistics) {
-	sst.sessionStats = consumer.AddUpStatistics(sst.sessionStats, sst.lastStats.DiffWithNew(stats))
-	sst.lastStats = stats
+func (sst *SessionStatisticsTracker) ConsumeStatisticsEvent(e connection.SessionStatsEvent) {
+	sst.sessionStats = consumer.AddUpStatistics(sst.sessionStats, sst.lastStats.DiffWithNew(e.Stats))
+	sst.lastStats = e.Stats
 }
 
 // ConsumeSessionEvent handles the session state changes

--- a/consumer/statistics/tracker_test.go
+++ b/consumer/statistics/tracker_test.go
@@ -30,7 +30,7 @@ import (
 func TestStatsSavingWorks(t *testing.T) {
 	statisticsTracker := NewSessionStatisticsTracker(time.Now)
 	e := connection.SessionStatsEvent{
-		Stats:       consumer.SessionStatistics{BytesSent: 1, BytesReceived: 2},
+		Stats: consumer.SessionStatistics{BytesSent: 1, BytesReceived: 2},
 	}
 
 	statisticsTracker.ConsumeStatisticsEvent(e)
@@ -92,7 +92,7 @@ func TestConsumeStatisticsEventChain(t *testing.T) {
 		timeGetter: time.Now,
 	}
 	e := connection.SessionStatsEvent{
-		Stats:       consumer.SessionStatistics{
+		Stats: consumer.SessionStatistics{
 			BytesReceived: 1,
 			BytesSent:     1,
 		},

--- a/core/connection/event.go
+++ b/core/connection/event.go
@@ -50,6 +50,6 @@ type SessionEvent struct {
 
 // SessionStatsEvent represents a session statistics event
 type SessionStatsEvent struct {
-	Stats consumer.SessionStatistics
+	Stats       consumer.SessionStatistics
 	SessionInfo SessionInfo
 }

--- a/core/connection/event.go
+++ b/core/connection/event.go
@@ -17,6 +17,8 @@
 
 package connection
 
+import "github.com/mysteriumnetwork/node/consumer"
+
 // Topic represents the different topics a consumer can subscribe to
 const (
 	// StateEventTopic represents the connection state change topic
@@ -43,5 +45,11 @@ const (
 // SessionEvent represents a session related event
 type SessionEvent struct {
 	Status      string
+	SessionInfo SessionInfo
+}
+
+// SessionStatsEvent represents a session statistics event
+type SessionStatsEvent struct {
+	Stats consumer.SessionStatistics
 	SessionInfo SessionInfo
 }

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -102,13 +102,13 @@ type connectionManager struct {
 	ipCheckParams            IPCheckParams
 
 	// These are populated by Connect at runtime.
-	ctx            context.Context
-	status         Status
-	statusLock     sync.RWMutex
-	sessionInfo    SessionInfo
-	sessionInfoMux sync.Mutex
-	cleanup        []func() error
-	cancel         func()
+	ctx           context.Context
+	status        Status
+	statusLock    sync.RWMutex
+	sessionInfo   SessionInfo
+	sessionInfoMu sync.Mutex
+	cleanup       []func() error
+	cancel        func()
 
 	discoLock sync.Mutex
 }
@@ -214,7 +214,7 @@ func (manager *connectionManager) checkSessionIP(dialog communication.Dialog, se
 		manager.publishStateEvent(StateIPNotChanged)
 	}
 
-	// Notify if check is done.
+	// Notify that check is done.
 	manager.ipCheckParams.Done <- struct{}{}
 }
 
@@ -512,15 +512,15 @@ func (manager *connectionManager) publishStateEvent(state State) {
 }
 
 func (manager *connectionManager) setCurrentSession(info SessionInfo) {
-	manager.sessionInfoMux.Lock()
-	defer manager.sessionInfoMux.Unlock()
+	manager.sessionInfoMu.Lock()
+	defer manager.sessionInfoMu.Unlock()
 
 	manager.sessionInfo = info
 }
 
 func (manager *connectionManager) getCurrentSession() SessionInfo {
-	manager.sessionInfoMux.Lock()
-	defer manager.sessionInfoMux.Unlock()
+	manager.sessionInfoMu.Lock()
+	defer manager.sessionInfoMu.Unlock()
 
 	return manager.sessionInfo
 }

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -432,7 +432,10 @@ func (manager *connectionManager) consumeConnectionStates(stateChannel <-chan St
 
 func (manager *connectionManager) consumeStats(statisticsChannel <-chan consumer.SessionStatistics) {
 	for stats := range statisticsChannel {
-		manager.eventPublisher.Publish(StatisticsEventTopic, stats)
+		manager.eventPublisher.Publish(StatisticsEventTopic, SessionStatsEvent{
+			Stats:       stats,
+			SessionInfo: manager.sessionInfo,
+		})
 	}
 }
 

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -357,9 +357,9 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 
 	for _, v := range history {
 		if v.calledWithTopic == StatisticsEventTopic {
-			event := v.calledWithData.(consumer.SessionStatistics)
-			assert.True(tc.T(), event.BytesReceived == tc.mockStatistics.BytesReceived)
-			assert.True(tc.T(), event.BytesSent == tc.mockStatistics.BytesSent)
+			event := v.calledWithData.(SessionStatsEvent)
+			assert.True(tc.T(), event.Stats.BytesReceived == tc.mockStatistics.BytesReceived)
+			assert.True(tc.T(), event.Stats.BytesSent == tc.mockStatistics.BytesSent)
 		}
 		if v.calledWithTopic == StateEventTopic {
 			event := v.calledWithData.(StateEvent)

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -46,6 +46,8 @@ type testContext struct {
 	stubPublisher         *StubPublisher
 	mockStatistics        consumer.SessionStatistics
 	fakeResolver          ip.Resolver
+	ipCheckParams         IPCheckParams
+	statusSender          *mockStatusSender
 	sync.RWMutex
 }
 
@@ -114,6 +116,15 @@ func (tc *testContext) SetupTest() {
 		},
 	}
 
+	tc.ipCheckParams = IPCheckParams{
+		MaxAttempts:             3,
+		SleepDurationAfterCheck: 1 * time.Millisecond,
+		Done:                    make(chan struct{}, 1),
+	}
+
+	tc.statusSender = &mockStatusSender{}
+	tc.fakeResolver = ip.NewResolverMock("ip")
+
 	tc.connManager = NewManager(
 		dialogCreator,
 		func(paymentInfo *promise.PaymentInfo,
@@ -131,8 +142,9 @@ func (tc *testContext) SetupTest() {
 		},
 		tc.fakeConnectionFactory.CreateConnection,
 		tc.stubPublisher,
-		newMockStatusSender(),
-		ip.NewResolverMock("ip"),
+		tc.statusSender,
+		tc.fakeResolver,
+		tc.ipCheckParams,
 	)
 }
 
@@ -349,11 +361,12 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 
 	err := tc.connManager.Connect(consumerID, activeProposal, ConnectParams{})
 	assert.NoError(tc.T(), err)
+	<-tc.ipCheckParams.Done
 
 	waitABit()
 
 	history := tc.stubPublisher.GetEventHistory()
-	assert.Len(tc.T(), history, 3)
+	assert.Len(tc.T(), history, 4)
 
 	for _, v := range history {
 		if v.calledWithTopic == StatisticsEventTopic {
@@ -361,9 +374,17 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 			assert.True(tc.T(), event.Stats.BytesReceived == tc.mockStatistics.BytesReceived)
 			assert.True(tc.T(), event.Stats.BytesSent == tc.mockStatistics.BytesSent)
 		}
-		if v.calledWithTopic == StateEventTopic {
+		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == Connected {
 			event := v.calledWithData.(StateEvent)
 			assert.Equal(tc.T(), Connected, event.State)
+			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
+			assert.Equal(tc.T(), establishedSessionID, event.SessionInfo.SessionID)
+			assert.Equal(tc.T(), activeProposal.ProviderID, event.SessionInfo.Proposal.ProviderID)
+			assert.Equal(tc.T(), activeProposal.ServiceType, event.SessionInfo.Proposal.ServiceType)
+		}
+		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == StateIPNotChanged {
+			event := v.calledWithData.(StateEvent)
+			assert.Equal(tc.T(), StateIPNotChanged, event.State)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
 			assert.Equal(tc.T(), establishedSessionID, event.SessionInfo.SessionID)
 			assert.Equal(tc.T(), activeProposal.ProviderID, event.SessionInfo.Proposal.ProviderID)
@@ -378,6 +399,71 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 			assert.Equal(tc.T(), activeProposal.ServiceType, event.SessionInfo.Proposal.ServiceType)
 		}
 	}
+}
+
+func (tc *testContext) Test_ManagerNotifiesAboutSessionIPNotChanged() {
+	tc.stubPublisher.Clear()
+
+	tc.fakeConnectionFactory.mockConnection.onStartReportStates = []fakeState{
+		connectedState,
+	}
+
+	err := tc.connManager.Connect(consumerID, activeProposal, ConnectParams{})
+	assert.NoError(tc.T(), err)
+	<-tc.ipCheckParams.Done
+
+	// Check that state event with StateIPNotChanged status was called.
+	history := tc.stubPublisher.GetEventHistory()
+	var ipNotChangedEvent *StubPublisherEvent
+	for _, v := range history {
+		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == StateIPNotChanged {
+			ipNotChangedEvent = &v
+		}
+	}
+	assert.NotNil(tc.T(), ipNotChangedEvent)
+
+	// Check that status sender was called with status code.
+	expectedStatusMsg := connectivity.StatusMessage{
+		SessionID:  string(establishedSessionID),
+		StatusCode: connectivity.StatusSessionIPNotChanged,
+		Message:    "",
+	}
+	assert.NotNil(tc.T(), tc.statusSender.sentMsg)
+	assert.Equal(tc.T(), &expectedStatusMsg, tc.statusSender.sentMsg)
+}
+
+func (tc *testContext) Test_ManagerNotifiesAboutSuccessfulConnection() {
+	tc.stubPublisher.Clear()
+
+	tc.fakeConnectionFactory.mockConnection.onStartReportStates = []fakeState{
+		connectedState,
+	}
+
+	// Simulate IP change.
+	tc.connManager.ipResolver = ip.NewResolverMock("10.0.0.4", "10.0.5")
+
+	err := tc.connManager.Connect(consumerID, activeProposal, ConnectParams{})
+	assert.NoError(tc.T(), err)
+	<-tc.ipCheckParams.Done
+
+	// Check that state event with StateIPNotChanged status was not called.
+	history := tc.stubPublisher.GetEventHistory()
+	var ipNotChangedEvent *StubPublisherEvent
+	for _, v := range history {
+		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == StateIPNotChanged {
+			ipNotChangedEvent = &v
+		}
+	}
+	assert.Nil(tc.T(), ipNotChangedEvent)
+
+	// Check that status sender was called with status code.
+	expectedStatusMsg := connectivity.StatusMessage{
+		SessionID:  string(establishedSessionID),
+		StatusCode: connectivity.StatusConnectionOk,
+		Message:    "",
+	}
+	assert.NotNil(tc.T(), tc.statusSender.sentMsg)
+	assert.Equal(tc.T(), &expectedStatusMsg, tc.statusSender.sentMsg)
 }
 
 func TestConnectionManagerSuite(t *testing.T) {
@@ -431,14 +517,13 @@ func (mpm *MockPaymentIssuer) Stop() {
 	close(mpm.stopChan)
 }
 
-func newMockStatusSender() *mockStatusSender {
-	return &mockStatusSender{}
-}
-
 type mockStatusSender struct {
 	sentMsg *connectivity.StatusMessage
+	sync.Mutex
 }
 
-func (s mockStatusSender) Send(dialog communication.Sender, msg *connectivity.StatusMessage) {
+func (s *mockStatusSender) Send(dialog communication.Sender, msg *connectivity.StatusMessage) {
+	s.Lock()
+	defer s.Unlock()
 	s.sentMsg = msg
 }

--- a/core/connection/status.go
+++ b/core/connection/status.go
@@ -40,6 +40,10 @@ const (
 	Unknown = State("Unknown")
 	// Canceled means that connection initialization was started, but failed never reaching Connected state
 	Canceled = State("Canceled")
+	// StateIPNotChanged means that consumer ip not changed after connection is created
+	StateIPNotChanged = State("IPNotChanged")
+	// StateConnectionFailed means that underlying connection is failed
+	StateConnectionFailed = State("ConnectionFailed")
 )
 
 // Status holds connection state, session id and proposal of the connection

--- a/core/ip/fake_resolver.go
+++ b/core/ip/fake_resolver.go
@@ -69,7 +69,6 @@ func (client *mockResolver) getNextIP() string {
 	if len(client.ipAddresses) > 0 {
 		ip := client.ipAddresses[0]
 		client.ipAddresses = client.ipAddresses[1:]
-		fmt.Println("return ip", ip)
 		return ip
 	}
 	return ""

--- a/core/ip/fake_resolver.go
+++ b/core/ip/fake_resolver.go
@@ -18,7 +18,6 @@
 package ip
 
 import (
-	"fmt"
 	"net"
 )
 
@@ -61,7 +60,6 @@ func (client *mockResolver) GetOutboundIPAsString() (string, error) {
 func (client *mockResolver) getNextIP() string {
 	// Return first address if only one provided.
 	if len(client.ipAddresses) == 1 {
-		fmt.Println("get first ip")
 		return client.ipAddresses[0]
 	}
 	// Return first address and dequeue from address list. This allows to

--- a/core/quality/sender.go
+++ b/core/quality/sender.go
@@ -54,10 +54,10 @@ func NewSender(transport Transport, appVersion string, manager connection.Manage
 
 // Sender builds events and sends them using given transport
 type Sender struct {
-	Transport      Transport
-	AppVersion     string
-	connection     connection.Manager
-	location       location.OriginResolver
+	Transport  Transport
+	AppVersion string
+	connection connection.Manager
+	location   location.OriginResolver
 }
 
 // Event contains data about event, which is sent using transport
@@ -119,8 +119,7 @@ func (sender *Sender) SendSessionData(e connection.SessionStatsEvent) {
 	})
 }
 
-
-// SendSessionEvent sends session update events.
+// SendConnStateEvent sends session update events.
 func (sender *Sender) SendConnStateEvent(e connection.StateEvent) {
 	sender.sendEvent(sessionEventName, sessionEventContext{
 		Event: string(e.State),

--- a/tequilapi/endpoints/session_connectivity.go
+++ b/tequilapi/endpoints/session_connectivity.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/mysteriumnetwork/node/requests"
 	"github.com/mysteriumnetwork/node/session/connectivity"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 )
@@ -41,7 +40,6 @@ type sessionConnectivityStatus struct {
 }
 
 type sessionConnectivityEndpoint struct {
-	http          requests.HTTPTransport
 	statusStorage connectivity.StatusStorage
 }
 
@@ -73,9 +71,8 @@ func (e *sessionConnectivityEndpoint) List(resp http.ResponseWriter, req *http.R
 }
 
 // AddRoutesForConnectivityStatus attaches connectivity statuses endpoints to router.
-func AddRoutesForConnectivityStatus(bindAddress string, router *httprouter.Router, statusStorage connectivity.StatusStorage) {
+func AddRoutesForConnectivityStatus(router *httprouter.Router, statusStorage connectivity.StatusStorage) {
 	e := &sessionConnectivityEndpoint{
-		http:          requests.NewHTTPClient(bindAddress, 20*time.Second),
 		statusStorage: statusStorage,
 	}
 	router.GET("/sessions-connectivity-status", e.List)


### PR DESCRIPTION
This PR implements consumer session IP change check and sends status to another peer and quality oracle. IP check is done in separate go routine with default 3 retries and 2 seconds delay between each try.

Part of https://github.com/mysteriumnetwork/node/issues/1298