### PR TITLE
Fix openvpn client DNS resolution

### DIFF
--- a/services/openvpn/client.go
+++ b/services/openvpn/client.go
@@ -62,7 +62,7 @@ func (c *Client) Start(options connection.ConnectOptions) error {
 		return err
 	}
 	c.process = proc
-	log.Info().Msgf("client config: %v", clientConfig)
+	log.Info().Interface("data", clientConfig).Msgf("Openvpn client configuration")
 	removeAllowedIPRule, err := firewall.AllowIPAccess(clientConfig.VpnConfig.RemoteIP)
 	if err != nil {
 		return err

--- a/services/openvpn/client_config.go
+++ b/services/openvpn/client_config.go
@@ -88,6 +88,10 @@ func NewClientConfigFromSession(vpnConfig *VPNConfig, configDir string, runtimeD
 	clientFileConfig := newClientConfig(runtimeDir, configDir, enableDNS)
 	if enableDNS && len(vpnConfig.DNS) > 0 {
 		clientFileConfig.SetParam("dhcp-option", "DNS", vpnConfig.DNS)
+	} else {
+		// TODO remove these once most of the providers are capable of running DNS proxy?
+		clientFileConfig.SetParam("dhcp-option", "DNS", "208.67.222.222")
+		clientFileConfig.SetParam("dhcp-option", "DNS", "208.67.220.220")
 	}
 	clientFileConfig.VpnConfig = vpnConfig
 	clientFileConfig.SetReconnectRetry(2)


### PR DESCRIPTION
DNS resolution doesn't work after establishing a connection unless the client sets custom DNS servers manually. @soffokl suggested that client's DNS provider might become unreachable.

As a short term fix, I'm restoring the previous behavior of using OpenDNS in the client configuration. This is compatible with Provider DNS implemented in #1285 - OpenDNS will only be used if `enableDNS` is not provided in `ConnectOptions`.

I'll release this ASAP as a patch version for the latest node (`0.14.1`) so the desktop app can be released.