### PR TITLE
Use upstream WireGuard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/mysteriumnetwork/node
 
 go 1.13
 
-replace golang.zx2c4.com/wireguard => github.com/mysteriumnetwork/wireguard-go v0.0.0-20191114114228-1a3c4386eb23
-
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DataDog/zstd v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,6 @@ github.com/mysteriumnetwork/metrics v0.0.0-20191002053948-084a00d6c6b2 h1:+MzoNo
 github.com/mysteriumnetwork/metrics v0.0.0-20191002053948-084a00d6c6b2/go.mod h1:QI+154TA1KKdrSYAWpr50FP6AzHsbT3wJvFD5kSEQVE=
 github.com/mysteriumnetwork/payments v0.0.11-0.20191120103343-ed922e3051db h1:OfCcf9GtFBAhTmet4yTnuF0ktdFBmPMq+kbgSUEEQHo=
 github.com/mysteriumnetwork/payments v0.0.11-0.20191120103343-ed922e3051db/go.mod h1:khz9e+0ipI8uVAEBhTdSrvo5ByYcdkWtioqkj14Pf7Q=
-github.com/mysteriumnetwork/wireguard-go v0.0.0-20191114114228-1a3c4386eb23 h1:fJGV0dFrt4+7d3y4e50xoRVOuZygnxkUhBeMXAfBlkI=
-github.com/mysteriumnetwork/wireguard-go v0.0.0-20191114114228-1a3c4386eb23/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
 github.com/nats-io/gnatsd v1.4.1 h1:RconcfDeWpKCD6QIIwiVFcvForlXpWeJP7i5/lDLy44=
 github.com/nats-io/gnatsd v1.4.1/go.mod h1:nqco77VO78hLCJpIcVfygDP2rPGfsEHkGTUk94uh5DQ=
 github.com/nats-io/go-nats v1.4.0 h1:HorYtzWLSxkmcEzAFmY6vJ20lFfeAPbrnkoAYgk8GSg=
@@ -751,6 +749,8 @@ golang.org/x/tools v0.0.0-20190911022129-16c5e0f7d110/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190916130336-e45ffcd953cc h1:+GB9/q0gCzmtaIl6WdoJFMS3lPwrR6rpcMyY6jfQHAw=
 golang.org/x/tools v0.0.0-20190916130336-e45ffcd953cc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.zx2c4.com/wireguard v0.0.20191012 h1:sdX+y3hrHkW8KJkjY7ZgzpT5Tqo8XnBkH55U1klphko=
+golang.zx2c4.com/wireguard v0.0.20191012/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20190515223858-5ec88494b814 h1:uNqb91RyXmeqAhh0vWc9583TQ0OaT3dvPxGxd3z/8iU=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20190515223858-5ec88494b814/go.mod h1:eJQAcrbllkYZEGZuBNQx0NsUz9y7j01OG3bgxUev834=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/mobile/mysterium/fd_android.go
+++ b/mobile/mysterium/fd_android.go
@@ -1,4 +1,4 @@
-// +build linux android
+// +build android
 /*
  * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
  *

--- a/mobile/mysterium/fd_android.go
+++ b/mobile/mysterium/fd_android.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysterium
+
+import "golang.zx2c4.com/wireguard/device"
+
+func peekLookAtSocketFd4(d *device.Device) (fd int, err error) {
+	return d.PeekLookAtSocketFd4()
+}

--- a/mobile/mysterium/fd_default.go
+++ b/mobile/mysterium/fd_default.go
@@ -1,0 +1,30 @@
+// +build !linux
+
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysterium
+
+import (
+	"errors"
+
+	"golang.zx2c4.com/wireguard/device"
+)
+
+func peekLookAtSocketFd4(d *device.Device) (fd int, err error) {
+	return 0, errors.New("not implemented")
+}

--- a/mobile/mysterium/fd_default.go
+++ b/mobile/mysterium/fd_default.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !android
 
 /*
  * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.

--- a/mobile/mysterium/fd_linux.go
+++ b/mobile/mysterium/fd_linux.go
@@ -1,3 +1,4 @@
+// +build linux android
 /*
  * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
  *

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -84,7 +84,11 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 		return errors.Wrap(err, "failed to start connection endpoint")
 	}
 
-	if err := c.connectionEndpoint.AddPeer(c.config.Provider.PublicKey, &c.config.Provider.Endpoint); err != nil {
+	peerInfo := wg.AddPeerOptions{
+		Endpoint:  &c.config.Provider.Endpoint,
+		PublicKey: c.config.Provider.PublicKey,
+	}
+	if err := c.connectionEndpoint.AddPeer(c.connectionEndpoint.InterfaceName(), peerInfo); err != nil {
 		c.stateChannel <- connection.NotConnected
 		c.connection.Done()
 		removeAllowedIPRule()

--- a/services/wireguard/device_parser.go
+++ b/services/wireguard/device_parser.go
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package wireguard
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// UserspaceDevice is a WireGuard device.
+type UserspaceDevice struct {
+	// ListenPort is the device's network listening port.
+	ListenPort int
+
+	// FirewallMark is the device's current firewall mark.
+	//
+	// The firewall mark can be used in conjunction with firewall software to
+	// take action on outgoing WireGuard packets.
+	FirewallMark int
+
+	// Peers is the list of network peers associated with this device.
+	Peers []UserspaceDevicePeer
+}
+
+// UserspaceDevicePeer is a WireGuard peer to a Device.
+type UserspaceDevicePeer struct {
+	// PublicKey is the public key of a peer, computed from its private key.
+	//
+	// PublicKey is always present in a Peer.
+	PublicKey string
+
+	// Endpoint is the most recent source address used for communication by
+	// this Peer.
+	Endpoint *net.UDPAddr
+
+	// PersistentKeepaliveInterval specifies how often an "empty" packet is sent
+	// to a peer to keep a connection alive.
+	//
+	// A value of 0 indicates that persistent keepalives are disabled.
+	PersistentKeepaliveInterval time.Duration
+
+	// LastHandshakeTime indicates the most recent time a handshake was performed
+	// with this peer.
+	//
+	// A zero-value time.Time indicates that no handshake has taken place with
+	// this peer.
+	LastHandshakeTime time.Time
+
+	// ReceiveBytes indicates the number of bytes received from this peer.
+	ReceiveBytes int64
+
+	// TransmitBytes indicates the number of bytes transmitted to this peer.
+	TransmitBytes int64
+
+	// AllowedIPs specifies which IPv4 and IPv6 addresses this peer is allowed
+	// to communicate on.
+	//
+	// 0.0.0.0/0 indicates that all IPv4 addresses are allowed, and ::/0
+	// indicates that all IPv6 addresses are allowed.
+	AllowedIPs []net.IPNet
+
+	// ProtocolVersion specifies which version of the WireGuard protocol is used
+	// for this Peer.
+	//
+	// A value of 0 indicates that the most recent protocol version will be used.
+	ProtocolVersion int
+}
+
+// ParseUserspaceDevice parses WireGuard device state buffer.
+func ParseUserspaceDevice(ipcGetOp func(w *bufio.Writer) *device.IPCError) (*UserspaceDevice, error) {
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+	if err := ipcGetOp(writer); err != nil {
+		return nil, err
+	}
+	if err := writer.Flush(); err != nil {
+		return nil, err
+	}
+
+	var dp deviceParser
+	s := bufio.NewScanner(&buf)
+	for s.Scan() {
+		b := s.Bytes()
+		if len(b) == 0 {
+			// Empty line, done parsing.
+			break
+		}
+
+		// All data is in key=value format.
+		kvs := bytes.Split(b, []byte("="))
+		if len(kvs) != 2 {
+			return nil, fmt.Errorf("invalid key=value pair: %q", string(b))
+		}
+
+		dp.Parse(string(kvs[0]), string(kvs[1]))
+	}
+
+	if dp.err != nil {
+		return nil, dp.err
+	}
+	return &dp.d, nil
+}
+
+// A deviceParser accumulates information about a Device and its Peers. Adapted from
+// https://github.com/WireGuard/wgctrl-go/blob/master/internal/wguser/parse.go.
+type deviceParser struct {
+	d   UserspaceDevice
+	err error
+
+	parsePeers    bool
+	peers         int
+	hsSec, hsNano int
+}
+
+// Parse parses a single key/value pair into fields of a Device.
+func (dp *deviceParser) Parse(key, value string) {
+	switch key {
+	case "errno":
+		// 0 indicates success, anything else returns an error number that matches
+		// definitions from errno.h.
+		if errno := dp.parseInt(value); errno != 0 {
+			dp.err = os.NewSyscallError("read", fmt.Errorf("wguser: errno=%d", errno))
+			return
+		}
+	case "public_key":
+		// We've either found the first peer or the next peer.  Stop parsing
+		// Device fields and start parsing Peer fields, including the public
+		// key indicated here.
+		dp.parsePeers = true
+		dp.peers++
+
+		dp.d.Peers = append(dp.d.Peers, UserspaceDevicePeer{
+			PublicKey: dp.parseKey(value),
+		})
+		return
+	}
+
+	// Are we parsing peer fields?
+	if dp.parsePeers {
+		dp.peerParse(key, value)
+		return
+	}
+
+	// Device field parsing.
+	switch key {
+	case "listen_port":
+		dp.d.ListenPort = dp.parseInt(value)
+	case "fwmark":
+		dp.d.FirewallMark = dp.parseInt(value)
+	}
+}
+
+// curPeer returns the current Peer being parsed so its fields can be populated.
+func (dp *deviceParser) curPeer() *UserspaceDevicePeer {
+	return &dp.d.Peers[dp.peers-1]
+}
+
+// peerParse parses a key/value field into the current Peer.
+func (dp *deviceParser) peerParse(key, value string) {
+	p := dp.curPeer()
+	switch key {
+	case "endpoint":
+		p.Endpoint = dp.parseAddr(value)
+	case "last_handshake_time_sec":
+		dp.hsSec = dp.parseInt(value)
+	case "last_handshake_time_nsec":
+		dp.hsNano = dp.parseInt(value)
+
+		// Assume that we've seen both seconds and nanoseconds and populate this
+		// field now. However, if both fields were set to 0, assume we have never
+		// had a successful handshake with this peer, and return a zero-value
+		// time.Time to our callers.
+		if dp.hsSec > 0 && dp.hsNano > 0 {
+			p.LastHandshakeTime = time.Unix(int64(dp.hsSec), int64(dp.hsNano))
+		}
+	case "tx_bytes":
+		p.TransmitBytes = dp.parseInt64(value)
+	case "rx_bytes":
+		p.ReceiveBytes = dp.parseInt64(value)
+	case "persistent_keepalive_interval":
+		p.PersistentKeepaliveInterval = time.Duration(dp.parseInt(value)) * time.Second
+	case "allowed_ip":
+		cidr := dp.parseCIDR(value)
+		if cidr != nil {
+			p.AllowedIPs = append(p.AllowedIPs, *cidr)
+		}
+	case "protocol_version":
+		p.ProtocolVersion = dp.parseInt(value)
+	}
+}
+
+// parseKey parses a Key from a hex string.
+func (dp *deviceParser) parseKey(s string) string {
+	if dp.err != nil {
+		return ""
+	}
+
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		dp.err = err
+		return ""
+	}
+
+	key, err := wgtypes.NewKey(b)
+	if err != nil {
+		dp.err = err
+		return ""
+	}
+
+	return key.String()
+}
+
+// parseInt parses an integer from a string.
+func (dp *deviceParser) parseInt(s string) int {
+	if dp.err != nil {
+		return 0
+	}
+
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		dp.err = err
+		return 0
+	}
+
+	return v
+}
+
+// parseInt64 parses an int64 from a string.
+func (dp *deviceParser) parseInt64(s string) int64 {
+	if dp.err != nil {
+		return 0
+	}
+
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		dp.err = err
+		return 0
+	}
+
+	return v
+}
+
+// parseAddr parses a UDP address from a string.
+func (dp *deviceParser) parseAddr(s string) *net.UDPAddr {
+	if dp.err != nil {
+		return nil
+	}
+
+	addr, err := net.ResolveUDPAddr("udp", s)
+	if err != nil {
+		dp.err = err
+		return nil
+	}
+
+	return addr
+}
+
+// parseInt parses an address CIDR from a string.
+func (dp *deviceParser) parseCIDR(s string) *net.IPNet {
+	if dp.err != nil {
+		return nil
+	}
+
+	_, cidr, err := net.ParseCIDR(s)
+	if err != nil {
+		dp.err = err
+		return nil
+	}
+
+	return cidr
+}

--- a/services/wireguard/device_parser_test.go
+++ b/services/wireguard/device_parser_test.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package wireguard
+
+import (
+	"bufio"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.zx2c4.com/wireguard/device"
+)
+
+// Example string source (with some slight modifications to use all fields):
+// https://www.wireguard.com/xplatform/#example-dialog.
+const okGet = `private_key=e84b5a6d2717c1003a13b431570353dbaca9146cf150c5f8575680feba52027a
+listen_port=12912
+fwmark=1
+public_key=b85996fecc9c7f1fc6d2572a76eda11d59bcd20be8e543b15ce4bd85a8e75a33
+preshared_key=188515093e952f5f22e865cef3012e72f8b5f0b598ac0309d5dacce3b70fcf52
+allowed_ip=192.168.4.4/32
+endpoint=[abcd:23::33%2]:51820
+last_handshake_time_sec=1
+last_handshake_time_nsec=2
+public_key=58402e695ba1772b1cc9309755f043251ea77fdcf10fbe63989ceb7e19321376
+tx_bytes=38333
+rx_bytes=2224
+allowed_ip=192.168.4.6/32
+persistent_keepalive_interval=111
+endpoint=182.122.22.19:3233
+last_handshake_time_sec=0
+last_handshake_time_nsec=0
+public_key=662e14fd594556f522604703340351258903b64f35553763f19426ab2a515c58
+endpoint=5.152.198.39:51820
+last_handshake_time_sec=0
+last_handshake_time_nsec=0
+allowed_ip=192.168.4.10/32
+allowed_ip=192.168.4.11/32
+tx_bytes=1212111
+rx_bytes=1929999999
+protocol_version=1
+errno=0
+
+`
+
+func TestParseDevice(t *testing.T) {
+	// Used to trigger "parse peers" mode easily.
+	const okKey = "public_key=0000000000000000000000000000000000000000000000000000000000000000\n"
+
+	tests := []struct {
+		name string
+		res  []byte
+		ok   bool
+		d    *UserspaceDevice
+	}{
+		{
+			name: "invalid key=value",
+			res:  []byte("foo=bar=baz"),
+		},
+		{
+			name: "invalid public_key",
+			res:  []byte("public_key=xxx"),
+		},
+		{
+			name: "short public_key",
+			res:  []byte("public_key=abcd"),
+		},
+		{
+			name: "invalid fwmark",
+			res:  []byte("fwmark=foo"),
+		},
+		{
+			name: "invalid endpoint",
+			res:  []byte(okKey + "endpoint=foo"),
+		},
+		{
+			name: "invalid allowed_ip",
+			res:  []byte(okKey + "allowed_ip=foo"),
+		},
+		{
+			name: "error",
+			res:  []byte("errno=2\n\n"),
+		},
+		{
+			name: "ok",
+			res:  []byte(okGet),
+			ok:   true,
+			d: &UserspaceDevice{
+				ListenPort:   12912,
+				FirewallMark: 1,
+				Peers: []UserspaceDevicePeer{
+					{
+						PublicKey: "uFmW/sycfx/G0lcqdu2hHVm80gvo5UOxXOS9hajnWjM=",
+						Endpoint: &net.UDPAddr{
+							IP:   net.ParseIP("abcd:23::33"),
+							Port: 51820,
+							Zone: "2",
+						},
+						LastHandshakeTime: time.Unix(1, 2),
+						AllowedIPs: []net.IPNet{
+							{
+								IP:   net.IP{0xc0, 0xa8, 0x4, 0x4},
+								Mask: net.IPMask{0xff, 0xff, 0xff, 0xff},
+							},
+						},
+					},
+					{
+						PublicKey: "WEAuaVuhdyscyTCXVfBDJR6nf9zxD75jmJzrfhkyE3Y=",
+						Endpoint: &net.UDPAddr{
+							IP:   net.IPv4(182, 122, 22, 19),
+							Port: 3233,
+						},
+						// Zero-value because UNIX timestamp of 0. Explicitly
+						// set for documentation purposes here.
+						LastHandshakeTime:           time.Time{},
+						PersistentKeepaliveInterval: 111000000000,
+						ReceiveBytes:                2224,
+						TransmitBytes:               38333,
+						AllowedIPs: []net.IPNet{
+							{
+								IP:   net.IP{0xc0, 0xa8, 0x4, 0x6},
+								Mask: net.IPMask{0xff, 0xff, 0xff, 0xff},
+							},
+						},
+					},
+					{
+						PublicKey: "Zi4U/VlFVvUiYEcDNANRJYkDtk81VTdj8ZQmqypRXFg=",
+						Endpoint: &net.UDPAddr{
+							IP:   net.IPv4(5, 152, 198, 39),
+							Port: 51820,
+						},
+						ReceiveBytes:  1929999999,
+						TransmitBytes: 1212111,
+						AllowedIPs: []net.IPNet{
+							{
+								IP:   net.IP{0xc0, 0xa8, 0x4, 0xa},
+								Mask: net.IPMask{0xff, 0xff, 0xff, 0xff},
+							},
+							{
+								IP:   net.IP{0xc0, 0xa8, 0x4, 0xb},
+								Mask: net.IPMask{0xff, 0xff, 0xff, 0xff},
+							},
+						},
+						ProtocolVersion: 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := ParseUserspaceDevice(func(w *bufio.Writer) *device.IPCError {
+				_, _ = w.Write(tt.res)
+				return nil
+			})
+
+			if tt.ok && err != nil {
+				t.Fatalf("failed to get devices: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Fatal("expected an error, but none occurred")
+			}
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, tt.d, d)
+		})
+	}
+}

--- a/services/wireguard/endpoint/userspace/client.go
+++ b/services/wireguard/endpoint/userspace/client.go
@@ -18,9 +18,11 @@
 package userspace
 
 import (
+	"bufio"
 	"encoding/base64"
+	"fmt"
 	"net"
-	"time"
+	"strings"
 
 	wg "github.com/mysteriumnetwork/node/services/wireguard"
 	"github.com/pkg/errors"
@@ -30,7 +32,7 @@ import (
 
 type client struct {
 	tun    tun.Device
-	devAPI *device.DeviceApi
+	devAPI *device.Device
 }
 
 // NewWireguardClient creates new wireguard user space client.
@@ -43,47 +45,23 @@ func (c *client) ConfigureDevice(name string, config wg.DeviceConfig, subnet net
 		return errors.Wrap(err, "failed to create TUN device")
 	}
 
-	c.devAPI = device.UserspaceDeviceApi(c.tun)
-	if err := c.devAPI.SetListeningPort(uint16(config.ListenPort())); err != nil {
-		return errors.Wrap(err, "failed to set listening port")
+	c.devAPI = device.NewDevice(c.tun, device.NewLogger(device.LogLevelDebug, "[userspace-wg]"))
+	if err := c.setDeviceConfig(config.Encode()); err != nil {
+		return errors.Wrap(err, "failed to configure initial device")
 	}
-
-	key, err := base64stringTo32ByteArray(config.PrivateKey())
-	if err != nil {
-		return errors.Wrap(err, "failed to parse private key from config")
-	}
-
-	if err := c.devAPI.SetPrivateKey(device.NoisePrivateKey(key)); err != nil {
-		return errors.Wrap(err, "failed to set private key to userspace device API")
-	}
-
-	c.devAPI.Boot()
 	return nil
 }
 
-func (c *client) AddPeer(name string, peer wg.PeerInfo, allowedIPs ...string) error {
-	key, err := base64stringTo32ByteArray(peer.PublicKey())
-	if err != nil {
-		return err
-	}
-
-	extPeer := device.ExternalPeer{
-		PublicKey:  device.NoisePublicKey(key),
+func (c *client) AddPeer(iface string, peer wg.AddPeerOptions, _ ...string) error {
+	p := wg.Peer{
+		PublicKey:  peer.PublicKey,
 		AllowedIPs: []string{"0.0.0.0/0", "::/0"},
+		Endpoint:   peer.Endpoint,
 	}
-
-	if len(allowedIPs) > 0 {
-		extPeer.AllowedIPs = allowedIPs
+	if err := c.setDeviceConfig(p.Encode()); err != nil {
+		errors.Wrap(err, "failed to add device peer")
 	}
-
-	if ep := peer.Endpoint(); ep != nil {
-		extPeer.RemoteEndpoint, err = device.CreateEndpoint(ep.String())
-		if err != nil {
-			return err
-		}
-	}
-
-	return c.devAPI.AddPeer(extPeer)
+	return nil
 }
 
 func (c *client) RemovePeer(_ string, publicKey string) error {
@@ -93,7 +71,6 @@ func (c *client) RemovePeer(_ string, publicKey string) error {
 	}
 
 	c.devAPI.RemovePeer(key)
-
 	return nil
 }
 
@@ -109,25 +86,29 @@ func (c *client) ConfigureRoutes(iface string, ip net.IP) error {
 	return addDefaultRoute(iface)
 }
 
-func (c *client) PeerStats() (wg.Stats, error) {
-	peers, err := c.devAPI.Peers()
+func (c *client) PeerStats() (*wg.Stats, error) {
+	deviceState, err := wg.ParseUserspaceDevice(c.devAPI.IpcGetOperation)
 	if err != nil {
-		return wg.Stats{}, nil
+		return nil, err
 	}
-
-	if len(peers) != 1 {
-		return wg.Stats{}, errors.New("exactly 1 peer expected")
+	stats, err := wg.ParseDevicePeerStats(deviceState)
+	if err != nil {
+		return nil, err
 	}
-
-	return wg.Stats{
-		BytesSent:     peers[0].Stats.Sent,
-		BytesReceived: peers[0].Stats.Received,
-		LastHandshake: time.Unix(int64(peers[0].LastHanshake), 0),
-	}, nil
+	return stats, nil
 }
 
 func (c *client) DestroyDevice(name string) error {
 	return destroyDevice(name)
+}
+
+func (c *client) setDeviceConfig(config string) error {
+	if err := c.devAPI.IpcSetOperation(bufio.NewReader(strings.NewReader(config))); err != nil {
+		return errors.Wrap(err, "failed to set device config")
+	}
+	c.devAPI.Up()
+	fmt.Printf("---------setDeviceConfig: %s\n", config)
+	return nil
 }
 
 func base64stringTo32ByteArray(s string) (res [32]byte, err error) {

--- a/services/wireguard/endpoint/userspace/client.go
+++ b/services/wireguard/endpoint/userspace/client.go
@@ -20,7 +20,6 @@ package userspace
 import (
 	"bufio"
 	"encoding/base64"
-	"fmt"
 	"net"
 	"strings"
 
@@ -107,7 +106,6 @@ func (c *client) setDeviceConfig(config string) error {
 		return errors.Wrap(err, "failed to set device config")
 	}
 	c.devAPI.Up()
-	fmt.Printf("---------setDeviceConfig: %s\n", config)
 	return nil
 }
 

--- a/services/wireguard/service/service_test.go
+++ b/services/wireguard/service/service_test.go
@@ -96,15 +96,15 @@ func waitABit() {
 
 type mockConnectionEndpoint struct{}
 
-func (mce *mockConnectionEndpoint) InterfaceName() string                               { return "mce0" }
-func (mce *mockConnectionEndpoint) Stop() error                                         { return nil }
-func (mce *mockConnectionEndpoint) Start(_ *wg.ServiceConfig) error                     { return nil }
-func (mce *mockConnectionEndpoint) Config() (wg.ServiceConfig, error)                   { return wg.ServiceConfig{}, nil }
-func (mce *mockConnectionEndpoint) AddPeer(_ string, _ *net.UDPAddr, _ ...string) error { return nil }
-func (mce *mockConnectionEndpoint) RemovePeer(_ string) error                           { return nil }
-func (mce *mockConnectionEndpoint) ConfigureRoutes(_ net.IP) error                      { return nil }
-func (mce *mockConnectionEndpoint) PeerStats() (wg.Stats, error) {
-	return wg.Stats{LastHandshake: time.Now()}, nil
+func (mce *mockConnectionEndpoint) InterfaceName() string                        { return "mce0" }
+func (mce *mockConnectionEndpoint) Stop() error                                  { return nil }
+func (mce *mockConnectionEndpoint) Start(_ *wg.ServiceConfig) error              { return nil }
+func (mce *mockConnectionEndpoint) Config() (wg.ServiceConfig, error)            { return wg.ServiceConfig{}, nil }
+func (mce *mockConnectionEndpoint) AddPeer(_ string, _p wg.AddPeerOptions) error { return nil }
+func (mce *mockConnectionEndpoint) RemovePeer(_ string) error                    { return nil }
+func (mce *mockConnectionEndpoint) ConfigureRoutes(_ net.IP) error               { return nil }
+func (mce *mockConnectionEndpoint) PeerStats() (*wg.Stats, error) {
+	return &wg.Stats{LastHandshake: time.Now()}, nil
 }
 
 func newManagerStub(pub, out, country string) *Manager {

--- a/services/wireguard/service/service_test.go
+++ b/services/wireguard/service/service_test.go
@@ -100,7 +100,7 @@ func (mce *mockConnectionEndpoint) InterfaceName() string                       
 func (mce *mockConnectionEndpoint) Stop() error                                  { return nil }
 func (mce *mockConnectionEndpoint) Start(_ *wg.ServiceConfig) error              { return nil }
 func (mce *mockConnectionEndpoint) Config() (wg.ServiceConfig, error)            { return wg.ServiceConfig{}, nil }
-func (mce *mockConnectionEndpoint) AddPeer(_ string, _p wg.AddPeerOptions) error { return nil }
+func (mce *mockConnectionEndpoint) AddPeer(_ string, _ wg.AddPeerOptions) error { return nil }
 func (mce *mockConnectionEndpoint) RemovePeer(_ string) error                    { return nil }
 func (mce *mockConnectionEndpoint) ConfigureRoutes(_ net.IP) error               { return nil }
 func (mce *mockConnectionEndpoint) PeerStats() (*wg.Stats, error) {

--- a/services/wireguard/service/service_test.go
+++ b/services/wireguard/service/service_test.go
@@ -96,13 +96,13 @@ func waitABit() {
 
 type mockConnectionEndpoint struct{}
 
-func (mce *mockConnectionEndpoint) InterfaceName() string                        { return "mce0" }
-func (mce *mockConnectionEndpoint) Stop() error                                  { return nil }
-func (mce *mockConnectionEndpoint) Start(_ *wg.ServiceConfig) error              { return nil }
-func (mce *mockConnectionEndpoint) Config() (wg.ServiceConfig, error)            { return wg.ServiceConfig{}, nil }
+func (mce *mockConnectionEndpoint) InterfaceName() string                       { return "mce0" }
+func (mce *mockConnectionEndpoint) Stop() error                                 { return nil }
+func (mce *mockConnectionEndpoint) Start(_ *wg.ServiceConfig) error             { return nil }
+func (mce *mockConnectionEndpoint) Config() (wg.ServiceConfig, error)           { return wg.ServiceConfig{}, nil }
 func (mce *mockConnectionEndpoint) AddPeer(_ string, _ wg.AddPeerOptions) error { return nil }
-func (mce *mockConnectionEndpoint) RemovePeer(_ string) error                    { return nil }
-func (mce *mockConnectionEndpoint) ConfigureRoutes(_ net.IP) error               { return nil }
+func (mce *mockConnectionEndpoint) RemovePeer(_ string) error                   { return nil }
+func (mce *mockConnectionEndpoint) ConfigureRoutes(_ net.IP) error              { return nil }
 func (mce *mockConnectionEndpoint) PeerStats() (*wg.Stats, error) {
 	return &wg.Stats{LastHandshake: time.Now()}, nil
 }

--- a/services/wireguard/service/service_unix.go
+++ b/services/wireguard/service/service_unix.go
@@ -85,7 +85,8 @@ func (manager *Manager) ProvideConfig(sessionConfig json.RawMessage, traversalPa
 		return nil, err
 	}
 
-	if err := connectionEndpoint.AddPeer(key.PublicKey, nil); err != nil {
+	// TODO(anjmao): Check if peer info is correct here
+	if err := connectionEndpoint.AddPeer(connectionEndpoint.InterfaceName(), wg.AddPeerOptions{PublicKey: key.PublicKey}); err != nil {
 		return nil, err
 	}
 

--- a/services/wireguard/wireguard.go
+++ b/services/wireguard/wireguard.go
@@ -216,10 +216,8 @@ func (p *Peer) Encode() string {
 	if p.Endpoint != nil {
 		res.WriteString(fmt.Sprintf("endpoint=%s\n", p.Endpoint.String()))
 	}
-	if len(p.AllowedIPs) > 0 {
-		for _, ip := range p.AllowedIPs {
-			res.WriteString(fmt.Sprintf("allowed_ip=%s\n", ip))
-		}
+	for _, ip := range p.AllowedIPs {
+		res.WriteString(fmt.Sprintf("allowed_ip=%s\n", ip))
 	}
 	return res.String()
 }

--- a/services/wireguard/wireguard_test.go
+++ b/services/wireguard/wireguard_test.go
@@ -19,7 +19,10 @@ package wireguard
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/stretchr/testify/assert"
@@ -99,5 +102,130 @@ func Test_PaymentMethod_Unserialize(t *testing.T) {
 
 		assert.Equal(t, test.expectedModel, model)
 		assert.Equal(t, test.expectedError, err)
+	}
+}
+
+func TestDeviceConfig_Encode(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   DeviceConfig
+		expected string
+	}{
+		{
+			name: "Test encode all filled values",
+			config: DeviceConfig{
+				PrivateKey: "DyxwLJ++jVO+azusu7rPEnzdgfm+0fiOBQ1GTbkk3QQ=",
+				ListenPort: 53511,
+			},
+			expected: `private_key=0f2c702c9fbe8d53be6b3bacbbbacf127cdd81f9bed1f88e050d464db924dd04
+listen_port=53511
+`,
+		},
+		{
+			name: "Test encode default values",
+			config: DeviceConfig{
+				PrivateKey: "",
+				ListenPort: 0,
+			},
+			expected: `private_key=
+listen_port=0
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.config.Encode())
+		})
+	}
+}
+
+func TestPeerConfig_Encode(t *testing.T) {
+	endpoint := func() *net.UDPAddr {
+		res, _ := net.ResolveUDPAddr("udp", "182.122.22.19:3233")
+		return res
+	}
+	tests := []struct {
+		name     string
+		peer     Peer
+		expected string
+	}{
+		{
+			name: "Test encode all filled values",
+			peer: Peer{
+				PublicKey:       "DyxwLJ++jVO+azusu7rPEnzdgfm+0fiOBQ1GTbkk3QQ=",
+				Endpoint:        endpoint(),
+				AllowedIPs:      []string{"192.168.4.10/32", "192.168.4.11/32"},
+				KeepAlivePeriod: 20,
+			},
+			expected: `public_key=0f2c702c9fbe8d53be6b3bacbbbacf127cdd81f9bed1f88e050d464db924dd04
+persistent_keepalive_interval=20
+endpoint=182.122.22.19:3233
+allowed_ip=192.168.4.10/32
+allowed_ip=192.168.4.11/32
+`,
+		},
+		{
+			name: "Test encode default values",
+			peer: Peer{
+				PublicKey:       "",
+				Endpoint:        nil,
+				AllowedIPs:      []string{},
+				KeepAlivePeriod: 0,
+			},
+			expected: `public_key=
+persistent_keepalive_interval=0
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.peer.Encode())
+		})
+	}
+}
+
+func TestParsePeerStats(t *testing.T) {
+	tests := []struct {
+		name          string
+		device        *UserspaceDevice
+		expectedStats *Stats
+		expectedErr   error
+	}{
+		{
+			name: "Test parse stats successfully",
+			device: &UserspaceDevice{
+				Peers: []UserspaceDevicePeer{
+					{
+						TransmitBytes:     10,
+						ReceiveBytes:      12,
+						LastHandshakeTime: time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC),
+					},
+				},
+			},
+			expectedStats: &Stats{
+				BytesSent:     10,
+				BytesReceived: 12,
+				LastHandshake: time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "Test parse fail when more than one peer returned",
+			device: &UserspaceDevice{
+				Peers: []UserspaceDevicePeer{{}, {}},
+			},
+			expectedStats: nil,
+			expectedErr:   fmt.Errorf("exactly 1 peer expected, got %d", 2),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stats, err := ParseDevicePeerStats(test.device)
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expectedStats, stats)
+		})
 	}
 }


### PR DESCRIPTION
Use upstream https://github.com/WireGuard/wireguard-go and add needed changed to support it. Wireguard uses simple key value based configuration protocol which only supports passing it as a string.