### PR TITLE
Reveal R on session termination

### DIFF
--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -346,6 +346,9 @@ func (it *InvoiceTracker) Start() error {
 		emErrors <- it.listenForExchangeMessages()
 	}()
 
+	// on session close, try and reveal the promise before exiting
+	defer it.revealPromise()
+
 	// give the consumer a second to start up his payments before sending the first request
 	firstSend := time.After(time.Second)
 	for {


### PR DESCRIPTION
If a session was terminated prematurely(for example, by consumer) the last promise might not get revealed until the consumer would connect to us again.

This PR alleviates the problem somewhat by always trying to reveal R before exiting.

However, a proper mechanism for revealing R is required but is quite a bit harder to implement.

See #1585

Closes mysteriumnetwork/accountant#58