### PR TITLE
Disable client key renegotiation and increase server key reneg to 1 hour

### DIFF
--- a/services/openvpn/client_config.go
+++ b/services/openvpn/client_config.go
@@ -69,7 +69,7 @@ func defaultClientConfig(runtimeDir string, scriptSearchPath string) *ClientConf
 
 	clientConfig.SetParam("auth", "none")
 
-	clientConfig.SetParam("reneg-sec", "60")
+	clientConfig.SetParam("reneg-sec", "0")
 	clientConfig.SetParam("resolv-retry", "infinite")
 	clientConfig.SetParam("redirect-gateway", "def1", "bypass-dhcp")
 

--- a/services/openvpn/server_config.go
+++ b/services/openvpn/server_config.go
@@ -77,7 +77,7 @@ func NewServerConfig(
 	serverConfig.SetFlag("management-client-auth")
 	serverConfig.SetParam("verify-client-cert", "none")
 	serverConfig.SetParam("tls-cipher", "TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384")
-	serverConfig.SetParam("reneg-sec", "60")
+	serverConfig.SetParam("reneg-sec", "3600")
 	serverConfig.SetKeepAlive(10, 60)
 	serverConfig.SetPingTimerRemote()
 	serverConfig.SetPersistKey()


### PR DESCRIPTION
This should possible fix https://github.com/mysteriumnetwork/node/issues/1475 for error local/remote key IDs out of sync which happens randomly.