### PR TITLE
Fix WireGuard connection cleanup if start fails

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -838,8 +838,6 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
-gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/mobile/mysterium/wireguard_connection_setup_test.go
+++ b/mobile/mysterium/wireguard_connection_setup_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysterium
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mysteriumnetwork/node/consumer"
+	"github.com/mysteriumnetwork/node/core/connection"
+	"github.com/mysteriumnetwork/node/core/ip"
+	"github.com/mysteriumnetwork/node/nat/traversal"
+	wg "github.com/mysteriumnetwork/node/services/wireguard"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectionStartStop(t *testing.T) {
+	conn := newConn(t)
+
+	// Start connection.
+	sessionConfig, _ := json.Marshal(newServiceConfig())
+	err := conn.Start(connection.ConnectOptions{
+		DNS:           "1.2.3.4",
+		SessionConfig: sessionConfig,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, connection.Connecting, <-conn.State())
+	assert.Equal(t, connection.Connected, <-conn.State())
+	assert.Equal(t, consumer.SessionStatistics{BytesSent: 10, BytesReceived: 11}, <-conn.Statistics())
+
+	// Stop connection.
+	go func() {
+		conn.Stop()
+	}()
+	err = conn.Wait()
+	assert.NoError(t, err)
+}
+
+func TestConnectionStopAfterHandshakeError(t *testing.T) {
+	conn := newConn(t)
+	handshakeTimeoutErr := errors.New("handshake timeout")
+	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
+	sessionConfig, _ := json.Marshal(newServiceConfig())
+
+	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+	assert.Error(t, handshakeTimeoutErr, err)
+	assert.Equal(t, connection.Connecting, <-conn.State())
+	assert.Equal(t, connection.Disconnecting, <-conn.State())
+	assert.Equal(t, connection.NotConnected, <-conn.State())
+}
+
+func TestConnectionStopOnceAfterHandshakeErrorAndStopCall(t *testing.T) {
+	conn := newConn(t)
+	handshakeTimeoutErr := errors.New("handshake timeout")
+	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
+	sessionConfig, _ := json.Marshal(newServiceConfig())
+
+	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+
+	stopCh := make(chan struct{})
+	go func() {
+		conn.Stop()
+		stopCh <- struct{}{}
+	}()
+	<-stopCh
+
+	assert.Error(t, handshakeTimeoutErr, err)
+	assert.Equal(t, connection.Connecting, <-conn.State())
+	assert.Equal(t, connection.Disconnecting, <-conn.State())
+	assert.Equal(t, connection.NotConnected, <-conn.State())
+}
+
+func newConn(t *testing.T) *wireguardConnection {
+	opts := wireGuardOptions{
+		statsUpdateInterval: 1 * time.Microsecond,
+	}
+	conn, err := NewWireGuardConnection(opts, &mockWireGuardDevice{}, ip.NewResolverMock("172.44.1.12"), traversal.NewNoopPinger(), &mockHandshakeWaiter{})
+	assert.NoError(t, err)
+	return conn.(*wireguardConnection)
+}
+
+func newServiceConfig() wg.ServiceConfig {
+	endpoint, _ := net.ResolveUDPAddr("udp4", "127.0.0.1:51001")
+	return wg.ServiceConfig{
+		LocalPort:  51000,
+		RemotePort: 51001,
+		Provider: struct {
+			PublicKey string
+			Endpoint  net.UDPAddr
+		}{
+			PublicKey: "wg1",
+			Endpoint:  *endpoint,
+		},
+		Consumer: struct {
+			IPAddress    net.IPNet
+			DNSIPs       string
+			ConnectDelay int
+		}{
+			IPAddress: net.IPNet{
+				IP:   net.IPv4(127, 0, 0, 1),
+				Mask: net.IPv4Mask(255, 255, 255, 128),
+			},
+			DNSIPs:       "128.0.0.1",
+			ConnectDelay: 3000,
+		},
+	}
+}
+
+type mockWireGuardDevice struct {
+}
+
+func (m mockWireGuardDevice) Start(privateKey string, config wg.ServiceConfig) error {
+	return nil
+}
+
+func (m mockWireGuardDevice) Stop() {
+}
+
+func (m mockWireGuardDevice) Stats() (*wg.Stats, error) {
+	return &wg.Stats{BytesSent: 10, BytesReceived: 11}, nil
+}
+
+type mockHandshakeWaiter struct {
+	err error
+}
+
+func (m *mockHandshakeWaiter) Wait(statsFetch func() (*wg.Stats, error), timeout time.Duration, stop <-chan struct{}) error {
+	return m.err
+}

--- a/services/wireguard/connection/connection_test.go
+++ b/services/wireguard/connection/connection_test.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connection
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mysteriumnetwork/node/consumer"
+	"github.com/mysteriumnetwork/node/core/connection"
+	"github.com/mysteriumnetwork/node/core/ip"
+	"github.com/mysteriumnetwork/node/nat/traversal"
+	wg "github.com/mysteriumnetwork/node/services/wireguard"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectionStartStop(t *testing.T) {
+	conn := newConn(t)
+
+	// Start connection.
+	sessionConfig, _ := json.Marshal(newServiceConfig())
+	err := conn.Start(connection.ConnectOptions{
+		DNS:           "1.2.3.4",
+		SessionConfig: sessionConfig,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, connection.Connecting, <-conn.State())
+	assert.Equal(t, connection.Connected, <-conn.State())
+	assert.Equal(t, consumer.SessionStatistics{BytesSent: 10, BytesReceived: 11}, <-conn.Statistics())
+
+	// Stop connection.
+	go func() {
+		conn.Stop()
+	}()
+	err = conn.Wait()
+	assert.NoError(t, err)
+}
+
+func TestConnectionStopAfterHandshakeError(t *testing.T) {
+	conn := newConn(t)
+	handshakeTimeoutErr := errors.New("handshake timeout")
+	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
+	sessionConfig, _ := json.Marshal(newServiceConfig())
+
+	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+	assert.Error(t, handshakeTimeoutErr, err)
+	assert.Equal(t, connection.Connecting, <-conn.State())
+	assert.Equal(t, connection.Disconnecting, <-conn.State())
+	assert.Equal(t, connection.NotConnected, <-conn.State())
+}
+
+func TestConnectionStopOnceAfterHandshakeErrorAndStopCall(t *testing.T) {
+	conn := newConn(t)
+	handshakeTimeoutErr := errors.New("handshake timeout")
+	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
+	sessionConfig, _ := json.Marshal(newServiceConfig())
+
+	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+
+	stopCh := make(chan struct{})
+	go func() {
+		conn.Stop()
+		stopCh <- struct{}{}
+	}()
+	<-stopCh
+
+	assert.Error(t, handshakeTimeoutErr, err)
+	assert.Equal(t, connection.Connecting, <-conn.State())
+	assert.Equal(t, connection.Disconnecting, <-conn.State())
+	assert.Equal(t, connection.NotConnected, <-conn.State())
+}
+
+func newConn(t *testing.T) *Connection {
+	endpointFactory := func() (wg.ConnectionEndpoint, error) {
+		return &mockConnectionEndpoint{}, nil
+	}
+	opts := Options{
+		DNSConfigDir:        "/dns/dir",
+		StatsUpdateInterval: 1 * time.Microsecond,
+	}
+	conn, err := NewConnection(opts, ip.NewResolverMock("172.44.1.12"), traversal.NewNoopPinger(), endpointFactory, &mockDnsManager{}, &mockHandshakeWaiter{})
+	assert.NoError(t, err)
+	return conn.(*Connection)
+}
+
+func newServiceConfig() wg.ServiceConfig {
+	endpoint, _ := net.ResolveUDPAddr("udp4", "127.0.0.1:51001")
+	return wg.ServiceConfig{
+		LocalPort:  51000,
+		RemotePort: 51001,
+		Provider: struct {
+			PublicKey string
+			Endpoint  net.UDPAddr
+		}{
+			PublicKey: "wg1",
+			Endpoint:  *endpoint,
+		},
+		Consumer: struct {
+			IPAddress    net.IPNet
+			DNSIPs       string
+			ConnectDelay int
+		}{
+			IPAddress: net.IPNet{
+				IP:   net.IPv4(127, 0, 0, 1),
+				Mask: net.IPv4Mask(255, 255, 255, 128),
+			},
+			DNSIPs:       "128.0.0.1",
+			ConnectDelay: 3000,
+		},
+	}
+}
+
+type mockConnectionEndpoint struct{}
+
+func (mce *mockConnectionEndpoint) StartConsumerMode(config wg.ConsumerModeConfig) error { return nil }
+func (mce *mockConnectionEndpoint) StartProviderMode(config wg.ProviderModeConfig) error { return nil }
+func (mce *mockConnectionEndpoint) InterfaceName() string                                { return "mce0" }
+func (mce *mockConnectionEndpoint) Stop() error                                          { return nil }
+func (mce *mockConnectionEndpoint) Config() (wg.ServiceConfig, error)                    { return wg.ServiceConfig{}, nil }
+func (mce *mockConnectionEndpoint) AddPeer(_ string, _ wg.Peer) error                    { return nil }
+func (mce *mockConnectionEndpoint) RemovePeer(_ string) error                            { return nil }
+func (mce *mockConnectionEndpoint) ConfigureRoutes(_ net.IP) error                       { return nil }
+func (mce *mockConnectionEndpoint) PeerStats() (*wg.Stats, error) {
+	return &wg.Stats{LastHandshake: time.Now(), BytesSent: 10, BytesReceived: 11}, nil
+}
+
+type mockHandshakeWaiter struct {
+	err error
+}
+
+func (m *mockHandshakeWaiter) Wait(statsFetch func() (*wg.Stats, error), timeout time.Duration, stop <-chan struct{}) error {
+	return m.err
+}
+
+type mockDnsManager struct{}
+
+func (m mockDnsManager) Set(configDir, dev, dns string) error { return nil }
+func (m mockDnsManager) Clean(configDir, dev string) error    { return nil }

--- a/services/wireguard/connection/dns.go
+++ b/services/wireguard/connection/dns.go
@@ -25,14 +25,29 @@ import (
 	"path"
 )
 
-func setDNS(configDir, dev, dns string) error {
+// DNSManager is connection DNS configuration manager.
+type DNSManager interface {
+	// Set applies DNS configuration.
+	Set(configDir, dev, dns string) error
+	// Clean removes DNS configuration.
+	Clean(configDir, dev string) error
+}
+
+// NewDNSManager returns DNSManager instance.
+func NewDNSManager() DNSManager {
+	return &dnsManager{}
+}
+
+type dnsManager struct{}
+
+func (dm dnsManager) Set(configDir, dev, dns string) error {
 	cmd := exec.Command(path.Join(configDir, "update-resolv-conf"))
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "script_type=up", "dev="+dev, "foreign_option_1=dhcp-option DNS "+dns)
 	return cmd.Run()
 }
 
-func cleanDNS(configDir, dev string) error {
+func (dm dnsManager) Clean(configDir, dev string) error {
 	cmd := exec.Command(path.Join(configDir, "update-resolv-conf"))
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "script_type=down", "dev="+dev)

--- a/services/wireguard/wireguard.go
+++ b/services/wireguard/wireguard.go
@@ -73,6 +73,9 @@ func (method Payment) GetRate() market.PaymentRate {
 	}
 }
 
+// EndpointFactory creates new connection endpoint.
+type EndpointFactory func() (ConnectionEndpoint, error)
+
 // ConnectionEndpoint represents Wireguard network instance, it provide information
 // required for establishing connection between service provider and consumer.
 type ConnectionEndpoint interface {


### PR DESCRIPTION
Sometimes connection Start could finish setup tunnel but if handshake wait timeout (on any other error) occurs it will not cleanup. Now Start always calls Stop on error which does needed cleanup logic.

Fixes https://github.com/mysteriumnetwork/node/issues/1499