### PR TITLE
Fix npm repo tagging

### DIFF
--- a/ci/release/github.go
+++ b/ci/release/github.go
@@ -138,7 +138,7 @@ func ReleaseGithubTag() error {
 
 	_, err = tagReleaseGithub(&releaseGithubOpts{
 		owner:      env.Str(env.GithubOwner),
-		repository: env.Str("mysterium-client-npm-package"),
+		repository: "mysterium-client-npm-package",
 		version:    env.Str(env.BuildVersion),
 		token:      env.Str(env.GithubAPIToken),
 		createTag:  true, // Tag the related project to release artifacts in another repo


### PR DESCRIPTION
It supposes to be a static string, not an environment variable.