### PR TITLE
Add option for setting log directory

### DIFF
--- a/bin/docker/docker-entrypoint.sh
+++ b/bin/docker/docker-entrypoint.sh
@@ -9,6 +9,7 @@ export OS_DIR_RUN="/var/run/mysterium-node"
 
 exec /usr/bin/myst \
  --config-dir=$OS_DIR_CONFIG \
+ --log-dir="" \
  --data-dir=$OS_DIR_DATA \
  --runtime-dir=$OS_DIR_RUN \
  --tequilapi.address=0.0.0.0 \

--- a/bin/run
+++ b/bin/run
@@ -2,6 +2,7 @@
 
 sudo ./build/myst/myst \
    --data-dir=./build/myst/node \
+   --log-dir="" \
    --runtime-dir=./build/myst/node \
    --tequilapi.address=127.0.0.1 \
    --tequilapi.port=4051 \

--- a/config/flags_directory.go
+++ b/config/flags_directory.go
@@ -36,6 +36,11 @@ var (
 		Name:  "data-dir",
 		Usage: "Data directory containing keystore & other persistent files",
 	}
+	// FlagLogDir is a directory for storing log files.
+	FlagLogDir = cli.StringFlag{
+		Name:  "log-dir",
+		Usage: "Log directory for storing log files",
+	}
 	// FlagRuntimeDir runtime writable directory for temporary files.
 	FlagRuntimeDir = cli.StringFlag{
 		Name:  "runtime-dir",
@@ -57,11 +62,13 @@ func RegisterFlagsDirectory(flags *[]cli.Flag) error {
 
 	FlagConfigDir.Value = filepath.Join(currentDir, "config")
 	FlagDataDir.Value = filepath.Join(userHomeDir, ".mysterium")
+	FlagLogDir.Value = FlagDataDir.Value
 	FlagRuntimeDir.Value = currentDir
 
 	*flags = append(*flags,
 		FlagConfigDir,
 		FlagDataDir,
+		FlagLogDir,
 		FlagRuntimeDir,
 	)
 	return nil
@@ -69,6 +76,7 @@ func RegisterFlagsDirectory(flags *[]cli.Flag) error {
 
 // ParseFlagsDirectory function fills in directory options from CLI context
 func ParseFlagsDirectory(ctx *cli.Context) {
+	Current.ParseStringFlag(ctx, FlagLogDir)
 	Current.ParseStringFlag(ctx, FlagDataDir)
 	Current.ParseStringFlag(ctx, FlagConfigDir)
 	Current.ParseStringFlag(ctx, FlagRuntimeDir)

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -135,7 +135,7 @@ func GetOptions() *Options {
 
 // GetLogOptions retrieves logger options from the app configuration.
 func GetLogOptions() *logconfig.LogOptions {
-	logDir := config.GetString(config.FlagDataDir)
+	logDir := config.GetString(config.FlagLogDir)
 	level, err := zerolog.ParseLevel(config.GetString(config.FlagLogLevel))
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to parse logging level")


### PR DESCRIPTION
This will allow us to disable file logging or to put logs into the required place.

We need to be able to disable file logging for Docker container or server installation where logging controlled on the system level.