### PR TITLE
Increase proposal ping period

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -763,7 +763,7 @@ func (di *Dependencies) bootstrapDiscoveryComponents(options node.OptionsDiscove
 
 	di.DiscoveryFinder = discoveryFinder
 	di.DiscoveryFactory = func() service.Discovery {
-		return discovery.NewService(di.IdentityRegistry, discoveryRegistry, 60*time.Second, di.SignerFactory, di.EventBus)
+		return discovery.NewService(di.IdentityRegistry, discoveryRegistry, options.PingInterval, di.SignerFactory, di.EventBus)
 	}
 	return nil
 }

--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -20,6 +20,7 @@ package config
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/rs/zerolog"
@@ -35,6 +36,12 @@ var (
 		Name:  "discovery.type",
 		Usage: `Proposal discovery adapter(s) separated by comma Options: { "api", "broker", "api,broker" }`,
 		Value: &cli.StringSlice{"api", "broker"},
+	}
+	// FlagDiscoveryPingInterval proposal ping interval in seconds.
+	FlagDiscoveryPingInterval = cli.DurationFlag{
+		Name:  "discovery.ping",
+		Usage: `Proposal update interval `,
+		Value: 180 * time.Second,
 	}
 	// FlagBindAddress IP address to bind to.
 	FlagBindAddress = cli.StringFlag{
@@ -164,6 +171,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 	*flags = append(*flags,
 		FlagBindAddress,
 		FlagDiscoveryType,
+		FlagDiscoveryPingInterval,
 		FlagFeedbackURL,
 		FlagFirewallKillSwitch,
 		FlagFirewallProtectedNetworks,
@@ -197,6 +205,7 @@ func ParseFlagsNode(ctx *cli.Context) {
 
 	Current.ParseStringFlag(ctx, FlagBindAddress)
 	Current.ParseStringSliceFlag(ctx, FlagDiscoveryType)
+	Current.ParseDurationFlag(ctx, FlagDiscoveryPingInterval)
 	Current.ParseStringFlag(ctx, FlagFeedbackURL)
 	Current.ParseBoolFlag(ctx, FlagFirewallKillSwitch)
 	Current.ParseStringFlag(ctx, FlagFirewallProtectedNetworks)

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -180,6 +180,7 @@ func GetDiscoveryOptions() *OptionsDiscovery {
 	return &OptionsDiscovery{
 		Types:                  types,
 		ProposalFetcherEnabled: true,
+		PingInterval:           config.GetDuration(config.FlagDiscoveryPingInterval),
 	}
 }
 

--- a/core/node/options_discovery.go
+++ b/core/node/options_discovery.go
@@ -17,6 +17,8 @@
 
 package node
 
+import "time"
+
 // DiscoveryType identifies proposal discovery provider
 type DiscoveryType string
 
@@ -32,4 +34,5 @@ type OptionsDiscovery struct {
 	Types                  []DiscoveryType
 	Address                string
 	ProposalFetcherEnabled bool
+	PingInterval           time.Duration
 }


### PR DESCRIPTION
Enabling wireguard on RPIs by default will effectively double amount of proposals discovery has to process. Even now we are operating almost on edge.

Reducing proposal ping to every 3 min.