### PR TITLE
Filter proposals using query params instead of post-filtering result

### DIFF
--- a/core/discovery/apidiscovery/repository.go
+++ b/core/discovery/apidiscovery/repository.go
@@ -51,15 +51,5 @@ func (a *apiRepository) Proposal(id market.ProposalID) (*market.ServiceProposal,
 
 // Proposals returns proposals matching filter.
 func (a *apiRepository) Proposals(filter *proposal.Filter) ([]market.ServiceProposal, error) {
-	proposals, err := a.discoveryAPI.Proposals()
-	if err != nil {
-		return nil, err
-	}
-	var filtered []market.ServiceProposal
-	for _, p := range proposals {
-		if filter.Matches(p) {
-			filtered = append(filtered, p)
-		}
-	}
-	return filtered, nil
+	return a.discoveryAPI.QueryProposals(filter.ToAPIQuery())
 }

--- a/core/discovery/proposal/filter.go
+++ b/core/discovery/proposal/filter.go
@@ -55,10 +55,14 @@ func (filter *Filter) Matches(proposal market.ServiceProposal) bool {
 
 // ToAPIQuery serialises filter to query of Mysterium API
 func (filter *Filter) ToAPIQuery() mysterium.ProposalsQuery {
-	return mysterium.ProposalsQuery{
+	query := mysterium.ProposalsQuery{
 		NodeKey:            filter.ProviderID,
 		ServiceType:        filter.ServiceType,
 		AccessPolicyID:     filter.AccessPolicyID,
 		AccessPolicySource: filter.AccessPolicySource,
 	}
+	if filter.ServiceType == "" {
+		query.ServiceType = "all"
+	}
+	return query
 }

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -57,7 +57,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 
 			if i != len(servicesInFlag)-1 {
 				// this allows the nats to reconnect properly before starting a new service test
-				time.Sleep(time.Second * 5)
+				time.Sleep(time.Second * 10)
 			}
 		}
 	})

--- a/mobile/mysterium/proposals_manager.go
+++ b/mobile/mysterium/proposals_manager.go
@@ -136,9 +136,7 @@ func (m *proposalsManager) getFromCache() []market.ServiceProposal {
 }
 
 func (m *proposalsManager) getFromRepository() ([]market.ServiceProposal, error) {
-	allProposals, err := m.repository.Proposals(&proposal.Filter{
-		ServiceType: "all",
-	})
+	allProposals, err := m.repository.Proposals(&proposal.Filter{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes proposal fetching for mobile: query all service types and only non-whitelisted.

Related: https://github.com/mysteriumnetwork/node/pull/1523