### PR TITLE
Allow for settling of accountant promises

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -248,7 +248,14 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	}
 
 	di.bootstrapNodeComponents(nodeOptions, tequilaListener)
-	di.bootstrapProviderRegistrar(nodeOptions)
+	if err := di.bootstrapProviderRegistrar(nodeOptions); err != nil {
+		return err
+	}
+
+	if err := di.bootstrapAccountantPromiseSettler(nodeOptions); err != nil {
+		return err
+	}
+
 	di.registerConnections(nodeOptions)
 
 	if err = di.subscribeEventConsumers(); err != nil {
@@ -567,6 +574,7 @@ func newSessionManagerFactory(
 			pingpong.DefaultAccountantFailureCount,
 			uint16(nodeOptions.Payments.MaxAllowedPaymentPercentile),
 			bcHelper,
+			eventbus,
 		)
 		return session.NewManager(
 			proposal,

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -43,6 +43,7 @@ import (
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/mysteriumnetwork/node/session/connectivity"
+	"github.com/mysteriumnetwork/node/session/pingpong"
 	"github.com/mysteriumnetwork/node/ui"
 	uinoop "github.com/mysteriumnetwork/node/ui/noop"
 	"github.com/rs/zerolog/log"
@@ -197,6 +198,16 @@ func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) err
 	}
 	di.ProviderRegistrar = registry.NewProviderRegistrar(di.Transactor, di.IdentityRegistry, cfg)
 	return di.ProviderRegistrar.Subscribe(di.EventBus)
+}
+
+func (di *Dependencies) bootstrapAccountantPromiseSettler(nodeOptions node.Options) error {
+	cfg := pingpong.AccountantPromiseSettlerConfig{
+		AccountantAddress:    common.HexToAddress(nodeOptions.Accountant.AccountantID),
+		Threshold:            nodeOptions.Payments.AccountantPromiseSettlingThreshold,
+		MaxWaitForSettlement: nodeOptions.Payments.SettlementTimeout,
+	}
+	settler := pingpong.NewAccountantPromiseSettler(di.BCHelper, di.IdentityRegistry, di.Keystore, di.AccountantPromiseStorage, cfg)
+	return settler.Subscribe(di.EventBus)
 }
 
 // bootstrapServiceComponents initiates ServicesManager dependency

--- a/cmd/di_mobile.go
+++ b/cmd/di_mobile.go
@@ -44,3 +44,7 @@ func (di *Dependencies) bootstrapMMN(options node.Options) {
 func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) error {
 	return nil
 }
+
+func (di *Dependencies) bootstrapAccountantPromiseSettler(nodeOptions node.Options) error {
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -201,6 +201,11 @@ func (cfg *Config) GetUInt64(key string) uint64 {
 	return cast.ToUint64(cfg.Get(key))
 }
 
+// GetFloat64 returns config value as float64.
+func (cfg *Config) GetFloat64(key string) float64 {
+	return cast.ToFloat64(cfg.Get(key))
+}
+
 // GetDuration returns config value as duration.
 func (cfg *Config) GetDuration(key string) time.Duration {
 	return cast.ToDuration(cfg.Get(key))
@@ -263,6 +268,19 @@ func (cfg *Config) ParseUInt64Flag(ctx *cli.Context, flag cli.Uint64Flag) {
 	}
 }
 
+// ParseFloat64Flag parses a cli.Float64Flag from command's context and
+// sets default and CLI values to the application configuration.
+func (cfg *Config) ParseFloat64Flag(ctx *cli.Context, flag cli.Float64Flag) {
+	cfg.SetDefault(flag.Name, flag.Value)
+	if ctx.IsSet(flag.Name) {
+		cfg.SetCLI(flag.Name, ctx.Float64(flag.Name))
+	} else if ctx.GlobalIsSet(flag.Name) {
+		cfg.SetCLI(flag.Name, ctx.GlobalFloat64(flag.Name))
+	} else {
+		cfg.RemoveCLI(flag.Name)
+	}
+}
+
 // ParseDurationFlag parses a cli.DurationFlag from command's context and
 // sets default and CLI values to the application configuration.
 func (cfg *Config) ParseDurationFlag(ctx *cli.Context, flag cli.DurationFlag) {
@@ -317,6 +335,11 @@ func GetDuration(flag cli.DurationFlag) time.Duration {
 // GetUInt64 shorthand for getting current configuration value for cli.Uint64Flag.
 func GetUInt64(flag cli.Uint64Flag) uint64 {
 	return Current.GetUInt64(flag.Name)
+}
+
+// GetFloat64 shorthand for getting current configuration value for cli.Uint64Flag.
+func GetFloat64(flag cli.Float64Flag) float64 {
+	return Current.GetFloat64(flag.Name)
 }
 
 // Topic returns event bus topic for the given config key to listen for its updates.

--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -24,31 +24,47 @@ import (
 )
 
 var (
-	// FlagPaymentsMaxAccountantFee represents the max accountant fee
+	// FlagPaymentsMaxAccountantFee represents the max accountant fee.
 	FlagPaymentsMaxAccountantFee = cli.IntFlag{
 		Name:  "payments.accountant.max.fee",
 		Value: 1500,
 		Usage: "The max fee that we'll accept from an accountant. In percentiles. 1500 means 15%",
 	}
-	// FlagPaymentsBCTimeout represents the BC call timeout
+	// FlagPaymentsBCTimeout represents the BC call timeout.
 	FlagPaymentsBCTimeout = cli.DurationFlag{
 		Name:  "payments.bc.timeout",
 		Value: time.Second * 30,
 		Usage: "The duration we'll wait before timing out BC calls.",
 	}
+	// FlagPaymentsAccountantPromiseSettleThreshold represents the percentage of balance left when we go for promise settling.
+	FlagPaymentsAccountantPromiseSettleThreshold = cli.Float64Flag{
+		Name:  "payments.accountant.promise.threshold",
+		Value: 0.1,
+		Usage: "The percentage of balance before we settle promises",
+	}
+	// FlagPaymentsAccountantPromiseSettleTimeout represents the time we wait for confirmation of the promise settlement.
+	FlagPaymentsAccountantPromiseSettleTimeout = cli.DurationFlag{
+		Name:  "payments.accountant.promise.timeout",
+		Value: time.Hour * 2,
+		Usage: "The duration we'll wait before timing out our wait for promise settle.",
+	}
 )
 
-// RegisterFlagsPayments function register payments flags to flag list
+// RegisterFlagsPayments function register payments flags to flag list.
 func RegisterFlagsPayments(flags *[]cli.Flag) {
 	*flags = append(
 		*flags,
 		FlagPaymentsMaxAccountantFee,
 		FlagPaymentsBCTimeout,
+		FlagPaymentsAccountantPromiseSettleThreshold,
+		FlagPaymentsAccountantPromiseSettleTimeout,
 	)
 }
 
-// ParseFlagsPayments function fills in payments options from CLI context
+// ParseFlagsPayments function fills in payments options from CLI context.
 func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseIntFlag(ctx, FlagPaymentsMaxAccountantFee)
 	Current.ParseDurationFlag(ctx, FlagPaymentsBCTimeout)
+	Current.ParseFloat64Flag(ctx, FlagPaymentsAccountantPromiseSettleThreshold)
+	Current.ParseDurationFlag(ctx, FlagPaymentsAccountantPromiseSettleTimeout)
 }

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -130,8 +130,10 @@ func GetOptions() *Options {
 			ProviderRegistrationStake:       config.GetUInt64(config.FlagTransactorProviderRegistrationStake),
 		},
 		Payments: OptionsPayments{
-			MaxAllowedPaymentPercentile: config.GetInt(config.FlagPaymentsMaxAccountantFee),
-			BCTimeout:                   config.GetDuration(config.FlagPaymentsBCTimeout),
+			MaxAllowedPaymentPercentile:        config.GetInt(config.FlagPaymentsMaxAccountantFee),
+			BCTimeout:                          config.GetDuration(config.FlagPaymentsBCTimeout),
+			AccountantPromiseSettlingThreshold: config.GetFloat64(config.FlagPaymentsAccountantPromiseSettleThreshold),
+			SettlementTimeout:                  config.GetDuration(config.FlagPaymentsAccountantPromiseSettleTimeout),
 		},
 		Accountant: OptionsAccountant{
 			AccountantID:              config.GetString(config.FlagAccountantID),

--- a/session/pingpong/accountant_promise_settler.go
+++ b/session/pingpong/accountant_promise_settler.go
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	nodevent "github.com/mysteriumnetwork/node/core/node/event"
+	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/eventbus"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/identity/registry"
+	"github.com/mysteriumnetwork/payments/bindings"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// AccountantPromiseSettler is responsible for settling the accountant promises.
+type AccountantPromiseSettler struct {
+	bc                         providerChannelStatusProvider
+	config                     AccountantPromiseSettlerConfig
+	lock                       sync.Mutex
+	accountantPromiseGetter    accountantPromiseGetter
+	registrationStatusProvider registrationStatusProvider
+	ks                         ks
+
+	currentState map[identity.Identity]state
+	settleQueue  chan identity.Identity
+	stop         chan struct{}
+	once         sync.Once
+}
+
+// AccountantPromiseSettlerConfig configures the accountant promise settler accordingly.
+type AccountantPromiseSettlerConfig struct {
+	AccountantAddress    common.Address
+	Threshold            float64
+	MaxWaitForSettlement time.Duration
+}
+
+// NewAccountantPromiseSettler creates a new instance of accountant promise settler.
+func NewAccountantPromiseSettler(providerChannelStatusProvider providerChannelStatusProvider, registrationStatusProvider registrationStatusProvider, ks ks, accountantPromiseGetter accountantPromiseGetter, config AccountantPromiseSettlerConfig) *AccountantPromiseSettler {
+	return &AccountantPromiseSettler{
+		bc:                         providerChannelStatusProvider,
+		accountantPromiseGetter:    accountantPromiseGetter,
+		ks:                         ks,
+		registrationStatusProvider: registrationStatusProvider,
+		config:                     config,
+		currentState:               make(map[identity.Identity]state),
+		// defaulting to a queue of 5, in case we have a few active identities.
+		settleQueue: make(chan identity.Identity, 5),
+		stop:        make(chan struct{}),
+	}
+}
+
+// loadInitialState loads the initial state for the given identity. Inteded to be called on service start.
+func (aps *AccountantPromiseSettler) loadInitialState(addr identity.Identity) error {
+	aps.lock.Lock()
+	defer aps.lock.Unlock()
+
+	if _, ok := aps.currentState[addr]; ok {
+		log.Info().Msgf("State for %v already loaded, skipping", addr)
+		return nil
+	}
+
+	status, err := aps.registrationStatusProvider.GetRegistrationStatus(addr)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("could not check registration status for %v", addr))
+	}
+
+	if status != registry.RegisteredProvider {
+		log.Info().Msgf("Provider %v not registered, skipping", addr)
+		return nil
+	}
+
+	return aps.resyncState(addr)
+}
+
+func (aps *AccountantPromiseSettler) resyncState(addr identity.Identity) error {
+	res, err := aps.bc.GetProviderChannel(aps.config.AccountantAddress, addr.ToCommonAddress())
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("could not get provider channel for %v", addr))
+	}
+
+	promise, err := aps.accountantPromiseGetter.Get(addr, identity.FromAddress(aps.config.AccountantAddress.Hex()))
+	if err != nil && err != ErrNotFound {
+		return errors.Wrap(err, fmt.Sprintf("could not get accountant promise for %v", addr))
+	}
+
+	availableBalance := res.Balance.Uint64() + res.Settled.Uint64()
+	currentBalance := availableBalance - promise.Amount
+	s := state{
+		balance:          currentBalance,
+		availableBalance: availableBalance,
+		lastPromise:      promise,
+		registered:       true,
+	}
+
+	aps.currentState[addr] = s
+	log.Info().Msgf("Loaded state for provider %q: balance %v, available balance %v ", addr, s.balance, s.availableBalance)
+
+	return nil
+}
+
+// Subscribe subscribes the accountant promise settler to the appropriate events
+func (aps *AccountantPromiseSettler) Subscribe(sub eventbus.Subscriber) error {
+	err := sub.SubscribeAsync(nodevent.Topic, aps.handleNodeEvent)
+	if err != nil {
+		return errors.Wrap(err, "could not subscribe to node status event")
+	}
+
+	err = sub.SubscribeAsync(registry.RegistrationEventTopic, aps.handleRegistrationEvent)
+	if err != nil {
+		return errors.Wrap(err, "could not subscribe to registration event")
+	}
+
+	err = sub.SubscribeAsync(service.StatusTopic, aps.handleServiceEvent)
+	if err != nil {
+		return errors.Wrap(err, "could not subscribe to service status event")
+	}
+
+	err = sub.SubscribeAsync(AccountantPromiseTopic, aps.handleAccountantPromiseReceived)
+	return errors.Wrap(err, "could not subscribe to accountant promise event")
+}
+
+func (aps *AccountantPromiseSettler) handleServiceEvent(event service.EventPayload) {
+	switch event.Status {
+	case string(service.Running):
+		err := aps.loadInitialState(identity.FromAddress(event.ProviderID))
+		// TODO: should we retry? should we signal that we need to cancel and abort?
+		// In any case, if we start exceeding our balances, the accountant will let us know.
+		// Sessions will be aborted, node *should* stop, indicating something went wrong.
+		// On restart, a rebalance then should follow almost immediately.
+		// But we'll get punished for that, won't we?
+		if err != nil {
+			log.Error().Err(err).Msgf("could not load initial state for provider %v", event.ProviderID)
+		}
+	default:
+		log.Debug().Msgf("Ignoring service event with status %v", event.Status)
+	}
+}
+
+func (aps *AccountantPromiseSettler) handleNodeEvent(payload nodevent.Payload) {
+	if payload.Status == nodevent.StatusStarted {
+		aps.handleNodeStart()
+		return
+	}
+
+	if payload.Status == nodevent.StatusStopped {
+		aps.handleNodeStop()
+		return
+	}
+}
+
+func (aps *AccountantPromiseSettler) handleRegistrationEvent(payload registry.RegistrationEventPayload) {
+	aps.lock.Lock()
+	defer aps.lock.Unlock()
+
+	if payload.Status != registry.RegisteredProvider {
+		log.Debug().Msgf("Ignoring event %v for provider %q", payload.Status.String(), payload.ID)
+		return
+	}
+	log.Info().Msgf("Identity registration event received for provider %q", payload.ID)
+
+	err := aps.resyncState(payload.ID)
+	if err != nil {
+		// TODO: should we retry? should we signal that we need to cancel and abort?
+		// In any case, if we start exceeding our balances, the accountant will let us know.
+		// Sessions will be aborted, node *should* stop, indicating something went wrong.
+		// On restart, a rebalance then should follow almost immediately.
+		// But we'll get punished for that, won't we?
+		log.Error().Err(err).Msgf("Could not resync state for provider %v", payload.ID)
+		return
+	}
+
+	log.Info().Msgf("Identity registration event handled for provider %q", payload.ID)
+}
+
+func (aps *AccountantPromiseSettler) handleAccountantPromiseReceived(apep AccountantPromiseEventPayload) {
+	aps.lock.Lock()
+	defer aps.lock.Unlock()
+
+	log.Info().Msgf("Received accountant promise for %q", apep.ProviderID)
+
+	v, ok := aps.currentState[apep.ProviderID]
+	if !ok {
+		log.Error().Msgf("Have no info on provider %q, skipping", apep.ProviderID)
+		return
+	}
+
+	if !v.registered {
+		log.Error().Msgf("provider %q not registered, skipping", apep.ProviderID)
+		return
+	}
+
+	newState := v.updateWithNewPromise(apep.Promise)
+	aps.currentState[apep.ProviderID] = newState
+	log.Info().Msgf("Accountant promise state updated for provider %q", apep.ProviderID)
+
+	if newState.needsSettling(aps.config.Threshold) {
+		aps.settleQueue <- apep.ProviderID
+	}
+}
+
+func (aps *AccountantPromiseSettler) listenForSettlementRequests() {
+	log.Info().Msg("Listening for settlement events")
+	defer func() {
+		log.Info().Msg("Stopped listening for settlement events")
+	}()
+
+	for {
+		select {
+		case <-aps.stop:
+			return
+		case ID := <-aps.settleQueue:
+			aps.settle(ID)
+		}
+	}
+}
+
+func (aps *AccountantPromiseSettler) settle(ID identity.Identity) {
+	aps.setSettling(ID, true)
+	log.Info().Msgf("Marked provider %v as requesting setlement", ID)
+	sink, cancel, err := aps.bc.SubscribeToPromiseSettledEvent(ID.ToCommonAddress(), aps.config.AccountantAddress)
+	if err != nil {
+		aps.setSettling(ID, false)
+		log.Error().Err(err).Msg("Could not subscribe to promise settlement")
+	}
+	go func() {
+		defer cancel()
+		defer aps.setSettling(ID, false)
+		select {
+		case <-aps.stop:
+			return
+		case <-sink:
+			log.Info().Msgf("Settling complete for provider %v", ID)
+			err := aps.resyncState(ID)
+			if err != nil {
+				// This will get retried so we do not need to explicitly retry
+				// TODO: maybe add a sane limit of retries
+				log.Error().Err(err).Msgf("Resync failed for provider %v", ID)
+			} else {
+				log.Info().Msgf("Resync success for provider %v", ID)
+			}
+			return
+		case <-time.After(aps.config.MaxWaitForSettlement):
+			log.Info().Msgf("Settle timeout for %v", ID)
+			return
+		}
+	}()
+
+	// TODO: call transactor rebalance
+	// TODO: If transactor call fails, call cancel
+}
+
+func (aps *AccountantPromiseSettler) setSettling(id identity.Identity, settling bool) {
+	aps.lock.Lock()
+	defer aps.lock.Unlock()
+	v := aps.currentState[id]
+	v.settleInProgress = settling
+	aps.currentState[id] = v
+}
+
+func (aps *AccountantPromiseSettler) handleNodeStart() {
+	go aps.listenForSettlementRequests()
+
+	for _, v := range aps.ks.Accounts() {
+		addr := identity.FromAddress(v.Address.Hex())
+		go func(address identity.Identity) {
+			err := aps.loadInitialState(address)
+			if err != nil {
+				// TODO: should we retry? should we signal that we need to cancel and abort?
+				// In any case, if we start exceeding our balances, the accountant will let us know.
+				// Sessions will be aborted, node *should* stop, indicating something went wrong.
+				// On restart, a rebalance then should follow almost immediately.
+				// But we'll get punished for that, won't we?
+				log.Error().Err(err).Msgf("could not load initial state for %v", addr)
+			}
+		}(addr)
+	}
+}
+
+func (aps *AccountantPromiseSettler) handleNodeStop() {
+	aps.once.Do(func() {
+		close(aps.stop)
+	})
+}
+
+type providerChannelStatusProvider interface {
+	SubscribeToPromiseSettledEvent(providerID, accountantID common.Address) (sink chan *bindings.AccountantImplementationPromiseSettled, cancel func(), err error)
+	GetProviderChannel(accountantAddress common.Address, addressToCheck common.Address) (ProviderChannel, error)
+}
+
+type accountantPromiseGetter interface {
+	Get(providerID, accountantID identity.Identity) (crypto.Promise, error)
+}
+
+type state struct {
+	settleInProgress bool
+	balance          uint64
+	availableBalance uint64
+	registered       bool
+	lastPromise      crypto.Promise
+}
+
+func (s state) needsSettling(threshold float64) bool {
+	if !s.registered {
+		return false
+	}
+
+	if s.settleInProgress {
+		return false
+	}
+
+	if float64(s.balance) <= 0 {
+		return true
+	}
+
+	if float64(s.balance) <= threshold*float64(s.availableBalance) {
+		return true
+	}
+
+	return false
+}
+
+func (s state) updateWithNewPromise(promise crypto.Promise) state {
+	diff := promise.Amount - s.lastPromise.Amount
+	return state{
+		settleInProgress: s.settleInProgress,
+		balance:          s.balance - diff,
+		availableBalance: s.availableBalance,
+		registered:       s.registered,
+		lastPromise:      promise,
+	}
+}
+
+type ks interface {
+	Accounts() []accounts.Account
+}
+
+type registrationStatusProvider interface {
+	GetRegistrationStatus(id identity.Identity) (registry.RegistrationStatus, error)
+}

--- a/session/pingpong/accountant_promise_settler_test.go
+++ b/session/pingpong/accountant_promise_settler_test.go
@@ -1,0 +1,518 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pingpong
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/identity/registry"
+	"github.com/mysteriumnetwork/payments/bindings"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPromiseSettler_resyncState_returns_errors(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelReturnError: errMock,
+	}
+	mrsp := &mockRegistrationStatusProvider{}
+	mapg := &mockAccountantPromiseGetter{}
+	dir, err := ioutil.TempDir("", "testPromiseSettler_resyncState_returns_errors")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+	err = settler.resyncState(mockID)
+	assert.Equal(t, fmt.Sprintf("could not get provider channel for %v: %v", mockID, errMock.Error()), err.Error())
+
+	channelStatusProvider.channelReturnError = nil
+	mapg.err = errMock
+	err = settler.resyncState(mockID)
+	assert.Equal(t, fmt.Sprintf("could not get accountant promise for %v: %v", mockID, errMock.Error()), err.Error())
+}
+
+func TestPromiseSettler_resyncState_handles_no_promise(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: mockProviderChannel,
+	}
+	mrsp := &mockRegistrationStatusProvider{}
+	mapg := &mockAccountantPromiseGetter{
+		err: ErrNotFound,
+	}
+	dir, err := ioutil.TempDir("", "TestPromiseSettler_resyncState_handles_no_promise")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	id := identity.FromAddress("test")
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+	err = settler.resyncState(id)
+	assert.NoError(t, err)
+
+	v := settler.currentState[id]
+	expectedBalance := channelStatusProvider.channelToReturn.Balance.Uint64() + channelStatusProvider.channelToReturn.Settled.Uint64()
+	assert.Equal(t, expectedBalance, v.balance)
+	assert.Equal(t, expectedBalance, v.availableBalance)
+	assert.True(t, v.registered)
+}
+
+func TestPromiseSettler_resyncState_takes_promise_into_account(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: mockProviderChannel,
+	}
+	mrsp := &mockRegistrationStatusProvider{}
+	mapg := &mockAccountantPromiseGetter{
+		promise: crypto.Promise{
+			Amount: 7000000,
+		},
+	}
+	dir, err := ioutil.TempDir("", "TestPromiseSettler_resyncState_takes_promise_into_account")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+	err = settler.resyncState(mockID)
+	assert.NoError(t, err)
+
+	v := settler.currentState[mockID]
+	expectedBalance := channelStatusProvider.channelToReturn.Balance.Uint64() + channelStatusProvider.channelToReturn.Settled.Uint64() - mapg.promise.Amount
+	assert.Equal(t, expectedBalance, v.balance)
+	assert.Equal(t, channelStatusProvider.channelToReturn.Balance.Uint64()+channelStatusProvider.channelToReturn.Settled.Uint64(), v.availableBalance)
+	assert.True(t, v.registered)
+}
+
+func TestPromiseSettler_loadInitialState(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: mockProviderChannel,
+	}
+	mrsp := &mockRegistrationStatusProvider{
+		identities: map[identity.Identity]mockRegistrationStatus{
+			mockID: mockRegistrationStatus{
+				status: registry.RegisteredProvider,
+			},
+		},
+	}
+	mapg := &mockAccountantPromiseGetter{}
+	dir, err := ioutil.TempDir("", "TestPromiseSettler_loadInitialState")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+
+	settler.currentState[mockID] = state{}
+
+	// check if existing gets skipped
+	err = settler.loadInitialState(mockID)
+	assert.NoError(t, err)
+
+	v := settler.currentState[mockID]
+	assert.EqualValues(t, state{}, v)
+
+	// check if unregistered gets skipped
+	delete(settler.currentState, mockID)
+
+	mrsp.identities[mockID] = mockRegistrationStatus{
+		status: registry.RegisteredConsumer,
+	}
+
+	err = settler.loadInitialState(mockID)
+	assert.NoError(t, err)
+
+	v = settler.currentState[mockID]
+	assert.EqualValues(t, state{}, v)
+
+	// check if will resync
+	delete(settler.currentState, mockID)
+
+	mrsp.identities[mockID] = mockRegistrationStatus{
+		status: registry.RegisteredProvider,
+	}
+
+	err = settler.loadInitialState(mockID)
+	assert.NoError(t, err)
+
+	v = settler.currentState[mockID]
+	expectedBalance := channelStatusProvider.channelToReturn.Balance.Uint64() + channelStatusProvider.channelToReturn.Settled.Uint64() - mapg.promise.Amount
+	assert.Equal(t, expectedBalance, v.balance)
+	assert.Equal(t, channelStatusProvider.channelToReturn.Balance.Uint64()+channelStatusProvider.channelToReturn.Settled.Uint64(), v.availableBalance)
+	assert.True(t, v.registered)
+
+	// check if will bubble registration status errors
+	delete(settler.currentState, mockID)
+
+	mrsp.identities[mockID] = mockRegistrationStatus{
+		status: registry.RegisteredProvider,
+		err:    errMock,
+	}
+
+	err = settler.loadInitialState(mockID)
+	assert.Equal(t, fmt.Sprintf("could not check registration status for %v: %v", mockID, errMock.Error()), err.Error())
+}
+
+func TestPromiseSettler_handleServiceEvent(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: mockProviderChannel,
+	}
+	mrsp := &mockRegistrationStatusProvider{
+		identities: map[identity.Identity]mockRegistrationStatus{
+			mockID: mockRegistrationStatus{
+				status: registry.RegisteredProvider,
+			},
+		},
+	}
+	mapg := &mockAccountantPromiseGetter{}
+	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleServiceEvent")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+
+	statusesWithNoChangeExpected := []string{string(service.Starting), string(service.NotRunning)}
+
+	for _, v := range statusesWithNoChangeExpected {
+		settler.handleServiceEvent(service.EventPayload{
+			ProviderID: mockID.Address,
+			Status:     v,
+		})
+
+		_, ok := settler.currentState[mockID]
+
+		assert.False(t, ok)
+	}
+
+	settler.handleServiceEvent(service.EventPayload{
+		ProviderID: mockID.Address,
+		Status:     string(service.Running),
+	})
+
+	_, ok := settler.currentState[mockID]
+	assert.True(t, ok)
+}
+
+func TestPromiseSettler_handleRegistrationEvent(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: mockProviderChannel,
+	}
+	mrsp := &mockRegistrationStatusProvider{
+		identities: map[identity.Identity]mockRegistrationStatus{
+			mockID: mockRegistrationStatus{
+				status: registry.RegisteredProvider,
+			},
+		},
+	}
+	mapg := &mockAccountantPromiseGetter{}
+	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleRegistrationEvent")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+
+	statusesWithNoChangeExpected := []registry.RegistrationStatus{registry.RegisteredConsumer, registry.Unregistered, registry.InProgress, registry.Promoting, registry.RegistrationError}
+	for _, v := range statusesWithNoChangeExpected {
+		settler.handleRegistrationEvent(registry.RegistrationEventPayload{
+			ID:     mockID,
+			Status: v,
+		})
+
+		_, ok := settler.currentState[mockID]
+
+		assert.False(t, ok)
+	}
+
+	settler.handleRegistrationEvent(registry.RegistrationEventPayload{
+		ID:     mockID,
+		Status: registry.RegisteredProvider,
+	})
+
+	_, ok := settler.currentState[mockID]
+	assert.True(t, ok)
+}
+
+func TestPromiseSettler_handleAccountantPromiseReceived(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: mockProviderChannel,
+	}
+	mrsp := &mockRegistrationStatusProvider{
+		identities: map[identity.Identity]mockRegistrationStatus{
+			mockID: mockRegistrationStatus{
+				status: registry.RegisteredProvider,
+			},
+		},
+	}
+	mapg := &mockAccountantPromiseGetter{}
+	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleAccountantPromiseReceived")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	// no receive on unknown provider
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
+		ProviderID:   mockID,
+	})
+	assertNoReceive(t, settler.settleQueue)
+
+	// no receive should be gotten on a non registered provider
+	settler.currentState[mockID] = state{registered: false}
+	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
+		ProviderID:   mockID,
+	})
+	assertNoReceive(t, settler.settleQueue)
+
+	// should receive on registered provider. Should also expect a recalculated balance to be added to the state
+	settler.currentState[mockID] = state{
+		registered:       true,
+		balance:          13000000,
+		availableBalance: 1000000000,
+		lastPromise: crypto.Promise{
+			Amount: 100000,
+		},
+	}
+
+	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
+		ProviderID:   mockID,
+		Promise: crypto.Promise{
+			Amount: 110000,
+		},
+	})
+
+	assert.Equal(t, mockID, <-settler.settleQueue)
+
+	v := settler.currentState[mockID]
+	assert.Equal(t, uint64(13000000-10000), v.balance)
+
+	// should not receive here due to balance being large and stake being small
+	settler.currentState[mockID] = state{
+		registered:       true,
+		balance:          13000000,
+		availableBalance: 10,
+		lastPromise: crypto.Promise{
+			Amount: 100000,
+		},
+	}
+
+	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
+		ProviderID:   mockID,
+		Promise: crypto.Promise{
+			Amount: 110000,
+		},
+	})
+	assertNoReceive(t, settler.settleQueue)
+}
+
+func assertNoReceive(t *testing.T, ch chan identity.Identity) {
+	// at this point, we should not receive an event on settled queue as we have no info on provider, let's check for that
+	select {
+	case <-ch:
+		assert.Fail(t, "did not expect to receive from settled queue")
+	case <-time.After(time.Millisecond * 2):
+		// we've not received on the channel, continue
+	}
+}
+
+func TestPromiseSettler_handleNodeStart(t *testing.T) {
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: mockProviderChannel,
+	}
+
+	mapg := &mockAccountantPromiseGetter{}
+	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleAccountantPromiseReceived")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+	acc1, err := ks.NewAccount("")
+	assert.NoError(t, err)
+	acc2, err := ks.NewAccount("")
+	assert.NoError(t, err)
+
+	mrsp := &mockRegistrationStatusProvider{
+		identities: map[identity.Identity]mockRegistrationStatus{
+			identity.FromAddress(acc2.Address.Hex()): mockRegistrationStatus{
+				status: registry.RegisteredProvider,
+			},
+			identity.FromAddress(acc1.Address.Hex()): mockRegistrationStatus{
+				status: registry.RegisteredConsumer,
+			},
+		},
+	}
+
+	settler := NewAccountantPromiseSettler(channelStatusProvider, mrsp, ks, mapg, cfg)
+
+	settler.handleNodeStart()
+
+	// since each address is checked on BC in background, we'll need to wait here until that is complete
+	time.Sleep(time.Millisecond * 10)
+
+	assert.True(t, settler.currentState[identity.FromAddress(acc2.Address.Hex())].registered)
+	assert.False(t, settler.currentState[identity.FromAddress(acc1.Address.Hex())].registered)
+}
+
+func TestPromiseSettlerState_needsSettling(t *testing.T) {
+	s := state{
+		balance:          0,
+		availableBalance: 100,
+		registered:       true,
+	}
+
+	// should be true with zero balance left
+	assert.True(t, s.needsSettling(0.1))
+
+	s = state{
+		balance:          1000,
+		availableBalance: 10000,
+		registered:       true,
+	}
+
+	// should be true with 10% missing
+	assert.True(t, s.needsSettling(0.1))
+
+	s = state{
+		balance:          1001,
+		availableBalance: 10000,
+		registered:       true,
+	}
+
+	// should be false with 10.01% missing
+	assert.False(t, s.needsSettling(0.1))
+
+	s = state{
+		balance:          1001,
+		availableBalance: 10,
+		settleInProgress: true,
+		registered:       true,
+	}
+
+	// should be false with settle in progress
+	assert.False(t, s.needsSettling(0.1))
+	s = state{
+		balance:          1001,
+		availableBalance: 10,
+	}
+
+	// should be false with no registration
+	assert.False(t, s.needsSettling(0.1))
+}
+
+func TestPromiseSettlerState_updateWithNewPromise(t *testing.T) {
+	s := state{
+		balance:          100,
+		availableBalance: 100,
+		registered:       true,
+		lastPromise: crypto.Promise{
+			Amount: 15,
+		},
+	}
+	s = s.updateWithNewPromise(crypto.Promise{Amount: 15})
+	assert.Equal(t, uint64(100), s.balance)
+
+	s = state{
+		balance:          100,
+		availableBalance: 100,
+		registered:       true,
+		lastPromise: crypto.Promise{
+			Amount: 10,
+		},
+	}
+	s = s.updateWithNewPromise(crypto.Promise{Amount: 15})
+	assert.Equal(t, uint64(95), s.balance)
+}
+
+// mocks start here
+type mockProviderChannelStatusProvider struct {
+	channelToReturn    ProviderChannel
+	channelReturnError error
+	sinkToReturn       chan *bindings.AccountantImplementationPromiseSettled
+	subCancel          func()
+	subError           error
+}
+
+func (mpcsp *mockProviderChannelStatusProvider) SubscribeToPromiseSettledEvent(providerID, accountantID common.Address) (sink chan *bindings.AccountantImplementationPromiseSettled, cancel func(), err error) {
+	return mpcsp.sinkToReturn, mpcsp.subCancel, mpcsp.subError
+}
+
+func (mpcsp *mockProviderChannelStatusProvider) GetProviderChannel(accountantAddress common.Address, addressToCheck common.Address) (ProviderChannel, error) {
+	return mpcsp.channelToReturn, mpcsp.channelReturnError
+}
+
+var cfg = AccountantPromiseSettlerConfig{
+	AccountantAddress:    common.HexToAddress("0x9a8B6d979e188fA3DeAa93A470C3537362FdaE92"),
+	Threshold:            0.1,
+	MaxWaitForSettlement: time.Millisecond * 10,
+}
+
+type mockAccountantPromiseGetter struct {
+	promise crypto.Promise
+	err     error
+}
+
+func (mapg *mockAccountantPromiseGetter) Get(providerID, accountantID identity.Identity) (crypto.Promise, error) {
+	return mapg.promise, mapg.err
+}
+
+type mockRegistrationStatus struct {
+	status registry.RegistrationStatus
+	err    error
+}
+
+type mockRegistrationStatusProvider struct {
+	identities map[identity.Identity]mockRegistrationStatus
+}
+
+func (mrsp *mockRegistrationStatusProvider) GetRegistrationStatus(id identity.Identity) (registry.RegistrationStatus, error) {
+	if v, ok := mrsp.identities[id]; ok {
+		return v.status, v.err
+	}
+
+	return registry.Unregistered, nil
+}
+
+var errMock = errors.New("explosions everywhere")
+var mockID = identity.FromAddress("test")
+
+var mockProviderChannel = ProviderChannel{
+	Balance: big.NewInt(1000000000000),
+	Settled: big.NewInt(9000000),
+	Loan:    big.NewInt(12312323),
+}

--- a/session/pingpong/accountant_promise_storage_test.go
+++ b/session/pingpong/accountant_promise_storage_test.go
@@ -47,6 +47,7 @@ func TestAccountantPromiseStorage(t *testing.T) {
 
 	accountantStorage := NewAccountantPromiseStorage(bolt)
 
+	id := identity.FromAddress("0x44440954558C5bFA0D4153B0002B1d1E3E3f5Ff5")
 	firstAccountant := identity.FromAddress(acc.Address.Hex())
 	firstPromise, err := crypto.CreatePromise("0x30960954558C5bFA0D4153B0002B1d1E3E3f5Ff5", 1, 1, "0xD87C7cF5FF5FDb85988c9AFEf52Ce00A7112eC2e", ks, acc.Address)
 	assert.NoError(t, err)
@@ -55,22 +56,22 @@ func TestAccountantPromiseStorage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check if errors are wrapped correctly
-	_, err = accountantStorage.Get(firstAccountant)
+	_, err = accountantStorage.Get(id, firstAccountant)
 	assert.Equal(t, ErrNotFound, err)
 
 	// store and check that promise is stored correctly
-	err = accountantStorage.Store(firstAccountant, *firstPromise)
+	err = accountantStorage.Store(id, firstAccountant, *firstPromise)
 	assert.NoError(t, err)
 
-	promise, err := accountantStorage.Get(firstAccountant)
+	promise, err := accountantStorage.Get(id, firstAccountant)
 	assert.NoError(t, err)
 	assert.EqualValues(t, *firstPromise, promise)
 
 	// overwrite the promise, check if it is overwritten
-	err = accountantStorage.Store(firstAccountant, *secondPromise)
+	err = accountantStorage.Store(id, firstAccountant, *secondPromise)
 	assert.NoError(t, err)
 
-	promise, err = accountantStorage.Get(firstAccountant)
+	promise, err = accountantStorage.Get(id, firstAccountant)
 	assert.NoError(t, err)
 	assert.EqualValues(t, *secondPromise, promise)
 
@@ -83,14 +84,14 @@ func TestAccountantPromiseStorage(t *testing.T) {
 
 	secondAccountant := identity.FromAddress(account2.Address.Hex())
 
-	err = accountantStorage.Store(secondAccountant, *firstPromise)
+	err = accountantStorage.Store(id, secondAccountant, *firstPromise)
 	assert.NoError(t, err)
 
-	promise, err = accountantStorage.Get(firstAccountant)
+	promise, err = accountantStorage.Get(id, firstAccountant)
 	assert.NoError(t, err)
 	assert.EqualValues(t, *secondPromise, promise)
 
-	promise, err = accountantStorage.Get(secondAccountant)
+	promise, err = accountantStorage.Get(id, secondAccountant)
 	assert.NoError(t, err)
 	assert.EqualValues(t, *firstPromise, promise)
 }

--- a/session/pingpong/event.go
+++ b/session/pingpong/event.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2018 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,14 +15,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package node
+package pingpong
 
-import "time"
+import (
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/payments/crypto"
+)
 
-// OptionsPayments controls the behaviour of payments
-type OptionsPayments struct {
-	MaxAllowedPaymentPercentile        int
-	BCTimeout                          time.Duration
-	AccountantPromiseSettlingThreshold float64
-	SettlementTimeout                  time.Duration
+// AccountantPromiseTopic represents a topic to which we send accountant promise events.
+const AccountantPromiseTopic = "accountant_promise_received"
+
+// AccountantPromiseEventPayload represents the payload that is sent on the AccountantPromiseTopic.
+type AccountantPromiseEventPayload struct {
+	Promise      crypto.Promise
+	AccountantID identity.Identity
+	ProviderID   identity.Identity
 }

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/node"
+	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/services/openvpn/discovery/dto"
@@ -57,6 +58,7 @@ func InvoiceFactoryCreator(
 	maxAccountantFailureCount uint64,
 	maxAllowedAccountantFee uint16,
 	blockchainHelper bcHelper,
+	publisher eventbus.Publisher,
 ) func(identity.Identity, identity.Identity) (session.PaymentEngine, error) {
 	return func(providerID identity.Identity, accountantID identity.Identity) (session.PaymentEngine, error) {
 		exchangeChan := make(chan crypto.ExchangeMessage, 1)
@@ -85,6 +87,7 @@ func InvoiceFactoryCreator(
 			MaxAccountantFailureCount:  maxAccountantFailureCount,
 			MaxAllowedAccountantFee:    maxAllowedAccountantFee,
 			BlockchainHelper:           blockchainHelper,
+			Publisher:                  publisher,
 		}
 		paymentEngine := NewInvoiceTracker(deps)
 		return paymentEngine, nil


### PR DESCRIPTION
Initial implementation of the accountant promise settling.

The promise settler is launched on node start.
Once launched, it checks the local keystore for addresses.
For each address, it keeps a state in memory. The state is loaded from BC and local DB.
The state stores the current balance information as well as registration status for the provider.

It also listens for service start events, and performs the steps mentioned above if a new identity is used for service start.

It is also listening for events that are emitted once a new accountant promise is emitted. These events cause the internal state to be updated with the latest promise.
After the mentioned state update a check is performed. If the current balance is less than the threshold * available balance it indicates it's time to settle the promise.

The settle part is missing still, as the transactor is missing the relevant endpoint.

Updates #1413