### PR TITLE
Reuse requests Client to close idle connections by timeout

### DIFF
--- a/tequilapi/client/http_client.go
+++ b/tequilapi/client/http_client.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/mysteriumnetwork/node/requests"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -43,10 +44,7 @@ type httpRequestInterface interface {
 
 func newHTTPClient(baseURL string, ua string) *httpClient {
 	return &httpClient{
-		http: &http.Client{
-			Transport: &http.Transport{},
-			Timeout:   100 * time.Second,
-		},
+		http:    requests.NewHTTPClient("0.0.0.0", 100*time.Second),
 		baseURL: baseURL,
 		ua:      ua,
 	}


### PR DESCRIPTION
TequilAPI client was never closing the idle connection.
Now it will use requests Client with sanity configuration for closing connections.

Sometimes a number of opened connections could grow dramatically:
![image](https://user-images.githubusercontent.com/8612618/71610504-c2232180-2ba2-11ea-91e5-b9ebb7183096.png)

```
goroutine profile: total 137
54 @ 0x4033030 0x4042abb 0x4314623 0x4061351
#	0x4314622	net/http.(*persistConn).writeLoop+0x122	/usr/local/Cellar/go/1.13.4/libexec/src/net/http/transport.go:2204
53 @ 0x4033030 0x402de9a 0x402d465 0x40ce305 0x40cf2db 0x40cf2bd 0x41be97f 0x41d2e68 0x4311ed5 0x4168be3 0x4168d4f 0x4312b86 0x4061351
#	0x402d464	internal/poll.runtime_pollWait+0x54		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/netpoll.go:184
#	0x40ce304	internal/poll.(*pollDesc).wait+0x44		/usr/local/Cellar/go/1.13.4/libexec/src/internal/poll/fd_poll_runtime.go:87
#	0x40cf2da	internal/poll.(*pollDesc).waitRead+0x22a	/usr/local/Cellar/go/1.13.4/libexec/src/internal/poll/fd_poll_runtime.go:92
#	0x40cf2bc	internal/poll.(*FD).Read+0x20c			/usr/local/Cellar/go/1.13.4/libexec/src/internal/poll/fd_unix.go:169
#	0x41be97e	net.(*netFD).Read+0x4e				/usr/local/Cellar/go/1.13.4/libexec/src/net/fd_unix.go:202
#	0x41d2e67	net.(*conn).Read+0x67				/usr/local/Cellar/go/1.13.4/libexec/src/net/net.go:184
#	0x4311ed4	net/http.(*persistConn).Read+0x74		/usr/local/Cellar/go/1.13.4/libexec/src/net/http/transport.go:1752
#	0x4168be2	bufio.(*Reader).fill+0x102			/usr/local/Cellar/go/1.13.4/libexec/src/bufio/bufio.go:100
#	0x4168d4e	bufio.(*Reader).Peek+0x4e			/usr/local/Cellar/go/1.13.4/libexec/src/bufio/bufio.go:138
#	0x4312b85	net/http.(*persistConn).readLoop+0x1d5		/usr/local/Cellar/go/1.13.4/libexec/src/net/http/transport.go:1905
```