### PR TITLE
Install wireguard from launchpad instead of deb unstable

### DIFF
--- a/bin/package/raspberry/files/1-setup-node.sh
+++ b/bin/package/raspberry/files/1-setup-node.sh
@@ -14,11 +14,10 @@ add_apt_source() {
 touch /boot/ssh
 
 # Add APT sources
-add_apt_source "deb http://deb.debian.org/debian/ unstable main" "/etc/apt/sources.list.d/unstable.list"
-printf 'Package: *\nPin: release a=unstable\nPin-Priority: 150\n' | tee --append /etc/apt/preferences.d/limit-unstable
 add_apt_source "deb http://ppa.launchpad.net/mysteriumnetwork/node/ubuntu bionic main" "/etc/apt/sources.list.d/mysterium.list"
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ECCB6A56B22C536D
+add_apt_source "deb http://ppa.launchpad.net/wireguard/wireguard/ubuntu bionic main" "/etc/apt/sources.list.d/wireguard.list"
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AE33835F504A1A25
 apt-get update --allow-releaseinfo-change
 
 # Install myst dependencies

--- a/install.sh
+++ b/install.sh
@@ -137,11 +137,9 @@ install_dependencies() {
     fi
 
     # Wireguard
-    echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
-    printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' > /etc/apt/preferences.d/limit-unstable
+    echo "deb http://ppa.launchpad.net/wireguard/wireguard/ubuntu bionic main" > "/etc/apt/sources.list.d/wireguard.list"
     apt-get install -y dirmngr
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ECCB6A56B22C536D
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AE33835F504A1A25
     apt-get update
     apt-get install -y wireguard
     apt-get install -y libmnl-dev libelf-dev linux-headers-$(uname -r) build-essential pkg-config


### PR DESCRIPTION
It appears there are issues downloading wireguard packages from debian unstable as of today - causing all our build pipelines to fail:
```
# Install myst dependencies
apt-get -y install \
  wireguard \
  openvpn
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 wireguard : Depends: wireguard-dkms (>= 0.0.20191219) but it is not installable or
                      wireguard-modules (>= 0.0.20191219) but it is not installable
E: Unable to correct problems, you have held broken packages.
```
 Switching to launchpad PPA as it appears to be delivering more stable results.
Tested on debian/raspbian buster (10).
