### PR TITLE
Introduce service for SOCKS5 

### DIFF
--- a/ci/dev/build.go
+++ b/ci/dev/build.go
@@ -63,6 +63,19 @@ func Wireguard() error {
 	return sh.RunV(cmdParts[0], cmdParts[1:]...)
 }
 
+// SOCKS5 builds and starts SOCKS5 service with terms accepted
+func SOCKS5() error {
+	if err := sh.RunV("bin/build"); err != nil {
+		return err
+	}
+	cmd := "build/myst/myst service --agreed-terms-and-conditions socks5"
+	if runtime.GOOS == "darwin" {
+		cmd = "sudo " + cmd
+	}
+	cmdParts := strings.Split(cmd, " ")
+	return sh.RunV(cmdParts[0], cmdParts[1:]...)
+}
+
 // CLI builds and runs myst CLI
 func CLI() error {
 	if err := sh.RunV("bin/build"); err != nil {

--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -37,6 +37,8 @@ import (
 	"github.com/mysteriumnetwork/node/services/noop"
 	"github.com/mysteriumnetwork/node/services/openvpn"
 	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn/service"
+	"github.com/mysteriumnetwork/node/services/socks5"
+	socks5_service "github.com/mysteriumnetwork/node/services/socks5/service"
 	"github.com/mysteriumnetwork/node/services/wireguard"
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	tequilapi_client "github.com/mysteriumnetwork/node/tequilapi/client"
@@ -668,6 +670,7 @@ func parseStartFlags(serviceType string, args ...string) (service.Options, confi
 	config.RegisterFlagsServiceShared(&flags)
 	config.RegisterFlagsServiceOpenvpn(&flags)
 	config.RegisterFlagsServiceWireguard(&flags)
+	config.RegisterFlagsServiceSOCK5(&flags)
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
 	for _, f := range flags {
@@ -690,6 +693,9 @@ func parseStartFlags(serviceType string, args ...string) (service.Options, confi
 	case openvpn.ServiceType:
 		config.ParseFlagsServiceOpenvpn(ctx)
 		return openvpn_service.GetOptions(), services.SharedConfiguredOptions(), nil
+	case socks5.ServiceType:
+		config.ParseFlagsServiceSOCKS5(ctx)
+		return socks5_service.GetOptions(), services.SharedConfiguredOptions(), nil
 	}
 
 	return nil, config.Options{}, errors.New("service type not found")

--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -156,6 +156,7 @@ func registerFlags(flags *[]cli.Flag) {
 	config.RegisterFlagsServiceShared(flags)
 	config.RegisterFlagsServiceOpenvpn(flags)
 	config.RegisterFlagsServiceWireguard(flags)
+	config.RegisterFlagsServiceSOCK5(flags)
 }
 
 // parseIdentityFlags function fills in service command options from CLI context

--- a/cmd/commands/service/serviceTypes.go
+++ b/cmd/commands/service/serviceTypes.go
@@ -23,13 +23,15 @@ import (
 	"github.com/mysteriumnetwork/node/services/noop"
 	"github.com/mysteriumnetwork/node/services/openvpn"
 	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn/service"
+	"github.com/mysteriumnetwork/node/services/socks5"
+	socks5_service "github.com/mysteriumnetwork/node/services/socks5/service"
 	"github.com/mysteriumnetwork/node/services/wireguard"
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/urfave/cli/v2"
 )
 
 var (
-	serviceTypes = []string{"openvpn", "wireguard", "noop"}
+	serviceTypes = []string{"openvpn", "wireguard", "socks5", "noop"}
 
 	serviceTypesFlagsParser = map[string]func(ctx *cli.Context) service.Options{
 		noop.ServiceType: noop.ParseFlags,
@@ -40,6 +42,10 @@ var (
 		wireguard.ServiceType: func(ctx *cli.Context) service.Options {
 			config.ParseFlagsServiceWireguard(ctx)
 			return wireguard_service.GetOptions()
+		},
+		socks5.ServiceType: func(ctx *cli.Context) service.Options {
+			config.ParseFlagsServiceSOCKS5(ctx)
+			return socks5_service.GetOptions()
 		},
 	}
 )

--- a/cmd/serviceTypes.go
+++ b/cmd/serviceTypes.go
@@ -21,6 +21,8 @@ import (
 	service_noop "github.com/mysteriumnetwork/node/services/noop"
 	service_openvpn "github.com/mysteriumnetwork/node/services/openvpn"
 	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn/service"
+	service_socks5 "github.com/mysteriumnetwork/node/services/socks5"
+	socks5_service "github.com/mysteriumnetwork/node/services/socks5/service"
 	service_wireguard "github.com/mysteriumnetwork/node/services/wireguard"
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/mysteriumnetwork/node/tequilapi/endpoints"
@@ -31,5 +33,6 @@ var (
 		service_noop.ServiceType:      service_noop.ParseJSONOptions,
 		service_openvpn.ServiceType:   openvpn_service.ParseJSONOptions,
 		service_wireguard.ServiceType: wireguard_service.ParseJSONOptions,
+		service_socks5.ServiceType:    socks5_service.ParseJSONOptions,
 	}
 )

--- a/config/flags_service_socks5.go
+++ b/config/flags_service_socks5.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	// FlagSOCKS5Port port of listen port.
+	FlagSOCKS5Port = cli.IntFlag{
+		Name:  "socks5.port",
+		Usage: "Port of listen (e.g. 8080)",
+		Value: 8080,
+	}
+)
+
+// RegisterFlagsServiceSOCK5 function register SOCKS5 flags to flag list
+func RegisterFlagsServiceSOCK5(flags *[]cli.Flag) {
+	*flags = append(*flags,
+		&FlagSOCKS5Port,
+	)
+}
+
+// ParseFlagsServiceSOCKS5 parses CLI flags and registers value to configuration
+func ParseFlagsServiceSOCKS5(ctx *cli.Context) {
+	Current.ParseIntFlag(ctx, FlagSOCKS5Port)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/Sereal/Sereal v0.0.0-20190618215532-0b8ac451a863 // indirect
+	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/arthurkiller/rollingwriter v1.1.2
 	github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05
 	github.com/asdine/storm v2.1.2+incompatible

--- a/services/socks5/bootstrap.go
+++ b/services/socks5/bootstrap.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package socks5
+
+import (
+	"encoding/json"
+
+	"github.com/mysteriumnetwork/node/market"
+)
+
+// Bootstrap is called on program initialization time and registers various deserializers related to SOCKS5 service
+func Bootstrap() {
+	market.RegisterServiceDefinitionUnserializer(
+		ServiceType,
+		func(rawDefinition *json.RawMessage) (market.ServiceDefinition, error) {
+			var definition ServiceDefinition
+			err := json.Unmarshal(*rawDefinition, &definition)
+
+			return definition, err
+		},
+	)
+}
+
+// ServiceType indicates "socks5" service type
+const ServiceType = "socks5"
+
+// ServiceDefinition structure represents "socks5" service parameters
+type ServiceDefinition struct {
+	// Approximate information on location where the service is provided from
+	Location market.Location `json:"location"`
+
+	// Approximate information on location where the actual tunnelled traffic will originate from.
+	// This is used by providers having their own means of setting tunnels to other remote exit points.
+	LocationOriginate market.Location `json:"location_originate"`
+}
+
+// GetLocation returns geographic location of service definition provider
+func (service ServiceDefinition) GetLocation() market.Location {
+	return service.Location
+}

--- a/services/socks5/service/options.go
+++ b/services/socks5/service/options.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/mysteriumnetwork/node/config"
+	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/core/service"
+)
+
+// Options describes options which are required to start SOCKS5 service.
+type Options struct {
+	Port port.Port
+}
+
+// DefaultOptions is a SOCKS5 service configuration that will be used if no options provided.
+var DefaultOptions = Options{
+	Port: port.Port(8080),
+}
+
+// GetOptions returns effective SOCKS5 service options from application configuration.
+func GetOptions() Options {
+	return Options{
+		Port: port.Port(config.GetInt(config.FlagSOCKS5Port)),
+	}
+}
+
+// ParseJSONOptions function fills in SOCKS5 options from JSON request
+func ParseJSONOptions(request *json.RawMessage) (service.Options, error) {
+	var requestOptions = GetOptions()
+	if request == nil {
+		return requestOptions, nil
+	}
+
+	opts := DefaultOptions
+	err := json.Unmarshal(*request, &opts)
+	return opts, err
+}
+
+// MarshalJSON implements json.Marshaler interface to provide human readable configuration.
+func (o Options) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Port int `json:"port"`
+	}{
+		Port: o.Port.Num(),
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface to receive human readable configuration.
+func (o *Options) UnmarshalJSON(data []byte) error {
+	var options struct {
+		Port int `json:"port"`
+	}
+	if err := json.Unmarshal(data, &options); err != nil {
+		return err
+	}
+
+	if options.Port != 0 {
+		o.Port = port.Port(options.Port)
+	}
+
+	return nil
+}

--- a/services/socks5/service/options_test.go
+++ b/services/socks5/service/options_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"encoding/json"
+	"flag"
+	"testing"
+
+	"github.com/mysteriumnetwork/node/config"
+	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func Test_ParseJSONOptions_HandlesNil(t *testing.T) {
+	configureDefaults()
+	options, err := ParseJSONOptions(nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultOptions, options)
+}
+
+func Test_ParseJSONOptions_HandlesEmptyRequest(t *testing.T) {
+	configureDefaults()
+	request := json.RawMessage(`{}`)
+	options, err := ParseJSONOptions(&request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultOptions, options)
+}
+
+func Test_ParseJSONOptions_ValidRequest(t *testing.T) {
+	configureDefaults()
+	request := json.RawMessage(`{"port": 8000}`)
+	options, err := ParseJSONOptions(&request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Options{
+		Port: port.Port(8000),
+	}, options)
+}
+
+func configureDefaults() {
+	ctx := emptyContext()
+	config.ParseFlagsServiceSOCKS5(ctx)
+}
+
+func emptyContext() *cli.Context {
+	return cli.NewContext(nil, flag.NewFlagSet("", flag.ContinueOnError), nil)
+}

--- a/services/socks5/service/service.go
+++ b/services/socks5/service/service.go
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mysteriumnetwork/node/core/location"
+	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/nat/event"
+	"github.com/mysteriumnetwork/node/nat/mapping"
+	"github.com/mysteriumnetwork/node/nat/traversal"
+	"github.com/mysteriumnetwork/node/services/openvpn/discovery/dto"
+	"github.com/mysteriumnetwork/node/services/socks5"
+	sock5_session "github.com/mysteriumnetwork/node/services/socks5/session"
+	"github.com/mysteriumnetwork/node/session"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// GetProposal returns the proposal for SOCKS5 service
+func GetProposal(location location.Location) market.ServiceProposal {
+	marketLocation := market.Location{
+		Continent: location.Continent,
+		Country:   location.Country,
+		City:      location.City,
+
+		ASN:      location.ASN,
+		ISP:      location.ISP,
+		NodeType: location.NodeType,
+	}
+
+	return market.ServiceProposal{
+		ServiceType: socks5.ServiceType,
+		ServiceDefinition: socks5.ServiceDefinition{
+			Location:          marketLocation,
+			LocationOriginate: marketLocation,
+		},
+		PaymentMethodType: dto.PaymentMethodPerTime,
+		PaymentMethod:     dto.DefaultPaymentInfo,
+	}
+}
+
+// NATPinger defined Pinger interface for Provider
+type NATPinger interface {
+	BindServicePort(key string, port int)
+	Stop()
+	Valid() bool
+}
+
+// NATEventGetter allows us to fetch the last known NAT event
+type NATEventGetter interface {
+	LastEvent() *event.Event
+}
+
+// NewManager creates new instance of SOCKS5 service
+func NewManager(
+	options Options,
+	location location.ServiceLocationInfo,
+	natPort func(port int) (natRelease func()),
+	natEventGetter NATEventGetter,
+	natPinger NATPinger,
+) *Manager {
+	return &Manager{
+		natPort:        natPort,
+		natPinger:      natPinger,
+		natEventGetter: natEventGetter,
+		natPingerPorts: port.NewPool(),
+
+		servicePort: options.Port.Num(),
+		publicIP:    location.PubIP,
+		outboundIP:  location.OutIP,
+
+		done: make(chan struct{}),
+	}
+}
+
+// Manager represents an instance of SOCKS5 service
+type Manager struct {
+	natPort        func(int) (natPortRelease func())
+	natPinger      NATPinger
+	natPingerPorts port.ServicePortSupplier
+	natEventGetter NATEventGetter
+
+	servicePort int
+	publicIP    string
+	outboundIP  string
+
+	done chan struct{}
+}
+
+// ProvideConfig provides the config for consumer and handles new SOCKS5 connection.
+func (m *Manager) ProvideConfig(sessionRequestData json.RawMessage) (*session.ConfigParams, error) {
+	if m.servicePort == 0 {
+		return nil, errors.New("Service port not initialized")
+	}
+
+	sessionConfig := sock5_session.Response{
+		Port: m.servicePort,
+	}
+	sessionDestroy := func() {
+		// Do nothing
+	}
+
+	sessionRequest := sock5_session.Request{}
+	err := json.Unmarshal(sessionRequestData, &sessionRequest)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not unmarshal SOCKS5 session request")
+	}
+
+	natPingerEnabled := m.natPinger.Valid() && m.isBehindNAT() && m.portMappingFailed()
+	traversalParams, err := m.newTraversalParams(natPingerEnabled, sessionRequest)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create traversal params")
+	}
+
+	if natPingerEnabled {
+		log.Info().Msgf("NAT Pinger enabled, binding service port for proxy, key: %s", traversalParams.ProxyPortMappingKey)
+		m.natPinger.BindServicePort(traversalParams.ProxyPortMappingKey, sessionConfig.Port)
+		sessionConfig.PortNat = traversalParams.ConsumerPort
+		sessionConfig.Port = traversalParams.ProviderPort
+	}
+
+	return &session.ConfigParams{SessionServiceConfig: sessionConfig, SessionDestroyCallback: sessionDestroy, TraversalParams: &traversalParams}, nil
+}
+
+// Serve starts service - does block
+func (m *Manager) Serve(providerID identity.Identity) error {
+	releasePorts := m.natPort(m.servicePort)
+	defer releasePorts()
+
+	log.Info().Msg("SOCKS5 service started successfully now")
+	<-m.done
+	return nil
+}
+
+// Stop stops service.
+func (m *Manager) Stop() error {
+	close(m.done)
+
+	log.Info().Msg("SOCKS5 service stopped")
+	return nil
+}
+
+func (m *Manager) isBehindNAT() bool {
+	return m.outboundIP != m.publicIP
+}
+
+func (m *Manager) portMappingFailed() bool {
+	lastEvent := m.natEventGetter.LastEvent()
+	if lastEvent == nil {
+		return false
+	}
+
+	if lastEvent.Stage == traversal.StageName {
+		return true
+	}
+	return lastEvent.Stage == mapping.StageName && !lastEvent.Successful
+}
+
+func (m *Manager) newTraversalParams(natPingerEnabled bool, sessionRequest sock5_session.Request) (traversal.Params, error) {
+	params := traversal.Params{
+		Cancel: make(chan struct{}),
+	}
+	if !natPingerEnabled {
+		return params, nil
+	}
+
+	cp, err := m.natPingerPorts.Acquire()
+	if err != nil {
+		return params, errors.Wrap(err, "could not acquire NAT pinger consumer port")
+	}
+
+	params.ProviderPort = m.servicePort
+	params.ConsumerPort = cp.Num()
+	params.ProxyPortMappingKey = fmt.Sprintf("%s_%d", socks5.ServiceType, params.ProviderPort)
+
+	if sessionRequest.IP == "" {
+		return params, errors.New("remote party does not support NAT Hole punching, public IP is missing")
+	}
+	params.ConsumerPublicIP = sessionRequest.IP
+
+	return params, nil
+}

--- a/services/socks5/service/service_test.go
+++ b/services/socks5/service/service_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mysteriumnetwork/node/core/location"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/services/openvpn/discovery/dto"
+	"github.com/mysteriumnetwork/node/services/socks5"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	providerID  = identity.FromAddress("provider-id")
+	servicePort = 8080
+	publicIP    = "127.0.0.1"
+	outboundIP  = "127.0.0.1"
+	country     = "LT"
+)
+
+func Test_GetProposal(t *testing.T) {
+	assert.Exactly(
+		t,
+		market.ServiceProposal{
+			ServiceType: "socks5",
+			ServiceDefinition: socks5.ServiceDefinition{
+				Location:          market.Location{Country: country},
+				LocationOriginate: market.Location{Country: country},
+			},
+			PaymentMethodType: "PER_TIME",
+			PaymentMethod:     dto.DefaultPaymentInfo,
+		},
+		GetProposal(location.Location{Country: country}),
+	)
+}
+
+func Test_Manager_Stop(t *testing.T) {
+	manager := newManagerStub(servicePort, publicIP, outboundIP)
+
+	go func() {
+		err := manager.Serve(providerID)
+		assert.NoError(t, err)
+	}()
+
+	waitABit()
+	err := manager.Stop()
+	assert.NoError(t, err)
+}
+
+func Test_Manager_ProviderConfig_FailsWhenSessionConfigIsInvalid(t *testing.T) {
+	manager := newManagerStub(servicePort, publicIP, outboundIP)
+
+	params, err := manager.ProvideConfig(nil)
+
+	assert.Nil(t, params)
+	assert.Error(t, err)
+}
+
+// usually time.Sleep call gives a chance for other goroutines to kick in important when testing async code
+func waitABit() {
+	time.Sleep(10 * time.Millisecond)
+}
+
+func newManagerStub(servicePort int, publicIP, outboundIP string) *Manager {
+	return &Manager{
+		natPort: func(int) (natPortRelease func()) {
+			return func() {}
+		},
+
+		servicePort: servicePort,
+		publicIP:    publicIP,
+		outboundIP:  outboundIP,
+
+		done: make(chan struct{}),
+	}
+}

--- a/services/socks5/service/service_test.go
+++ b/services/socks5/service/service_test.go
@@ -89,7 +89,5 @@ func newManagerStub(servicePort int, publicIP, outboundIP string) *Manager {
 		servicePort: servicePort,
 		publicIP:    publicIP,
 		outboundIP:  outboundIP,
-
-		done: make(chan struct{}),
 	}
 }

--- a/services/socks5/session/config.go
+++ b/services/socks5/session/config.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package session
+
+// Request is used for sending some configuration from consumer to provider
+type Request struct {
+	IP string `json:"ip"`
+}
+
+// Response structure represents SOCKS5 configuration options for given session
+type Response struct {
+	Port    int `json:"port"`
+	PortNat int `json:"port_nat"`
+}


### PR DESCRIPTION
Providers can start additional service type now - "socks5" and shared their IP for cases like crawling, http request proxying, etc.
Crawling case enduser needed to establish proxy frontend on top of VPN connection, which is heavy, endusers can connection in P2P style.

Not implemented yet:
- connection negotiation part to this service
- authentication layer to allow only negotiated connections
- calculation of established session statistics