### PR TITLE
Vend replace wireguard with mn/wireguard-go

### DIFF
--- a/bin/release_ppa
+++ b/bin/release_ppa
@@ -38,7 +38,7 @@ if ! [ -x "$(command -v vend)" ]; then
     go get github.com/mysteriumnetwork/vend
 fi
 
-vend
+vend -replace golang.zx2c4.com/wireguard=github.com/mysteriumnetwork/wireguard-go
 
 DATE=`date -R`
 


### PR DESCRIPTION
Add missing replace flag for vend that emulates `replace` directive in go.mod