### PR TITLE
Do not crash on specifying discovery.type flag

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -744,7 +744,7 @@ func (di *Dependencies) bootstrapDiscoveryComponents(options node.OptionsDiscove
 				discoveryFinder.AddFinder(discovery_noop.NewFinder())
 			} else {
 				discoveryFinder.AddFinder(
-					discovery_api.NewFinder(di.DiscoveryStorage, di.MysteriumAPI.Proposals, 30*time.Minute),
+					discovery_api.NewFinder(di.DiscoveryStorage, di.MysteriumAPI.Proposals, 30*time.Second),
 				)
 			}
 		case node.DiscoveryTypeBroker:

--- a/config/config.go
+++ b/config/config.go
@@ -218,11 +218,12 @@ func (cfg *Config) GetString(key string) string {
 
 // GetStringSlice returns config value as []string.
 func (cfg *Config) GetStringSlice(key string) []string {
-	switch cfg.Get(key).(type) {
+	val := cfg.Get(key)
+	switch val.(type) {
 	case *cli.StringSlice:
-		return cast.ToStringSlice([]string(*cfg.Get(key).(*cli.StringSlice)))
+		return cast.ToStringSlice([]string(*val.(*cli.StringSlice)))
 	default:
-		return cast.ToStringSlice(cfg.Get(key))
+		return cast.ToStringSlice(val)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -218,7 +218,12 @@ func (cfg *Config) GetString(key string) string {
 
 // GetStringSlice returns config value as []string.
 func (cfg *Config) GetStringSlice(key string) []string {
-	return cast.ToStringSlice(cfg.Get(key))
+	switch cfg.Get(key).(type) {
+	case *cli.StringSlice:
+		return cast.ToStringSlice([]string(*cfg.Get(key).(*cli.StringSlice)))
+	default:
+		return cast.ToStringSlice(cfg.Get(key))
+	}
 }
 
 // ParseBoolFlag parses a cli.BoolFlag from command's context and

--- a/config/config.go
+++ b/config/config.go
@@ -218,8 +218,7 @@ func (cfg *Config) GetString(key string) string {
 
 // GetStringSlice returns config value as []string.
 func (cfg *Config) GetStringSlice(key string) []string {
-	value := cfg.Get(key).(*cli.StringSlice)
-	return cast.ToStringSlice([]string(*value))
+	return cast.ToStringSlice(cfg.Get(key))
 }
 
 // ParseBoolFlag parses a cli.BoolFlag from command's context and


### PR DESCRIPTION
still flag does not work as I would expect it. It appends, not overrides flag value. Filling separate bug issue since it is cli package related. 