### PR TITLE
Use mysteriumnetwork xgo docker images [ci full]

### DIFF
--- a/bin/build_xgo
+++ b/bin/build_xgo
@@ -31,7 +31,6 @@ docker run --rm \
     -v "$PWD"/$DIR_TEMP:/build \
     -v "$GOPATH"/xgo-cache:/deps-cache:ro \
     -v "$PWD":/source \
-    -e PACK=./cmd/mysterium_node \
     -e OUT=myst \
     -e FLAG_V=false \
     -e FLAG_X=false \
@@ -39,7 +38,7 @@ docker run --rm \
     -e FLAG_LDFLAGS="-w -s $(get_linker_ldflags)" \
     -e FLAG_BUILDMODE=default \
     -e TARGETS="$XGO_TARGETS" \
-    anjmao/xgo:go-1.13.1
+    mysteriumnetwork/xgo:1.13.6 ./cmd/mysterium_node
 
 # Remove version from binary name:
 #  - myst-darwin-10.6-amd64 -> myst_darwin_amd64

--- a/bin/package_android
+++ b/bin/package_android
@@ -29,7 +29,7 @@ docker run --rm \
     -e TARGETS=android/. \
     -e EXT_GOPATH=/ext-go/1 \
     -e GO111MODULE=off \
-    mysteriumnetwork/xgo:1.13.1 github.com/mysteriumnetwork/node/mobile/mysterium
+    mysteriumnetwork/xgomobile:1.13.6 github.com/mysteriumnetwork/node/mobile/mysterium
 
 print_success "Android package '$PACKAGE_FILE' complete!"
 exit 0


### PR DESCRIPTION
There is now two separate repositories. Previously gomobile was included, but since go and gomobile are completely different tools it was hard to maintain it (especially with go modules).

[xgo](https://github.com/mysteriumnetwork/xgo) - cross compile go.
[xgomobile](https://github.com/mysteriumnetwork/xgomobile) - build android package.