### PR TITLE
Fix ssdp stop race

### DIFF
--- a/ui/discovery/ssdp.go
+++ b/ui/discovery/ssdp.go
@@ -107,18 +107,18 @@ func (ss *ssdpServer) Start() (err error) {
 }
 
 func (ss *ssdpServer) Stop() error {
+	var closeError error
 	ss.once.Do(func() {
 		close(ss.quit)
+		if ss.ssdp != nil {
+			if err := ss.ssdp.Bye(); err != nil {
+				log.Error().Err(err).Msg("Failed to send SSDP bye message")
+			}
+			closeError = errors.Wrap(ss.ssdp.Close(), "failed to send SSDP bye message")
+		}
 	})
 
-	if ss.ssdp != nil {
-		if err := ss.ssdp.Bye(); err != nil {
-			log.Error().Err(err).Msg("Failed to send SSDP bye message")
-		}
-		return errors.Wrap(ss.ssdp.Close(), "failed to send SSDP bye message")
-	}
-
-	return nil
+	return closeError
 }
 
 func (ss *ssdpServer) serveDeviceDescriptionDocument() (url.URL, error) {


### PR DESCRIPTION
…with the ssdp client already being closed

The issue is caused by multiple stop calls, hence the second call tries to send a bye when the ssdp client is already closed.

Moving the relevant code to the once func will solve the issue. However, there needs to be a better look at our stopping routines.
We need to figure out why the stops are being called multiple times. This is out of scope for this commit though.

Fixes #1333