### PR TITLE
Consumer promise fee set to 0

### DIFF
--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -424,7 +424,7 @@ func (it *InvoiceTracker) sendInvoice() error {
 	}
 
 	r := it.generateR()
-	invoice := crypto.CreateInvoice(it.agreementID, shouldBe, it.transactorFee, r)
+	invoice := crypto.CreateInvoice(it.agreementID, shouldBe, 0, r)
 	invoice.Provider = it.deps.ProviderID.Address
 	err := it.deps.PeerInvoiceSender.Send(invoice)
 	if err != nil {


### PR DESCRIPTION
There's no point in setting the promise fees for consumer as the accountant settles them on its own, therefore setting fee to 0.