### PR TITLE
Show service type and access policy in proposal list (CLI)

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -507,7 +507,12 @@ func (c *cliApp) proposals(filter string) {
 			country = "Unknown"
 		}
 
-		msg := fmt.Sprintf("- provider id: %v, proposal id: %v, country: %v", proposal.ProviderID, proposal.ID, country)
+		var policies []string
+		for _, policy := range proposal.AccessPolicies {
+			policies = append(policies, policy.ID)
+		}
+
+		msg := fmt.Sprintf("- provider id: %v\ttype: %v\tcountry: %v\taccess policies: %v", proposal.ProviderID, proposal.ServiceType, country, strings.Join(policies, ","))
 
 		if filter == "" ||
 			strings.Contains(proposal.ProviderID, filter) ||

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -55,6 +55,13 @@ type ProposalDTO struct {
 	ProviderID        string               `json:"providerId"`
 	ServiceType       string               `json:"serviceType"`
 	ServiceDefinition ServiceDefinitionDTO `json:"serviceDefinition"`
+	AccessPolicies    []AccessPolicy       `json:"accessPolicies"`
+}
+
+// AccessPolicy represents the access controls for proposal
+type AccessPolicy struct {
+	ID     string `json:"id"`
+	Source string `json:"source"`
 }
 
 func (p ProposalDTO) String() string {


### PR DESCRIPTION
Fixes: #1033

Makes service type and access policy (whitelist) visible in proposal list. 

Before:

```
[INFO] Found 555 proposals
[INFO] - provider id: 0x00782112dc28d0d1dfde4a7b377aa164da66e324, proposal id: 1, country: GB
[INFO] - provider id: 0x00abc7e1b3cad87369608aff3bd05965c08ada06, proposal id: 1, country: IT
[INFO] - provider id: 0x01cf3cae1b4e9905d28c99afc89993d9590c9c54, proposal id: 1, country: GB
[INFO] - provider id: 0x01e225517954a1a2ded3ce1fac2328e671f88fff, proposal id: 1, country: GB
[INFO] - provider id: 0x0207009b25ad86132c557b0dcce2e409a5625bb4, proposal id: 1, country: GB
[INFO] - provider id: 0x0237931f015b22eda9482212a1efaec2d1b2ddd4, proposal id: 1, country: GB
[INFO] - provider id: 0x0237931f015b22eda9482212a1efaec2d1b2ddd4, proposal id: 1, country: GB
[INFO] - provider id: 0x0237931f015b22eda9482212a1efaec2d1b2ddd4, proposal id: 1, country: GB
```

After:

```
» proposals
[INFO] Found 555 proposals
[INFO] - provider id: 0x00782112dc28d0d1dfde4a7b377aa164da66e324	type: openvpn	country: GB	access policies: mysterium
[INFO] - provider id: 0x00abc7e1b3cad87369608aff3bd05965c08ada06	type: openvpn	country: IT	access policies: mysterium
[INFO] - provider id: 0x01cf3cae1b4e9905d28c99afc89993d9590c9c54	type: openvpn	country: GB	access policies: mysterium
[INFO] - provider id: 0x01e225517954a1a2ded3ce1fac2328e671f88fff	type: openvpn	country: GB	access policies: mysterium
[INFO] - provider id: 0x0207009b25ad86132c557b0dcce2e409a5625bb4	type: openvpn	country: GB	access policies: mysterium
[INFO] - provider id: 0x0237931f015b22eda9482212a1efaec2d1b2ddd4	type: noop	country: GB	access policies:
[INFO] - provider id: 0x0237931f015b22eda9482212a1efaec2d1b2ddd4	type: openvpn	country: GB	access policies:
[INFO] - provider id: 0x0237931f015b22eda9482212a1efaec2d1b2ddd4	type: wireguard	country: GB	access policies:
[INFO] - provider id: 0x02ad9df48b84fee858189abe024c10718fa11c73	type: openvpn	country: US	access policies: mysterium
[INFO] - provider id: 0x03314a55077727271f2faa650cee0b1d544b60ea	type: openvpn	country: US	access policies:
[INFO] - provider id: 0x035740809db0d41aefef1ee5678d1c2df6db03cc	type: openvpn	country: US	access policies: mysterium
[INFO] - provider id: 0x0440d4a4f986684b624a5144719b5cee5bb18b3a	type: openvpn	country: GB	access policies:
[INFO] - provider id: 0x0499b8aa4d685e11adfe61573d64bf8d9d6c9b5e	type: noop	country: GB	access policies:
[INFO] - provider id: 0x0499b8aa4d685e11adfe61573d64bf8d9d6c9b5e	type: openvpn	country: GB	access policies:
[INFO] - provider id: 0x0499b8aa4d685e11adfe61573d64bf8d9d6c9b5e	type: wireguard	country: GB	access policies:
[INFO] - provider id: 0x0507d9a93815b36ab8cfadc8bfa3579c148f02cd	type: openvpn	country: US	access policies: mysterium
[INFO] - provider id: 0x05d281173b11d065594e80ac8f328067d4cc7bbf	type: openvpn	country: GB	access policies: mysterium
[INFO] - provider id: 0x0666b1bb3d05f77b693c495cfc0107f434a68dd0	type: openvpn	country: GB	access policies: mysterium
[INFO] - provider id: 0x06a3c27e62808a94163222fe1ed72655b9863a11	type: openvpn	country: GB	access policies:
```
