### PR TITLE
Sensible limits payments

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -523,7 +523,9 @@ func (c *cliApp) proposals(filter string) {
 }
 
 func (c *cliApp) fetchProposals() []tequilapi_client.ProposalDTO {
-	proposals, err := c.tequilapi.Proposals()
+	upperBound := config.GetUInt64(config.FlagPaymentsConsumerUpperPriceBound)
+	lowerBound := config.GetUInt64(config.FlagPaymentsConsumerLowerPriceBound)
+	proposals, err := c.tequilapi.ProposalsByPrice(lowerBound, upperBound)
 	if err != nil {
 		warn(err)
 		return []tequilapi_client.ProposalDTO{}

--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -65,6 +65,18 @@ var (
 		Name:  "payments.disable",
 		Usage: "Disables payments and moves to a backwards compatible legacy mode",
 	}
+	// FlagPaymentsConsumerUpperPriceBound sets the upper price bound to a set value.
+	FlagPaymentsConsumerUpperPriceBound = cli.Uint64Flag{
+		Name:  "payments.consumer.price.upper.bound",
+		Usage: "Sets the maximum price of the service. All proposals with a price above this bound will be filtered out and not visible.",
+		Value: 1000000,
+	}
+	// FlagPaymentsConsumerLowerPriceBound sets the lower price bound to a set value.
+	FlagPaymentsConsumerLowerPriceBound = cli.Uint64Flag{
+		Name:  "payments.consumer.price.lower.bound",
+		Usage: "Sets the minimum price of the service. All proposals with a below above this bound will be filtered out and not visible.",
+		Value: 0,
+	}
 )
 
 // RegisterFlagsPayments function register payments flags to flag list.
@@ -78,6 +90,8 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagPaymentsMystSCAddress,
 		&FlagPaymentsMaxRRecovery,
 		&FlagPaymentsDisable,
+		&FlagPaymentsConsumerUpperPriceBound,
+		&FlagPaymentsConsumerLowerPriceBound,
 	)
 }
 
@@ -90,4 +104,6 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseStringFlag(ctx, FlagPaymentsMystSCAddress)
 	Current.ParseUInt64Flag(ctx, FlagPaymentsMaxRRecovery)
 	Current.ParseBoolFlag(ctx, FlagPaymentsDisable)
+	Current.ParseUInt64Flag(ctx, FlagPaymentsConsumerUpperPriceBound)
+	Current.ParseUInt64Flag(ctx, FlagPaymentsConsumerLowerPriceBound)
 }

--- a/core/discovery/proposal/filter.go
+++ b/core/discovery/proposal/filter.go
@@ -30,6 +30,8 @@ type Filter struct {
 	LocationType       string
 	AccessPolicyID     string
 	AccessPolicySource string
+	UpperPriceBound    *uint64
+	LowerPriceBound    *uint64
 }
 
 // Matches return flag if filter matches given proposal
@@ -47,6 +49,11 @@ func (filter *Filter) Matches(proposal market.ServiceProposal) bool {
 	if filter.AccessPolicyID != "" || filter.AccessPolicySource != "" {
 		conditions = append(conditions, reducer.AccessPolicy(filter.AccessPolicyID, filter.AccessPolicySource))
 	}
+
+	if filter.UpperPriceBound != nil && filter.LowerPriceBound != nil {
+		conditions = append(conditions, reducer.Price(*filter.LowerPriceBound, *filter.UpperPriceBound))
+	}
+
 	if len(conditions) > 0 {
 		return reducer.And(conditions...)(proposal)
 	}

--- a/core/discovery/reducer/mocks.go
+++ b/core/discovery/reducer/mocks.go
@@ -19,6 +19,7 @@ package reducer
 
 import (
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/money"
 )
 
 var (
@@ -55,7 +56,40 @@ var (
 		ServiceDefinition: mockService{Location: locationResidential},
 		AccessPolicies:    &[]market.AccessPolicy{accessRuleWhitelist, accessRuleBlacklist},
 	}
+	proposalExpensive = market.ServiceProposal{
+		PaymentMethod: &mockPaymentMethod{
+			price: money.NewMoney(9999999999999, money.CurrencyMyst),
+		},
+	}
+	proposalCheap = market.ServiceProposal{
+		PaymentMethod: &mockPaymentMethod{
+			price: money.NewMoney(0, money.CurrencyMyst),
+		},
+	}
+	proposalExact = market.ServiceProposal{
+		PaymentMethod: &mockPaymentMethod{
+			price: money.NewMoney(1000000, money.CurrencyMyst),
+		},
+	}
 )
+
+type mockPaymentMethod struct {
+	rate        market.PaymentRate
+	paymentType string
+	price       money.Money
+}
+
+func (mpm *mockPaymentMethod) GetPrice() money.Money {
+	return mpm.price
+}
+
+func (mpm *mockPaymentMethod) GetType() string {
+	return mpm.paymentType
+}
+
+func (mpm *mockPaymentMethod) GetRate() market.PaymentRate {
+	return mpm.rate
+}
 
 type mockService struct {
 	Location market.Location

--- a/core/discovery/reducer/proposal.go
+++ b/core/discovery/reducer/proposal.go
@@ -63,6 +63,18 @@ func LocationType(proposal market.ServiceProposal) interface{} {
 	return service.GetLocation().NodeType
 }
 
+// Price checks if the price is below the given value
+func Price(lowerBound, upperBound uint64) func(market.ServiceProposal) bool {
+	return func(proposal market.ServiceProposal) bool {
+		if proposal.PaymentMethod != nil {
+			price := proposal.PaymentMethod.GetPrice().Amount
+			return price >= lowerBound && price <= upperBound
+		}
+
+		return true
+	}
+}
+
 // AccessPolicy returns a matcher for checking if proposal allows given access policy
 func AccessPolicy(id, source string) func(market.ServiceProposal) bool {
 	return func(proposal market.ServiceProposal) bool {

--- a/core/discovery/reducer/proposal_test.go
+++ b/core/discovery/reducer/proposal_test.go
@@ -85,3 +85,12 @@ func Test_AccessPolicy_FiltersByIDAndSource(t *testing.T) {
 	assert.False(t, match(proposalProvider1Noop))
 	assert.True(t, match(proposalProvider2Streaming))
 }
+
+func Test_Price_FiltersByPrice(t *testing.T) {
+	match := Price(100, 1000000)
+
+	assert.True(t, match(proposalEmpty))
+	assert.False(t, match(proposalExpensive))
+	assert.False(t, match(proposalCheap))
+	assert.True(t, match(proposalExact))
+}

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -137,6 +137,8 @@ func GetOptions() *Options {
 			MystSCAddress:                      config.GetString(config.FlagPaymentsMystSCAddress),
 			MaxRRecoveryLength:                 config.GetUInt64(config.FlagPaymentsMaxRRecovery),
 			PaymentsDisabled:                   config.GetBool(config.FlagPaymentsDisable),
+			ConsumerUpperPriceBound:            config.GetUInt64(config.FlagPaymentsConsumerUpperPriceBound),
+			ConsumerLowerPriceBound:            config.GetUInt64(config.FlagPaymentsConsumerLowerPriceBound),
 		},
 		Accountant: OptionsAccountant{
 			AccountantID:              config.GetString(config.FlagAccountantID),

--- a/core/node/options_payments.go
+++ b/core/node/options_payments.go
@@ -28,4 +28,6 @@ type OptionsPayments struct {
 	MystSCAddress                      string
 	MaxRRecoveryLength                 uint64
 	PaymentsDisabled                   bool
+	ConsumerUpperPriceBound            uint64
+	ConsumerLowerPriceBound            uint64
 }

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -151,6 +151,8 @@ func NewNode(appPath string, optionsNetwork *MobileNetworkOptions) (*MobileNode,
 			AccountantPromiseSettlingThreshold: 0.1,
 			SettlementTimeout:                  time.Hour * 2,
 			MystSCAddress:                      "0x7753cfAD258eFbC52A9A1452e42fFbce9bE486cb",
+			ConsumerUpperPriceBound:            1000000,
+			ConsumerLowerPriceBound:            0,
 		},
 	}
 
@@ -182,6 +184,8 @@ func NewNode(appPath string, optionsNetwork *MobileNetworkOptions) (*MobileNode,
 			di.ProposalRepository,
 			di.MysteriumAPI,
 			di.QualityClient,
+			options.Payments.ConsumerLowerPriceBound,
+			options.Payments.ConsumerUpperPriceBound,
 		),
 	}
 	return mobileNode, nil

--- a/mobile/mysterium/proposals_manager.go
+++ b/mobile/mysterium/proposals_manager.go
@@ -83,19 +83,24 @@ func newProposalsManager(
 	repository proposal.Repository,
 	mysteriumAPI mysteriumAPI,
 	qualityFinder qualityFinder,
+	lowerPriceBound,upperPriceBound uint64,
 ) *proposalsManager {
 	return &proposalsManager{
-		repository:    repository,
-		mysteriumAPI:  mysteriumAPI,
-		qualityFinder: qualityFinder,
+		repository:      repository,
+		mysteriumAPI:    mysteriumAPI,
+		qualityFinder:   qualityFinder,
+		upperPriceBound: upperPriceBound,
+		lowerPriceBound: lowerPriceBound,
 	}
 }
 
 type proposalsManager struct {
-	repository    proposal.Repository
-	cache         []market.ServiceProposal
-	mysteriumAPI  mysteriumAPI
-	qualityFinder qualityFinder
+	repository      proposal.Repository
+	cache           []market.ServiceProposal
+	mysteriumAPI    mysteriumAPI
+	qualityFinder   qualityFinder
+	upperPriceBound uint64
+	lowerPriceBound uint64
 }
 
 func (m *proposalsManager) getProposals(req *GetProposalsRequest) ([]byte, error) {
@@ -136,7 +141,10 @@ func (m *proposalsManager) getFromCache() []market.ServiceProposal {
 }
 
 func (m *proposalsManager) getFromRepository() ([]market.ServiceProposal, error) {
-	allProposals, err := m.repository.Proposals(&proposal.Filter{})
+	allProposals, err := m.repository.Proposals(&proposal.Filter{
+		UpperPriceBound: &m.upperPriceBound,
+		LowerPriceBound: &m.lowerPriceBound,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/mobile/mysterium/proposals_manager.go
+++ b/mobile/mysterium/proposals_manager.go
@@ -83,7 +83,7 @@ func newProposalsManager(
 	repository proposal.Repository,
 	mysteriumAPI mysteriumAPI,
 	qualityFinder qualityFinder,
-	lowerPriceBound,upperPriceBound uint64,
+	lowerPriceBound, upperPriceBound uint64,
 ) *proposalsManager {
 	return &proposalsManager{
 		repository:      repository,

--- a/mobile/mysterium/proposals_manager_test.go
+++ b/mobile/mysterium/proposals_manager_test.go
@@ -47,6 +47,7 @@ func (s *proposalManagerTestSuite) SetupTest() {
 		s.repository,
 		s.mysteriumAPI,
 		s.qualityFinder,
+		0, 1000000,
 	)
 }
 

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -296,7 +296,16 @@ func (client *Client) OriginLocation() (location LocationDTO, err error) {
 func (client *Client) ProposalsByType(serviceType string) ([]ProposalDTO, error) {
 	queryParams := url.Values{}
 	queryParams.Add("serviceType", serviceType)
-	response, err := client.http.Get("proposals", queryParams)
+	return client.proposals(queryParams)
+}
+
+// Proposals returns all available proposals for services
+func (client *Client) Proposals() ([]ProposalDTO, error) {
+	return client.proposals(url.Values{})
+}
+
+func (client *Client) proposals(query url.Values) ([]ProposalDTO, error) {
+	response, err := client.http.Get("proposals", query)
 	if err != nil {
 		return []ProposalDTO{}, err
 	}
@@ -307,17 +316,12 @@ func (client *Client) ProposalsByType(serviceType string) ([]ProposalDTO, error)
 	return proposals.Proposals, err
 }
 
-// Proposals returns all available proposals for services
-func (client *Client) Proposals() ([]ProposalDTO, error) {
-	response, err := client.http.Get("proposals", url.Values{})
-	if err != nil {
-		return []ProposalDTO{}, err
-	}
-	defer response.Body.Close()
-
-	var proposals ProposalList
-	err = parseResponseJSON(response, &proposals)
-	return proposals.Proposals, err
+// ProposalsByPrice returns all available proposals within the given price range
+func (client *Client) ProposalsByPrice(lower, upper uint64) ([]ProposalDTO, error) {
+	values := url.Values{}
+	values.Add("upperPriceBound", fmt.Sprintf("%v", upper))
+	values.Add("lowerPriceBound", fmt.Sprintf("%v", lower))
+	return client.proposals(values)
 }
 
 // Unlock allows using identity in following commands


### PR DESCRIPTION
Added a sensible limit for consumer in terms of price. Consumers can still force-connect if they have the required id's, but otherwise will not see proposals with exceedingly large prices.

Closes #1570 