### PR TITLE
Protect networks from VPN access on macOS and Linux

### DIFF
--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -36,12 +36,6 @@ var (
 		Usage: "Proposal discovery adapter. Options: { api, broker }",
 		Value: "api",
 	}
-	// FlagBindAddress IP address to bind to.
-	FlagBindAddress = cli.StringFlag{
-		Name:  "bind.address",
-		Usage: "IP address to bind to",
-		Value: "0.0.0.0",
-	}
 	// FlagDiscoveryAddress proposal discovery URL.
 	FlagDiscoveryAddress = cli.StringFlag{
 		Name: "discovery.address",
@@ -50,6 +44,12 @@ var (
 			FlagDiscoveryType.Name,
 		),
 		Value: FlagAPIAddress.Value,
+	}
+	// FlagBindAddress IP address to bind to.
+	FlagBindAddress = cli.StringFlag{
+		Name:  "bind.address",
+		Usage: "IP address to bind to",
+		Value: "0.0.0.0",
 	}
 	// FlagFeedbackURL URL of Feedback API.
 	FlagFeedbackURL = cli.StringFlag{
@@ -61,6 +61,12 @@ var (
 	FlagFirewallKillSwitch = cli.BoolFlag{
 		Name:  "firewall.killSwitch.always",
 		Usage: "Always block non-tunneled outgoing consumer traffic",
+	}
+	// FlagFirewallProtectedNetworks protects provider's networks from access via VPN
+	FlagFirewallProtectedNetworks = cli.StringFlag{
+		Name:  "firewall.protected.networks",
+		Usage: "List of comma separated (no spaces) subnets to be protected from access via VPN",
+		Value: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
 	}
 	// FlagKeystoreLightweight determines the scrypt memory complexity.
 	FlagKeystoreLightweight = cli.BoolFlag{
@@ -167,6 +173,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		FlagDiscoveryType,
 		FlagFeedbackURL,
 		FlagFirewallKillSwitch,
+		FlagFirewallProtectedNetworks,
 		FlagKeystoreLightweight,
 		FlagLogHTTP,
 		FlagLogLevel,
@@ -198,6 +205,7 @@ func ParseFlagsNode(ctx *cli.Context) {
 	Current.ParseStringFlag(ctx, FlagDiscoveryType)
 	Current.ParseStringFlag(ctx, FlagFeedbackURL)
 	Current.ParseBoolFlag(ctx, FlagFirewallKillSwitch)
+	Current.ParseStringFlag(ctx, FlagFirewallProtectedNetworks)
 	Current.ParseBoolFlag(ctx, FlagKeystoreLightweight)
 	Current.ParseBoolFlag(ctx, FlagLogHTTP)
 	Current.ParseStringFlag(ctx, FlagLogLevel)

--- a/e2e/compatibility-matrix/docker-compose.yml
+++ b/e2e/compatibility-matrix/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       --experiment-identity-check
       --experiment-payments
       --localnet
+      --firewall.protected.networks=""
       --broker-address=broker
       --api.address=http://mysterium-api/v1
       --ether.client.rpc=ws://ganache:8545

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       --location.country=e2e-land
       --experiment-identity-check
       --localnet
+      --firewall.protected.networks=""
       --broker-address=broker
       --api.address=http://mysterium-api:8001/v1
       --ether.client.rpc=ws://ganache:8545

--- a/e2e/traversal/docker-compose.yml
+++ b/e2e/traversal/docker-compose.yml
@@ -235,6 +235,7 @@ services:
       --location.country=e2e-land
       --experiment-identity-check=true
       --broker-address=broker
+      --firewall.protected.networks=""
       --api.address=http://mysterium-api/v1
       --ether.client.rpc=ws://ganache:8545
       --transactor.registry-address=0x241F6e1d0bB17f45767DC60A6Bd3D21Cdb543a0c

--- a/nat/service_iptables.go
+++ b/nat/service_iptables.go
@@ -103,7 +103,10 @@ func iptables(action string, rule RuleForwarding) error {
 
 func dropToLocal(action, sourceSubnet string) error {
 	destinations := config.GetString(config.FlagFirewallProtectedNetworks)
-
+	if destinations == "" {
+		log.Info().Msgf("no protected networks set")
+		return nil
+	}
 	command := fmt.Sprintf("/sbin/iptables --%s FORWARD --source %s --destination %s -j DROP",
 		action, sourceSubnet, destinations)
 	cmd := utils.SplitCommand("sudo", command)

--- a/nat/service_pfctl.go
+++ b/nat/service_pfctl.go
@@ -24,9 +24,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+
+	"github.com/mysteriumnetwork/node/config"
+	"github.com/mysteriumnetwork/node/utils"
 )
 
 type servicePFCtl struct {
@@ -91,11 +93,14 @@ func (service *servicePFCtl) enableRules() error {
 	defer service.mu.Unlock()
 
 	var natRule string
+
 	for rule := range service.rules {
 		iface, err := ifaceByAddress(rule.TargetIP)
 		if err != nil {
 			return err
 		}
+		natRule += fmt.Sprintf("no nat on %s inet from %s to { %s } \n",
+			iface, rule.SourceSubnet, config.GetString(config.FlagFirewallProtectedNetworks))
 		natRule += fmt.Sprintf("nat on %v inet from %v to any -> %v\n", iface, rule.SourceSubnet, rule.TargetIP)
 	}
 

--- a/nat/service_pfctl.go
+++ b/nat/service_pfctl.go
@@ -99,8 +99,14 @@ func (service *servicePFCtl) enableRules() error {
 		if err != nil {
 			return err
 		}
-		natRule += fmt.Sprintf("no nat on %s inet from %s to { %s } \n",
-			iface, rule.SourceSubnet, config.GetString(config.FlagFirewallProtectedNetworks))
+
+		destinations := config.GetString(config.FlagFirewallProtectedNetworks)
+		if destinations == "" {
+			log.Info().Msgf("no protected networks set")
+		} else {
+			natRule += fmt.Sprintf("no nat on %s inet from %s to { %s } \n",
+				iface, rule.SourceSubnet, destinations)
+		}
 		natRule += fmt.Sprintf("nat on %v inet from %v to any -> %v\n", iface, rule.SourceSubnet, rule.TargetIP)
 	}
 


### PR DESCRIPTION
- Prohibit access form VPN users to providers local networks. 
- Added flag 'firewall.protected.networks' to override/extend defaults