### PR TITLE
Provide a way for 3rd party vendor to identify their nodes

### DIFF
--- a/cmd/flags_node.go
+++ b/cmd/flags_node.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"github.com/mysteriumnetwork/node/config"
 	"gopkg.in/urfave/cli.v1"
 	"gopkg.in/urfave/cli.v1/altsrc"
 
@@ -66,7 +67,14 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		return err
 	}
 
-	*flags = append(*flags, tequilapiAddressFlag, tequilapiPortFlag, keystoreLightweightFlag, bindAddressFlag, feedbackURLFlag)
+	*flags = append(*flags,
+		tequilapiAddressFlag,
+		tequilapiPortFlag,
+		keystoreLightweightFlag,
+		bindAddressFlag,
+		feedbackURLFlag,
+		config.VendorIDFlag,
+	)
 
 	RegisterFlagsNetwork(flags)
 	RegisterFlagsDiscovery(flags)

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import "gopkg.in/urfave/cli.v1"
+
+var (
+	// VendorIDFlag identifies 3rd party vendor (distributor) of Mysterium node
+	VendorIDFlag = cli.StringFlag{
+		Name: "vendor.id",
+		Usage: "Marks vendor (distributor) of the node for collecting statistics. " +
+			"3rd party vendors may use their own identifier here.",
+		Value: "",
+	}
+)

--- a/mmn/node_information.go
+++ b/mmn/node_information.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/mysteriumnetwork/go-ci/shell"
+	"github.com/mysteriumnetwork/node/config"
 	"github.com/rs/zerolog/log"
 
 	"github.com/mysteriumnetwork/node/core/ip"
@@ -38,6 +39,7 @@ type NodeInformation struct {
 	Arch        string `json:"arch"`
 	NodeVersion string `json:"node_version"`
 	Identity    string `json:"identity"`
+	VendorID    string `json:"vendor_id"`
 }
 
 // CollectNodeData sends node information to MMN on identity unlock
@@ -64,6 +66,7 @@ func CollectNodeData(client *client, resolver ip.Resolver) func(string) {
 		info.MACAddress = hex.EncodeToString(sha256Bytes[:])
 		info.LocalIP = outboundIp
 		info.Identity = identity
+		info.VendorID = config.Current.GetString(config.VendorIDFlag.Name)
 
 		if err = client.RegisterNode(info); err != nil {
 			log.Error().Err(err).Msg("failed to send NodeInformation to MMN")


### PR DESCRIPTION
`vendor.id` flag (can be set in `config.toml`) will allow 3rd party vendors to track their nodes.

Fixes: #1345 

_Note: configuration flags refactoring is needed to unify the approach and/or improve current config implementation, that I will do with a separate PR_