### PR TITLE
Decrease location cache to 30 seconds

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -724,7 +724,7 @@ func (di *Dependencies) bootstrapLocationComponents(options node.Options) (err e
 		return err
 	}
 
-	di.LocationResolver = location.NewCache(resolver, time.Minute*5)
+	di.LocationResolver = location.NewCache(resolver, time.Second*30)
 
 	err = di.EventBus.SubscribeAsync(connection.StateEventTopic, di.LocationResolver.HandleConnectionEvent)
 	if err != nil {


### PR DESCRIPTION
Mobile app is fetching location cache each 10 seconds but as IP may not change instantly it will update IP in UI only after 5 minutes. As a short term solution decreasing to cache to 30 seconds will make UI experience a bit better.