### PR TITLE
Use forked vend for ppa build

### DIFF
--- a/bin/release_ppa
+++ b/bin/release_ppa
@@ -35,7 +35,7 @@ if [ -z "$DISTR" ]; then
 fi
 
 if ! [ -x "$(command -v vend)" ]; then
-    go get github.com/nomad-software/vend
+    go get github.com/mysteriumnetwork/vend
 fi
 
 vend


### PR DESCRIPTION
PPA builds started failing because in #1410 I missed that PPA build uses vend tool, too.