### PR TITLE
Provider will now check for user registration prior to serving the se…

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -17,11 +17,20 @@
 
 package identity
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+)
 
 // Identity represents unique user network identity
 type Identity struct {
 	Address string `json:"address"`
+}
+
+// ToCommonAddress returns the common address representation for identity
+func (i Identity) ToCommonAddress() common.Address {
+	return common.HexToAddress(i.Address)
 }
 
 // FromAddress converts address to identity

--- a/session/pingpong/blockchain.go
+++ b/session/pingpong/blockchain.go
@@ -61,3 +61,19 @@ func (bc *Blockchain) GetAccountantFee(accountantAddress common.Address) (uint16
 
 	return res.Value, err
 }
+
+// IsRegistered checks wether the given identity is registered or not
+func (bc *Blockchain) IsRegistered(registryAddress, addressToCheck common.Address) (bool, error) {
+	caller, err := bindings.NewRegistryCaller(registryAddress, bc.client)
+	if err != nil {
+		return false, errors.Wrap(err, "could not create registry caller")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), bc.bcTimeout)
+	defer cancel()
+
+	res, err := caller.IsRegistered(&bind.CallOpts{
+		Context: ctx,
+	}, addressToCheck)
+	return res, errors.Wrap(err, "could not check registration status")
+}


### PR DESCRIPTION
…ssion

The providers side of pingpong will now check wether the user is registered with the registry.
In case that user is  not registered, the session will be cancelled and the consumer will not be served.

Closes #1373

Opening this as a separate PR so that payment-v2-messaging does not get super duper huge and hard to review.