### PR TITLE
Fix leaking goroutines in the connection manager

### DIFF
--- a/bin/localnet/docker-compose.yml
+++ b/bin/localnet/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75
       -keystoreDir /keystore
       -accountantAddress 0x241F6e1d0bB17f45767DC60A6Bd3D21Cdb543a0c
+      -boltPath /bolt.db
     volumes:
       - "./deployer/keystore:/keystore"
 

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -356,7 +356,6 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 
 	err := tc.connManager.Connect(consumerID, accountantID, activeProposal, ConnectParams{})
 	assert.NoError(tc.T(), err)
-	<-tc.ipCheckParams.Done
 
 	waitABit()
 
@@ -405,7 +404,8 @@ func (tc *testContext) Test_ManagerNotifiesAboutSessionIPNotChanged() {
 
 	err := tc.connManager.Connect(consumerID, consumerID, activeProposal, ConnectParams{})
 	assert.NoError(tc.T(), err)
-	<-tc.ipCheckParams.Done
+
+	waitABit()
 
 	// Check that state event with StateIPNotChanged status was called.
 	history := tc.stubPublisher.GetEventHistory()
@@ -439,7 +439,8 @@ func (tc *testContext) Test_ManagerNotifiesAboutSuccessfulConnection() {
 
 	err := tc.connManager.Connect(consumerID, consumerID, activeProposal, ConnectParams{})
 	assert.NoError(tc.T(), err)
-	<-tc.ipCheckParams.Done
+
+	waitABit()
 
 	// Check that state event with StateIPNotChanged status was not called.
 	history := tc.stubPublisher.GetEventHistory()
@@ -457,8 +458,8 @@ func (tc *testContext) Test_ManagerNotifiesAboutSuccessfulConnection() {
 		StatusCode: connectivity.StatusConnectionOk,
 		Message:    "",
 	}
-	assert.NotNil(tc.T(), tc.statusSender.sentMsg)
-	assert.Equal(tc.T(), &expectedStatusMsg, tc.statusSender.sentMsg)
+
+	assert.Equal(tc.T(), expectedStatusMsg, tc.statusSender.getSentMsg())
 }
 
 func TestConnectionManagerSuite(t *testing.T) {
@@ -521,4 +522,10 @@ func (s *mockStatusSender) Send(dialog communication.Sender, msg *connectivity.S
 	s.Lock()
 	defer s.Unlock()
 	s.sentMsg = msg
+}
+
+func (s *mockStatusSender) getSentMsg() connectivity.StatusMessage {
+	s.Lock()
+	defer s.Unlock()
+	return *s.sentMsg
 }


### PR DESCRIPTION
It now clean channels correctly for statistics and IP checking.

The goroutine profile from the leaking instance:
```
1393 @ 0x4345d0 0x409248 0x40921e 0x408f4b 0xaa9f02 0x462891
#	0xaa9f01	github.com/mysteriumnetwork/node/core/connection.(*connectionManager).consumeStats+0x191	/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:480
1293 @ 0x4345d0 0x40862b 0x408601 0x4083e5 0xaaabf9 0xaa79c6 0x462891
#	0xaaabf8	github.com/mysteriumnetwork/node/core/connection.(*connectionManager).checkSessionIP.func1+0x38	/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:204
#	0xaa79c5	github.com/mysteriumnetwork/node/core/connection.(*connectionManager).checkSessionIP+0x255	/go/src/github.com/mysteriumnetwork/node/core/connection/manager.go:218
```