### PR TITLE
Expose registration endpoint through CLI

### DIFF
--- a/core/transactor/transactor.go
+++ b/core/transactor/transactor.go
@@ -28,7 +28,6 @@ import (
 	pc "github.com/mysteriumnetwork/payments/crypto"
 	"github.com/mysteriumnetwork/payments/registration"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 )
 
 // Transactor allows for convenient calls to the transactor service
@@ -172,7 +171,6 @@ func (t *Transactor) fillIdentityRegistrationRequest(id string, regReqDTO Identi
 
 	signatureHex := common.Bytes2Hex(sig)
 	regReq.Signature = strings.ToLower(fmt.Sprintf("0x%v", signatureHex))
-	log.Info().Msgf("regReq: %v", regReq)
 	regReq.Identity = id
 
 	return regReq, nil

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -95,6 +95,19 @@ func (client *Client) CurrentIdentity(identity, passphrase string) (id IdentityD
 	return id, err
 }
 
+// GetTransactorFees returns the transactor fees
+func (client *Client) GetTransactorFees() (transactor.Fees, error) {
+	res, err := client.http.Get("transactor/fees", nil)
+	if err != nil {
+		return transactor.Fees{}, err
+	}
+	defer res.Body.Close()
+
+	fees := transactor.Fees{}
+	err = parseResponseJSON(res, &fees)
+	return fees, err
+}
+
 // RegisterIdentity registers identity
 func (client *Client) RegisterIdentity(address, beneficiary string, stake, fee uint64) error {
 	payload := transactor.IdentityRegistrationRequestDTO{


### PR DESCRIPTION
We're now able to register our identity through CLI

Closes #1376

Opening this as a separate PR so that payment-v2-messaging does not get super duper huge and hard to review.

