### PR TITLE
Remove r recovery

### DIFF
--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -265,7 +265,6 @@ func (it *InvoiceTracker) requestPromise(r []byte, pm crypto.ExchangeMessage) er
 	if err != nil {
 		return errors.Wrap(err, "could not store accountant promise")
 	}
-	log.Debug().Msg("Accountant promise stored")
 
 	promise.R = r
 	it.deps.Publisher.Publish(AccountantPromiseTopic, AccountantPromiseEventPayload{
@@ -309,7 +308,6 @@ func (it *InvoiceTracker) revealPromise() error {
 	if err != nil {
 		return errors.Wrap(err, "could not store accountant promise")
 	}
-	log.Debug().Msg("Accountant promise stored")
 
 	return nil
 }


### PR DESCRIPTION
with the agreement ID's being random, the current R recovery logic does not do what it's supposed to do.

With the changes in invoice tracking the recovery should not be required, therefore removing it permanently.

A mechanism similar to this one will be needed once accountant starts returning consistent errors that we can handle.