### PR TITLE
Fix balance inconsistency

### DIFF
--- a/session/pingpong/exchange_message_tracker.go
+++ b/session/pingpong/exchange_message_tracker.go
@@ -242,7 +242,7 @@ func (emt *ExchangeMessageTracker) issueExchangeMessage(invoice crypto.Invoice) 
 
 	defer emt.deps.Publisher.Publish(ExchangeMessageTopic, ExchangeMessageEventPayload{
 		Identity:       emt.deps.Identity,
-		AmountPromised: amountToPromise,
+		AmountPromised: diff,
 	})
 
 	// TODO: we'd probably want to check if we have enough balance here

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -654,6 +654,20 @@ func (mbh *mockBlockchainHelper) IsRegistered(registryAddress, addressToCheck co
 	return mbh.isRegistered, mbh.isRegisteredError
 }
 
-type mockPublisher struct{}
+type event struct {
+	name  string
+	value interface{}
+}
 
-func (mp *mockPublisher) Publish(_ string, _ interface{}) {}
+type mockPublisher struct {
+	publicationChan chan event
+}
+
+func (mp *mockPublisher) Publish(topic string, payload interface{}) {
+	if mp.publicationChan != nil {
+		mp.publicationChan <- event{
+			name:  topic,
+			value: payload,
+		}
+	}
+}


### PR DESCRIPTION
Sending the total promised value instead of a diff caused a behaviour where balance would be shown incorrectly.

Sending the diff fixes this.

Closes #1558