### PR TITLE
Myst install through install.sh for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Currently node supports OpenVPN as its underlying VPN transport.
 
 Install latest stable release:
 ```bash
-curl https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh | sudo bash
+sudo bash <(curl -s https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh) 
 ```
 
 Or install latest snapshot (development build):
 ```bash
-curl https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh | SNAPSHOT=true sudo -E bash
+SNAPSHOT=true sudo -E bash <(curl -s https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh) 
 ```
 
 Service logs:

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Currently node supports OpenVPN as its underlying VPN transport.
 
 Install latest stable release:
 ```bash
-sudo bash <(curl -s https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh) 
+sudo -E bash -c "$(curl -s https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh)" 
 ```
 
 Or install latest snapshot (development build):
 ```bash
-SNAPSHOT=true sudo -E bash <(curl -s https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh) 
+SNAPSHOT=true sudo -E bash -c "$(curl -s https://raw.githubusercontent.com/mysteriumnetwork/node/master/install.sh)" 
 ```
 
 Service logs:
@@ -42,6 +42,8 @@ Service status:
 ```bash
 sudo systemctl status mysterium-node.service
 ```
+
+Installation script tested on these OSes so far: _Raspbian 10_, _Debian 9_, _Debian 10_, _Ubuntu 18.04_ and _Ubuntu 16.04_ .
 
 ### Docker
 

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
 shopt -s extglob
+set -e
 set -o errtrace
 set -o errexit
 set -o pipefail
 
-# Install latest release of myst for debian/raspbian
+# Install latest release of myst for debian/ubuntu/raspbian
 #
 # Variables:
 # - SNAPSHOT (default: false) - set to "true" to install development snapshot
 #
-
-# set -e
 
 if [[ "$SNAPSHOT" == "true" ]]; then
     releases_url="http://api.github.com/repos/mysteriumnetwork/node-builds/releases"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+shopt -s extglob
+set -o errtrace
+set -o errexit
+set -o pipefail
 
 # Install latest release of myst for debian/raspbian
 #
@@ -6,7 +11,7 @@
 # - SNAPSHOT (default: false) - set to "true" to install development snapshot
 #
 
-set -e
+# set -e
 
 if [[ "$SNAPSHOT" == "true" ]]; then
     releases_url="http://api.github.com/repos/mysteriumnetwork/node-builds/releases"


### PR DESCRIPTION
16.04, 18.04, debian 9 and debian 10 install supported through script.
