### PR TITLE
Enable traffic blocking for Openvpn service

### DIFF
--- a/bin/docker/alpine/Dockerfile
+++ b/bin/docker/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN bin/build
 FROM alpine:3.6
 
 # Install packages
-RUN apk add --update --no-cache iptables ca-certificates openvpn bash sudo openresolv
+RUN apk add --update --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv
 
 COPY bin/helpers/prepare-run-env.sh /usr/local/bin/prepare-run-env.sh
 COPY bin/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/bin/package/sudoers/mysterium-node
+++ b/bin/package/sudoers/mysterium-node
@@ -2,6 +2,7 @@
 # let mysterium-node run any command just as root without password
 mysterium-node    ALL=NOPASSWD: /sbin/sysctl
 mysterium-node    ALL=NOPASSWD: /sbin/iptables
+mysterium-node    ALL=NOPASSWD: /usr/sbin/ipset
 mysterium-node    ALL=NOPASSWD: /sbin/ip
 mysterium-node    ALL=NOPASSWD: /etc/mysterium-node/prepare-env.sh
 mysterium-node    ALL=NOPASSWD: /sbin/tc

--- a/bin/package_debian
+++ b/bin/package_debian
@@ -61,6 +61,7 @@ printf "Building Debian package '$PACKAGE_FILE' for architecture '$ARCH' ..\n" \
         --depends "resolvconf" \
         --depends "ca-certificates" \
         --depends "iptables" \
+        --depends "ipset" \
         --depends "iproute2" \
         --depends "sudo" \
         --depends "debconf" \

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -797,7 +797,7 @@ func (di *Dependencies) bootstrapNATComponents(options node.Options) {
 }
 
 func (di *Dependencies) bootstrapFirewall(options node.OptionsFirewall) error {
-	firewall.DefaultTrackingBlocker = firewall.NewTrackingBlocker()
+	firewall.DefaultTrackingBlocker = firewall.NewOutgoingTrafficBlocker()
 	if err := firewall.DefaultTrackingBlocker.Setup(); err != nil {
 		return err
 	}

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -181,6 +181,7 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 			portPool,
 			di.EventBus,
 			portMapper,
+			di.ServiceFirewall,
 		)
 		return manager, proposal, nil
 	}

--- a/core/policy/oracle.go
+++ b/core/policy/oracle.go
@@ -121,14 +121,11 @@ func (pr *Oracle) SubscribePolicies(policies []market.AccessPolicy, repository *
 	copy(subscriptionsNew, pr.fetchSubscriptions)
 
 	for _, policy := range policies {
-		index, exist := pr.getPolicyIndex(subscriptionsNew, policy)
-		if !exist {
-			index = len(subscriptionsNew)
-			subscriptionsNew = append(subscriptionsNew, policySubscription{
-				policy:      policy,
-				subscribers: []*Repository{repository},
-			})
-		}
+		index := len(subscriptionsNew)
+		subscriptionsNew = append(subscriptionsNew, policySubscription{
+			policy:      policy,
+			subscribers: []*Repository{repository},
+		})
 
 		if err := pr.fetchPolicyRules(&subscriptionsNew[index]); err != nil {
 			return errors.Wrap(err, "initial fetch failed")
@@ -137,16 +134,6 @@ func (pr *Oracle) SubscribePolicies(policies []market.AccessPolicy, repository *
 
 	pr.fetchSubscriptions = subscriptionsNew
 	return nil
-}
-
-func (pr *Oracle) getPolicyIndex(policyList []policySubscription, policy market.AccessPolicy) (int, bool) {
-	for index, policyMeta := range policyList {
-		if policyMeta.policy == policy {
-			return index, true
-		}
-	}
-
-	return 0, false
 }
 
 func (pr *Oracle) fetchPolicyRules(subscription *policySubscription) error {

--- a/core/policy/oracle_test.go
+++ b/core/policy/oracle_test.go
@@ -144,6 +144,23 @@ func Test_Oracle_SubscribePolicies_WhenEndpointSucceeds(t *testing.T) {
 	)
 }
 
+func Test_Oracle_SubscribePolicies_MultipleSubscribers(t *testing.T) {
+	server := mockPolicyServer()
+	defer server.Close()
+
+	oracle := createEmptyOracle(server.URL)
+
+	repo1 := NewRepository()
+	err := oracle.SubscribePolicies(oracle.Policies([]string{"1"}), repo1)
+	assert.NoError(t, err)
+	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRulesUpdated}, repo1.Rules())
+
+	repo2 := NewRepository()
+	err = oracle.SubscribePolicies(oracle.Policies([]string{"1"}), repo2)
+	assert.NoError(t, err)
+	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRulesUpdated}, repo2.Rules())
+}
+
 func Test_Oracle_StartSyncsPolicies(t *testing.T) {
 	repo := NewRepository()
 	server := mockPolicyServer()

--- a/core/policy/repository.go
+++ b/core/policy/repository.go
@@ -114,6 +114,25 @@ func (r *Repository) Rules() []market.AccessPolicyRuleSet {
 	return policiesRules
 }
 
+// HasDNSRules returns flag if any DNS rules are applied
+func (r *Repository) HasDNSRules() bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	for _, item := range r.items {
+		for _, rule := range item.rules.Allow {
+			if rule.Type == market.AccessPolicyTypeDNSZone {
+				return true
+			}
+			if rule.Type == market.AccessPolicyTypeDNSHostname {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func (r *Repository) findItemFor(policy market.AccessPolicy) (*listItem, error) {
 	for _, item := range r.items {
 		if item.policy == policy {

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -112,6 +112,7 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 	if len(policyIDs) > 0 {
 		policies := manager.policyOracle.Policies(policyIDs)
 		if err = manager.policyOracle.SubscribePolicies(policies, policyRules); err != nil {
+			log.Warn().Err(err).Msg("Can't find given access policies")
 			return id, ErrUnsupportedAccessPolicy
 		}
 		proposal.SetAccessPolicies(&policies)

--- a/firewall/factory.go
+++ b/firewall/factory.go
@@ -19,7 +19,7 @@
 
 package firewall
 
-// NewTrackingBlocker create instance of traffic blocker
-func NewTrackingBlocker() *noopTrafficBlocker {
-	return &noopTrafficBlocker{}
+// NewOutgoingTrafficBlocker create instance of traffic blocker
+func NewOutgoingTrafficBlocker() *outgoingBlockerNoop {
+	return &outgoingBlockerNoop{}
 }

--- a/firewall/factory.go
+++ b/firewall/factory.go
@@ -19,7 +19,12 @@
 
 package firewall
 
-// NewOutgoingTrafficBlocker create instance of traffic blocker
-func NewOutgoingTrafficBlocker() *outgoingBlockerNoop {
+// NewOutgoingTrafficBlocker creates instance of traffic blocker
+func NewOutgoingTrafficBlocker() OutgoingTrafficBlocker {
 	return &outgoingBlockerNoop{}
+}
+
+// NewIncomingTrafficBlocker creates instance of traffic blocker
+func NewIncomingTrafficBlocker() IncomingTrafficBlocker {
+	return NewIncomingTrafficBlockerNoop()
 }

--- a/firewall/factory.go
+++ b/firewall/factory.go
@@ -19,12 +19,12 @@
 
 package firewall
 
-// NewOutgoingTrafficBlocker creates instance of traffic blocker
+// NewOutgoingTrafficBlocker creates instance of traffic blocker.
 func NewOutgoingTrafficBlocker() OutgoingTrafficBlocker {
 	return &outgoingBlockerNoop{}
 }
 
-// NewIncomingTrafficBlocker creates instance of traffic blocker
+// NewIncomingTrafficBlocker creates instance of traffic blocker.
 func NewIncomingTrafficBlocker() IncomingTrafficBlocker {
 	return NewIncomingTrafficBlockerNoop()
 }

--- a/firewall/factory_android.go
+++ b/firewall/factory_android.go
@@ -19,7 +19,7 @@
 
 package firewall
 
-// NewTrackingBlocker create instance of traffic blocker
+// NewTrackingBlocker create instance of traffic blocker.
 func NewTrackingBlocker() *noopTrafficBlocker {
 	return &noopTrafficBlocker{}
 }

--- a/firewall/factory_linux.go
+++ b/firewall/factory_linux.go
@@ -19,7 +19,7 @@
 
 package firewall
 
-// NewOutgoingTrafficBlocker creates instance of traffic blocker
+// NewOutgoingTrafficBlocker creates instance of traffic blocker.
 func NewOutgoingTrafficBlocker() OutgoingTrafficBlocker {
 	return &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
@@ -27,7 +27,7 @@ func NewOutgoingTrafficBlocker() OutgoingTrafficBlocker {
 	}
 }
 
-// NewIncomingTrafficBlocker creates instance of traffic blocker
+// NewIncomingTrafficBlocker creates instance of traffic blocker.
 func NewIncomingTrafficBlocker() IncomingTrafficBlocker {
 	return NewIncomingTrafficBlockerIptables()
 }

--- a/firewall/factory_linux.go
+++ b/firewall/factory_linux.go
@@ -19,9 +19,9 @@
 
 package firewall
 
-// NewTrackingBlocker create instance of traffic blocker
-func NewTrackingBlocker() *iptablesTrafficBlocker {
-	return &iptablesTrafficBlocker{
+// NewOutgoingTrafficBlocker create instance of traffic blocker
+func NewOutgoingTrafficBlocker() *outgoingBlockerIptables {
+	return &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 		trafficLockScope: none,
 	}

--- a/firewall/incoming_blocker_interface.go
+++ b/firewall/incoming_blocker_interface.go
@@ -1,5 +1,3 @@
-//+build linux,!android
-
 /*
  * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
  *
@@ -19,15 +17,17 @@
 
 package firewall
 
-// NewOutgoingTrafficBlocker creates instance of traffic blocker
-func NewOutgoingTrafficBlocker() OutgoingTrafficBlocker {
-	return &outgoingBlockerIptables{
-		referenceTracker: make(map[string]refCount),
-		trafficLockScope: none,
-	}
+import (
+	"net"
+)
+
+// IncomingTrafficBlocker interface neededs to be satisfied by any implementations which provide firewall capabilities, like iptables
+type IncomingTrafficBlocker interface {
+	Setup() error
+	Teardown()
+	BlockIncomingTraffic(network net.IPNet) (IncomingRuleRemove, error)
+	AllowIPAccess(ip net.IP) (IncomingRuleRemove, error)
 }
 
-// NewIncomingTrafficBlocker creates instance of traffic blocker
-func NewIncomingTrafficBlocker() IncomingTrafficBlocker {
-	return NewIncomingTrafficBlockerIptables()
-}
+// IncomingRuleRemove type defines function for removal of created rule
+type IncomingRuleRemove func() error

--- a/firewall/incoming_blocker_interface.go
+++ b/firewall/incoming_blocker_interface.go
@@ -21,7 +21,7 @@ import (
 	"net"
 )
 
-// IncomingTrafficBlocker interface neededs to be satisfied by any implementations which provide firewall capabilities, like iptables
+// IncomingTrafficBlocker defines provider side firewall, to control which traffic is enabled to pass and which not.
 type IncomingTrafficBlocker interface {
 	Setup() error
 	Teardown()
@@ -29,5 +29,5 @@ type IncomingTrafficBlocker interface {
 	AllowIPAccess(ip net.IP) (IncomingRuleRemove, error)
 }
 
-// IncomingRuleRemove type defines function for removal of created rule
+// IncomingRuleRemove type defines function for removal of created rule.
 type IncomingRuleRemove func() error

--- a/firewall/incoming_blocker_iptables.go
+++ b/firewall/incoming_blocker_iptables.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	dnsFirewallChain = "PROVIDER_DNS_FIREWALL"
+	dnsFirewallChain = "MYST_PROVIDER_FIREWALL"
 	dnsFirewallIpset = "myst-provider-dst-whitelist"
 )
 
@@ -126,7 +126,7 @@ func (ibi *incomingBlockerIptables) cleanupStaleRules() error {
 		return err
 	}
 	for _, rule := range rules {
-		// detect if any references exist in FORWARD chain like -j PROVIDER_DNS_FIREWALL
+		// detect if any references exist in FORWARD chain like -j MYST_PROVIDER_FIREWALL
 		if strings.HasSuffix(rule, dnsFirewallChain) {
 			deleteRule := strings.Replace(rule, "-A", "-D", 1)
 			deleteRuleArgs := strings.Split(deleteRule, " ")

--- a/firewall/incoming_blocker_iptables.go
+++ b/firewall/incoming_blocker_iptables.go
@@ -31,12 +31,12 @@ const (
 	dnsFirewallIpset = "myst-provider-dst-whitelist"
 )
 
-// NewIncomingTrafficBlockerIptables creates instance iptables based traffic blocker
+// NewIncomingTrafficBlockerIptables creates instance iptables based traffic blocker.
 func NewIncomingTrafficBlockerIptables() IncomingTrafficBlocker {
 	return &incomingBlockerIptables{}
 }
 
-// incomingBlockerIptables allows incoming traffic blocking in IP granularity
+// incomingBlockerIptables allows incoming traffic blocking in IP granularity.
 type incomingBlockerIptables struct{}
 
 func (ibi *incomingBlockerIptables) Setup() error {

--- a/firewall/incoming_blocker_iptables.go
+++ b/firewall/incoming_blocker_iptables.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package firewall
+
+import (
+	"net"
+	"strings"
+
+	"github.com/mysteriumnetwork/node/firewall/ipset"
+	"github.com/mysteriumnetwork/node/firewall/iptables"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	dnsFirewallChain = "PROVIDER_DNS_FIREWALL"
+	dnsFirewallIpset = "dns-firewall-whitelist"
+)
+
+// NewIncomingTrafficBlockerIptables creates instance iptables based traffic blocker
+func NewIncomingTrafficBlockerIptables() IncomingTrafficBlocker {
+	return &incomingBlockerIptables{}
+}
+
+// incomingBlockerIptables allows incoming traffic blocking in IP granularity
+type incomingBlockerIptables struct{}
+
+func (ibi *incomingBlockerIptables) Setup() error {
+	if err := ibi.checkIpsetVersion(); err != nil {
+		return err
+	}
+
+	// Clean up setups from previous runs, just in case
+	if err := ibi.cleanupStaleRules(); err != nil {
+		return err
+	}
+	ipset.Exec(ipset.OpSetDelete(dnsFirewallIpset))
+
+	op := ipset.OpSetCreate(dnsFirewallIpset, ipset.SetTypeHashIP, net.CIDRMask(24, 32), 64)
+	if _, err := ipset.Exec(op); err != nil {
+		return err
+	}
+	return ibi.setupDNSFirewallChain()
+}
+
+func (ibi *incomingBlockerIptables) Teardown() {
+	if err := ibi.cleanupStaleRules(); err != nil {
+		log.Warn().Err(err).Msg("Error cleaning up iptables rules, you might want to do it yourself")
+	}
+	if errOutput, err := ipset.Exec(ipset.OpSetDelete(dnsFirewallIpset)); err != nil {
+		log.Warn().Err(err).Msgf("Error deleting ipset table. %s", strings.Join(errOutput, ""))
+	}
+}
+
+func (ibi *incomingBlockerIptables) BlockIncomingTraffic(network net.IPNet) (IncomingRuleRemove, error) {
+	remover, err := iptables.AddRuleWithRemoval(
+		iptables.AppendTo("FORWARD").RuleSpec("-s", network.String(), "-j", dnsFirewallChain),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		remover()
+		return nil
+	}, nil
+}
+
+func (ibi *incomingBlockerIptables) AllowIPAccess(ip net.IP) (IncomingRuleRemove, error) {
+	if _, err := ipset.Exec(ipset.OpSetIPAdd(dnsFirewallIpset, ip)); err != nil {
+		return nil, err
+	}
+	return func() error {
+		_, err := ipset.Exec(ipset.OpSetIPRemove(dnsFirewallIpset, ip))
+		return err
+	}, nil
+}
+
+func (ibi *incomingBlockerIptables) checkIpsetVersion() error {
+	output, err := ipset.Exec(ipset.OpVersion())
+	if err != nil {
+		return err
+	}
+	for _, line := range output {
+		log.Info().Msg("[version check] " + line)
+	}
+	return nil
+}
+
+func (ibi *incomingBlockerIptables) setupDNSFirewallChain() error {
+	// Add chain
+	if _, err := iptables.Exec("-N", dnsFirewallChain); err != nil {
+		return err
+	}
+
+	// Append rule - by default all packets going to dns firewall chain are rejected
+	if _, err := iptables.Exec("-A", dnsFirewallChain, "-m", "set", "--match-set", dnsFirewallIpset, "dst", "-j", "ACCEPT"); err != nil {
+		return err
+	}
+
+	// Append rule - by default all packets going to dns firewall chain are rejected
+	if _, err := iptables.Exec("-A", dnsFirewallChain, "-j", "REJECT"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ibi *incomingBlockerIptables) cleanupStaleRules() error {
+	// List rules
+	rules, err := iptables.Exec("-S", "FORWARD")
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		// detect if any references exist in FORWARD chain like -j PROVIDER_DNS_FIREWALL
+		if strings.HasSuffix(rule, dnsFirewallChain) {
+			deleteRule := strings.Replace(rule, "-A", "-D", 1)
+			deleteRuleArgs := strings.Split(deleteRule, " ")
+			if _, err := iptables.Exec(deleteRuleArgs...); err != nil {
+				return err
+			}
+		}
+	}
+
+	// List chain rules
+	if _, err := iptables.Exec("-L", dnsFirewallChain); err != nil {
+		// error means no such chain - log error just in case and bail out
+		log.Info().Err(err).Msg("[setup] Got error while listing kill switch chain rules. Probably nothing to worry about")
+		return nil
+	}
+
+	// Remove chain rules
+	if _, err := iptables.Exec("-F", dnsFirewallChain); err != nil {
+		return err
+	}
+
+	// Remove chain
+	_, err = iptables.Exec("-X", dnsFirewallChain)
+	return err
+}
+
+var _ IncomingTrafficBlocker = &incomingBlockerIptables{}

--- a/firewall/incoming_blocker_iptables_test.go
+++ b/firewall/incoming_blocker_iptables_test.go
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package firewall
+
+import (
+	"net"
+	"testing"
+
+	"github.com/mysteriumnetwork/node/firewall/ipset"
+	"github.com/mysteriumnetwork/node/firewall/iptables"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_iptablesDNSFirewall_Setup(t *testing.T) {
+	mockedIpset := ipsetExecMock{
+		mocks: map[string]ipsetExecResult{
+			"--version": {
+				output: []string{
+					"ipset v7.2, protocol version: 7",
+					"Warning: Kernel support protocol versions 6-6 while userspace supports protocol versions 6-7",
+				},
+			},
+			"-S FORWARD": {
+				output: []string{"-P FORWARD ACCEPT"},
+			},
+		},
+	}
+	ipset.Exec = mockedIpset.Exec
+
+	mockedIptables := iptablesExecMock{
+		mocks: map[string]iptablesExecResult{},
+	}
+	iptables.Exec = mockedIptables.Exec
+
+	firewall := &incomingBlockerIptables{}
+	err := firewall.Setup()
+	assert.NoError(t, err)
+	assert.True(t, mockedIpset.VerifyCalledWithArgs("version"))
+	assert.True(t, mockedIpset.VerifyCalledWithArgs("create dns-firewall-whitelist hash:ip --netmask 24 --hashsize 64"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-N PROVIDER_DNS_FIREWALL"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-A PROVIDER_DNS_FIREWALL -m set --match-set dns-firewall-whitelist dst -j ACCEPT"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-A PROVIDER_DNS_FIREWALL -j REJECT"))
+}
+
+func Test_iptablesDNSFirewall_Teardown(t *testing.T) {
+	mockedIpset := ipsetExecMock{
+		mocks: map[string]ipsetExecResult{},
+	}
+	ipset.Exec = mockedIpset.Exec
+
+	mockedIptables := iptablesExecMock{
+		mocks: map[string]iptablesExecResult{
+			"-S FORWARD": {
+				output: []string{
+					"-P FORWARD ACCEPT",
+				},
+			},
+		},
+	}
+	iptables.Exec = mockedIptables.Exec
+
+	firewall := &incomingBlockerIptables{}
+	firewall.Teardown()
+	assert.True(t, mockedIpset.VerifyCalledWithArgs("destroy dns-firewall-whitelist"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-F PROVIDER_DNS_FIREWALL"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-X PROVIDER_DNS_FIREWALL"))
+}
+
+func Test_iptablesDNSFirewall_TeardownIfPreviousCleanupFailed(t *testing.T) {
+	mockedIpset := ipsetExecMock{
+		mocks: map[string]ipsetExecResult{},
+	}
+	ipset.Exec = mockedIpset.Exec
+
+	mockedIptables := iptablesExecMock{
+		mocks: map[string]iptablesExecResult{
+			"-S FORWARD": {
+				output: []string{
+					"-P FORWARD ACCEPT",
+					// leftover - dns direwall is still enabled
+					"-A FORWARD -s 10.8.0.1/24 -j PROVIDER_DNS_FIREWALL",
+				},
+			},
+			// dns firewall chain still exists
+			"-S PROVIDER_DNS_FIREWALL": {
+				output: []string{
+					// with some allowed ips
+					"-N PROVIDER_DNS_FIREWALL",
+					"-A PROVIDER_DNS_FIREWALL -m set --match-set dns-firewall-whitelist dst -j ACCEPT",
+					"-A PROVIDER_DNS_FIREWALL -j REJECT --reject-with icmp-port-unreachable",
+				},
+			},
+		},
+	}
+	iptables.Exec = mockedIptables.Exec
+
+	firewall := &incomingBlockerIptables{}
+	firewall.Teardown()
+	assert.True(t, mockedIpset.VerifyCalledWithArgs("destroy dns-firewall-whitelist"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-D FORWARD -s 10.8.0.1/24 -j PROVIDER_DNS_FIREWALL"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-F PROVIDER_DNS_FIREWALL"))
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-X PROVIDER_DNS_FIREWALL"))
+}
+
+func Test_iptablesDNSFirewall_BlockIncomingTraffic(t *testing.T) {
+	mockedIptables := iptablesExecMock{
+		mocks: map[string]iptablesExecResult{},
+	}
+	iptables.Exec = mockedIptables.Exec
+
+	firewall := &incomingBlockerIptables{}
+
+	_, network, _ := net.ParseCIDR("10.8.0.1/24")
+	removeRule, err := firewall.BlockIncomingTraffic(*network)
+	assert.NoError(t, err)
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-A FORWARD -s 10.8.0.0/24 -j PROVIDER_DNS_FIREWALL"))
+
+	removeRule()
+	assert.True(t, mockedIptables.VerifyCalledWithArgs("-D FORWARD -s 10.8.0.0/24 -j PROVIDER_DNS_FIREWALL"))
+}
+
+func Test_iptablesDNSFirewall_AllowIPAccess(t *testing.T) {
+	mockedIpset := ipsetExecMock{
+		mocks: map[string]ipsetExecResult{},
+	}
+	ipset.Exec = mockedIpset.Exec
+
+	firewall := &incomingBlockerIptables{}
+
+	removeRule, err := firewall.AllowIPAccess(net.IP{1, 2, 3, 4})
+	assert.NoError(t, err)
+	assert.True(t, mockedIpset.VerifyCalledWithArgs("add dns-firewall-whitelist 1.2.3.4"))
+
+	err = removeRule()
+	assert.NoError(t, err)
+	assert.True(t, mockedIpset.VerifyCalledWithArgs("del dns-firewall-whitelist 1.2.3.4"))
+}

--- a/firewall/incoming_blocker_noop.go
+++ b/firewall/incoming_blocker_noop.go
@@ -18,49 +18,47 @@
 package firewall
 
 import (
+	"net"
+
 	"github.com/rs/zerolog/log"
 )
 
-// outgoingBlockerNoop is a Vendor implementation which only logs allow requests with no effects
+// NewIncomingTrafficBlockerNoop creates instance of noop traffic blocker
+func NewIncomingTrafficBlockerNoop() IncomingTrafficBlocker {
+	return &incomingBlockerNoop{}
+}
+
+// incomingBlockerNoop is a implementation which only logs allow requests with no effects
 // used by default
-type outgoingBlockerNoop struct{}
+type incomingBlockerNoop struct{}
 
 // Setup noop setup (just log call)
-func (obn *outgoingBlockerNoop) Setup() error {
+func (ibn *incomingBlockerNoop) Setup() error {
+	log.Info().Msg("Rules bootstrap was requested")
 	return nil
 }
 
 // Teardown noop cleanup (just log call)
-func (obn *outgoingBlockerNoop) Teardown() {
+func (ibn *incomingBlockerNoop) Teardown() {
 	log.Info().Msg("Rules reset was requested")
 }
 
 // BlockOutgoingTraffic just logs the call
-func (obn *outgoingBlockerNoop) BlockOutgoingTraffic(scope Scope, outboundIP string) (OutgoingRuleRemove, error) {
-	log.Info().Msg("Outgoing traffic block requested")
-	return func() {
-		log.Info().Msg("Outgoing traffic block removed")
+func (ibn *incomingBlockerNoop) BlockIncomingTraffic(network net.IPNet) (IncomingRuleRemove, error) {
+	log.Info().Msg("Incoming traffic block requested")
+	return func() error {
+		log.Info().Msg("Incoming traffic block removed")
+		return nil
 	}, nil
 }
 
 // AllowIPAccess logs IP for which access was requested
-func (obn *outgoingBlockerNoop) AllowIPAccess(ip string) (OutgoingRuleRemove, error) {
+func (ibn *incomingBlockerNoop) AllowIPAccess(ip net.IP) (IncomingRuleRemove, error) {
 	log.Info().Msgf("Allow IP %s access", ip)
-	return func() {
+	return func() error {
 		log.Info().Msgf("Rule for IP: %s removed", ip)
+		return nil
 	}, nil
 }
 
-// AllowIPAccess logs URL for which access was requested
-func (obn *outgoingBlockerNoop) AllowURLAccess(rawURLs ...string) (OutgoingRuleRemove, error) {
-	for _, rawURL := range rawURLs {
-		log.Info().Msgf("Allow URL %s access", rawURL)
-	}
-	return func() {
-		for _, rawURL := range rawURLs {
-			log.Info().Msgf("Rule for URL: %s removed", rawURL)
-		}
-	}, nil
-}
-
-var _ OutgoingTrafficBlocker = &outgoingBlockerNoop{}
+var _ IncomingTrafficBlocker = &incomingBlockerNoop{}

--- a/firewall/incoming_blocker_noop.go
+++ b/firewall/incoming_blocker_noop.go
@@ -23,27 +23,27 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// NewIncomingTrafficBlockerNoop creates instance of noop traffic blocker
+// NewIncomingTrafficBlockerNoop creates instance of noop traffic blocker.
 func NewIncomingTrafficBlockerNoop() IncomingTrafficBlocker {
 	return &incomingBlockerNoop{}
 }
 
-// incomingBlockerNoop is a implementation which only logs allow requests with no effects
-// used by default
+// incomingBlockerNoop is a implementation which only logs allow requests with no effects.
+// Used by default.
 type incomingBlockerNoop struct{}
 
-// Setup noop setup (just log call)
+// Setup noop setup (just log call).
 func (ibn *incomingBlockerNoop) Setup() error {
 	log.Info().Msg("Rules bootstrap was requested")
 	return nil
 }
 
-// Teardown noop cleanup (just log call)
+// Teardown noop cleanup (just log call).
 func (ibn *incomingBlockerNoop) Teardown() {
 	log.Info().Msg("Rules reset was requested")
 }
 
-// BlockOutgoingTraffic just logs the call
+// BlockOutgoingTraffic just logs the call.
 func (ibn *incomingBlockerNoop) BlockIncomingTraffic(network net.IPNet) (IncomingRuleRemove, error) {
 	log.Info().Msg("Incoming traffic block requested")
 	return func() error {
@@ -52,7 +52,7 @@ func (ibn *incomingBlockerNoop) BlockIncomingTraffic(network net.IPNet) (Incomin
 	}, nil
 }
 
-// AllowIPAccess logs IP for which access was requested
+// AllowIPAccess logs IP for which access was requested.
 func (ibn *incomingBlockerNoop) AllowIPAccess(ip net.IP) (IncomingRuleRemove, error) {
 	log.Info().Msgf("Allow IP %s access", ip)
 	return func() error {

--- a/firewall/ipset/ipset.go
+++ b/firewall/ipset/ipset.go
@@ -20,26 +20,22 @@ package ipset
 import (
 	"bufio"
 	"bytes"
-	"os/exec"
 
+	"github.com/mysteriumnetwork/node/utils/cmdutil"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 )
 
 // Exec activates given args
-var Exec = execCommand
+var Exec = defaultExec
 
-func execCommand(args []string) ([]string, error) {
+func defaultExec(args []string) ([]string, error) {
 	args = append([]string{"sudo", "/usr/sbin/ipset"}, args...)
-
-	log.Debug().Msgf("[cmd] %v", args)
-	output, err := exec.Command("sudo", args...).CombinedOutput()
+	output, err := cmdutil.ExecOutput(args...)
 	if err != nil {
-		log.Debug().Err(err).Msgf("[cmd error] %v output: %v", args, string(output))
 		return nil, errors.Wrap(err, "ipset cmd error")
 	}
 
-	outputScanner := bufio.NewScanner(bytes.NewBuffer(output))
+	outputScanner := bufio.NewScanner(bytes.NewBufferString(output))
 	var lines []string
 	for outputScanner.Scan() {
 		lines = append(lines, outputScanner.Text())

--- a/firewall/ipset/ipset.go
+++ b/firewall/ipset/ipset.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ipset
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// Exec activates given args
+var Exec = func(args []string) ([]string, error) {
+	args = append([]string{"sudo", "/usr/sbin/ipset"}, args...)
+
+	log.Debug().Msgf("[cmd] %v", args)
+	output, err := exec.Command("sudo", args...).CombinedOutput()
+	if err != nil {
+		log.Debug().Err(err).Msgf("[cmd error] %v output: %v", args, string(output))
+		return nil, errors.Wrap(err, "ipset cmd error")
+	}
+
+	outputScanner := bufio.NewScanner(bytes.NewBuffer(output))
+	var lines []string
+	for outputScanner.Scan() {
+		lines = append(lines, outputScanner.Text())
+	}
+	return lines, outputScanner.Err()
+}

--- a/firewall/ipset/ipset.go
+++ b/firewall/ipset/ipset.go
@@ -27,7 +27,9 @@ import (
 )
 
 // Exec activates given args
-var Exec = func(args []string) ([]string, error) {
+var Exec = execCommand
+
+func execCommand(args []string) ([]string, error) {
 	args = append([]string{"sudo", "/usr/sbin/ipset"}, args...)
 
 	log.Debug().Msgf("[cmd] %v", args)

--- a/firewall/ipset/operations.go
+++ b/firewall/ipset/operations.go
@@ -35,8 +35,8 @@ func OpVersion() []string {
 	return []string{"version"}
 }
 
-// OpSetCreate is an operation which creates a new set.
-func OpSetCreate(setName string, setType SetType, netMask net.IPMask, hashSize int) []string {
+// OpCreate is an operation which creates a new set.
+func OpCreate(setName string, setType SetType, netMask net.IPMask, hashSize int) []string {
 	args := []string{"create", setName, string(setType)}
 	if netMask != nil {
 		ones, _ := netMask.Size()
@@ -48,17 +48,17 @@ func OpSetCreate(setName string, setType SetType, netMask net.IPMask, hashSize i
 	return args
 }
 
-// OpSetDelete is an operation which destroys a named set.
-func OpSetDelete(setName string) []string {
+// OpDelete is an operation which destroys a named set.
+func OpDelete(setName string) []string {
 	return []string{"destroy", setName}
 }
 
-// OpSetIPAdd is an operation which adds IP entry to the named set.
-func OpSetIPAdd(setName string, ip net.IP) []string {
+// OpIPAdd is an operation which adds IP entry to the named set.
+func OpIPAdd(setName string, ip net.IP) []string {
 	return []string{"add", setName, ip.String()}
 }
 
-// OpSetIPRemove is an operation which deletes IP entry from the named set.
-func OpSetIPRemove(setName string, ip net.IP) []string {
+// OpIPRemove is an operation which deletes IP entry from the named set.
+func OpIPRemove(setName string, ip net.IP) []string {
 	return []string{"del", setName, ip.String()}
 }

--- a/firewall/ipset/operations.go
+++ b/firewall/ipset/operations.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ipset
+
+import (
+	"net"
+	"strconv"
+)
+
+// SetType defines type of IP set.
+type SetType string
+
+var (
+	// SetTypeHashIP set type uses a hash to store IP addresses where clashing is resolved by storing the clashing elements in an array and, as a last resort, by dynamically growing the hash.
+	SetTypeHashIP = SetType("hash:ip")
+)
+
+// OpVersion is an operation which prints version information.
+func OpVersion() []string {
+	return []string{"version"}
+}
+
+// OpSetCreate is an operation which creates a new set.
+func OpSetCreate(setName string, setType SetType, netMask net.IPMask, hashSize int) []string {
+	args := []string{"create", setName, string(setType)}
+	if netMask != nil {
+		ones, _ := netMask.Size()
+		args = append(args, "--netmask", strconv.Itoa(ones))
+	}
+	if hashSize != 0 {
+		args = append(args, "--hashsize", strconv.Itoa(hashSize))
+	}
+	return args
+}
+
+// OpSetDelete is an operation which destroys a named set.
+func OpSetDelete(setName string) []string {
+	return []string{"destroy", setName}
+}
+
+// OpSetIPAdd is an operation which adds IP entry to the named set.
+func OpSetIPAdd(setName string, ip net.IP) []string {
+	return []string{"add", setName, ip.String()}
+}
+
+// OpSetIPRemove is an operation which deletes IP entry from the named set.
+func OpSetIPRemove(setName string, ip net.IP) []string {
+	return []string{"del", setName, ip.String()}
+}

--- a/firewall/ipset_exec_mock.go
+++ b/firewall/ipset_exec_mock.go
@@ -1,5 +1,3 @@
-//+build linux,!android
-
 /*
  * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
  *
@@ -19,15 +17,29 @@
 
 package firewall
 
-// NewOutgoingTrafficBlocker creates instance of traffic blocker
-func NewOutgoingTrafficBlocker() OutgoingTrafficBlocker {
-	return &outgoingBlockerIptables{
-		referenceTracker: make(map[string]refCount),
-		trafficLockScope: none,
-	}
+import (
+	"strings"
+)
+
+type ipsetExecResult struct {
+	called bool
+	output []string
+	err    error
 }
 
-// NewIncomingTrafficBlocker creates instance of traffic blocker
-func NewIncomingTrafficBlocker() IncomingTrafficBlocker {
-	return NewIncomingTrafficBlockerIptables()
+type ipsetExecMock struct {
+	mocks map[string]ipsetExecResult
+}
+
+func (mce *ipsetExecMock) Exec(args []string) ([]string, error) {
+	key := strings.Join(args, " ")
+	res := mce.mocks[key]
+	res.called = true
+	mce.mocks[key] = res
+	return res.output, res.err
+}
+
+func (mce *ipsetExecMock) VerifyCalledWithArgs(args ...string) bool {
+	key := strings.Join(args, " ")
+	return mce.mocks[key].called
 }

--- a/firewall/iptables/iptables.go
+++ b/firewall/iptables/iptables.go
@@ -20,22 +20,23 @@ package iptables
 import (
 	"bufio"
 	"bytes"
-	"os/exec"
 
+	"github.com/mysteriumnetwork/node/utils/cmdutil"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
 // Exec actives given args
-var Exec = func(args ...string) ([]string, error) {
-	args = append([]string{"/sbin/iptables"}, args...)
-	log.Debug().Msgf("[cmd] %v", args)
-	output, err := exec.Command("sudo", args...).CombinedOutput()
+var Exec = defaultExec
+
+func defaultExec(args ...string) ([]string, error) {
+	args = append([]string{"sudo", "/sbin/iptables"}, args...)
+	output, err := cmdutil.ExecOutput(args...)
 	if err != nil {
-		log.Debug().Err(err).Msgf("[cmd error] %v output: %v", args, string(output))
 		return nil, errors.Wrap(err, "iptables cmd error")
 	}
-	outputScanner := bufio.NewScanner(bytes.NewBuffer(output))
+
+	outputScanner := bufio.NewScanner(bytes.NewBufferString(output))
 	var lines []string
 	for outputScanner.Scan() {
 		lines = append(lines, outputScanner.Text())

--- a/firewall/iptables_exec_mock.go
+++ b/firewall/iptables_exec_mock.go
@@ -31,17 +31,17 @@ type iptablesExecMock struct {
 	mocks map[string]iptablesExecResult
 }
 
-func (mce *iptablesExecMock) Exec(args ...string) ([]string, error) {
+func (iem *iptablesExecMock) Exec(args ...string) ([]string, error) {
 	key := argsToKey(args...)
-	res := mce.mocks[key]
+	res := iem.mocks[key]
 	res.called = true
-	mce.mocks[key] = res
+	iem.mocks[key] = res
 	return res.output, res.err
 }
 
-func (mce *iptablesExecMock) VerifyCalledWithArgs(args ...string) bool {
+func (iem *iptablesExecMock) VerifyCalledWithArgs(args ...string) bool {
 	key := argsToKey(args...)
-	return mce.mocks[key].called
+	return iem.mocks[key].called
 }
 
 func argsToKey(args ...string) string {

--- a/firewall/outgoing_blocker_default.go
+++ b/firewall/outgoing_blocker_default.go
@@ -33,29 +33,29 @@ var DefaultTrackingBlocker OutgoingTrafficBlocker = &outgoingBlockerNoop{}
 type OutgoingTrafficBlocker interface {
 	Setup() error
 	Teardown()
-	BlockOutgoingTraffic(scope Scope, outboundIP string) (RemoveRule, error)
-	AllowIPAccess(ip string) (RemoveRule, error)
-	AllowURLAccess(rawURLs ...string) (RemoveRule, error)
+	BlockOutgoingTraffic(scope Scope, outboundIP string) (OutgoingRuleRemove, error)
+	AllowIPAccess(ip string) (OutgoingRuleRemove, error)
+	AllowURLAccess(rawURLs ...string) (OutgoingRuleRemove, error)
 }
 
 // Scope type represents scope of blocking consumer traffic
 type Scope string
 
-// RemoveRule type defines function for removal of created rule
-type RemoveRule func()
+// OutgoingRuleRemove type defines function for removal of created rule
+type OutgoingRuleRemove func()
 
 // BlockNonTunnelTraffic effectively disallows any outgoing traffic from consumer node with specified scope
-func BlockNonTunnelTraffic(scope Scope, outboundIP string) (RemoveRule, error) {
+func BlockNonTunnelTraffic(scope Scope, outboundIP string) (OutgoingRuleRemove, error) {
 	return DefaultTrackingBlocker.BlockOutgoingTraffic(scope, outboundIP)
 }
 
 // AllowURLAccess adds exception to blocked traffic for specified URL (host part is usually taken)
-func AllowURLAccess(urls ...string) (RemoveRule, error) {
+func AllowURLAccess(urls ...string) (OutgoingRuleRemove, error) {
 	return DefaultTrackingBlocker.AllowURLAccess(urls...)
 }
 
 // AllowIPAccess adds IP based exception to underlying blocker implementation
-func AllowIPAccess(ip string) (RemoveRule, error) {
+func AllowIPAccess(ip string) (OutgoingRuleRemove, error) {
 	return DefaultTrackingBlocker.AllowIPAccess(ip)
 }
 

--- a/firewall/outgoing_blocker_default.go
+++ b/firewall/outgoing_blocker_default.go
@@ -27,10 +27,10 @@ const (
 )
 
 // DefaultTrackingBlocker traffic blocker bootstrapped for global calls
-var DefaultTrackingBlocker TrafficBlocker = &noopTrafficBlocker{}
+var DefaultTrackingBlocker OutgoingTrafficBlocker = &outgoingBlockerNoop{}
 
-// TrafficBlocker interface neededs to be satisfied by any implementations which provide firewall capabilities, like iptables
-type TrafficBlocker interface {
+// OutgoingTrafficBlocker interface neededs to be satisfied by any implementations which provide firewall capabilities, like iptables
+type OutgoingTrafficBlocker interface {
 	Setup() error
 	Teardown()
 	BlockOutgoingTraffic(scope Scope, outboundIP string) (RemoveRule, error)

--- a/firewall/outgoing_blocker_default.go
+++ b/firewall/outgoing_blocker_default.go
@@ -29,7 +29,9 @@ const (
 // DefaultTrackingBlocker traffic blocker bootstrapped for global calls
 var DefaultTrackingBlocker OutgoingTrafficBlocker = &outgoingBlockerNoop{}
 
-// OutgoingTrafficBlocker interface neededs to be satisfied by any implementations which provide firewall capabilities, like iptables
+// OutgoingTrafficBlocker defines consumer side firewall a.k.a. kill switch.
+// Purpose is to detect traffic which leaves machine and reject it,
+// because during established VPN connection it is expected to leave through tunnel device only.
 type OutgoingTrafficBlocker interface {
 	Setup() error
 	Teardown()
@@ -38,28 +40,28 @@ type OutgoingTrafficBlocker interface {
 	AllowURLAccess(rawURLs ...string) (OutgoingRuleRemove, error)
 }
 
-// Scope type represents scope of blocking consumer traffic
+// Scope type represents scope of blocking consumer traffic.
 type Scope string
 
-// OutgoingRuleRemove type defines function for removal of created rule
+// OutgoingRuleRemove type defines function for removal of created rule.
 type OutgoingRuleRemove func()
 
-// BlockNonTunnelTraffic effectively disallows any outgoing traffic from consumer node with specified scope
+// BlockNonTunnelTraffic effectively disallows any outgoing traffic from consumer node with specified scope.
 func BlockNonTunnelTraffic(scope Scope, outboundIP string) (OutgoingRuleRemove, error) {
 	return DefaultTrackingBlocker.BlockOutgoingTraffic(scope, outboundIP)
 }
 
-// AllowURLAccess adds exception to blocked traffic for specified URL (host part is usually taken)
+// AllowURLAccess adds exception to blocked traffic for specified URL (host part is usually taken).
 func AllowURLAccess(urls ...string) (OutgoingRuleRemove, error) {
 	return DefaultTrackingBlocker.AllowURLAccess(urls...)
 }
 
-// AllowIPAccess adds IP based exception to underlying blocker implementation
+// AllowIPAccess adds IP based exception to underlying blocker implementation.
 func AllowIPAccess(ip string) (OutgoingRuleRemove, error) {
 	return DefaultTrackingBlocker.AllowIPAccess(ip)
 }
 
-// Reset firewall state - usually called when cleanup is needed (during shutdown)
+// Reset firewall state - usually called when cleanup is needed (during shutdown).
 func Reset() {
 	DefaultTrackingBlocker.Teardown()
 }

--- a/firewall/outgoing_blocker_iptables.go
+++ b/firewall/outgoing_blocker_iptables.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var killswitchChain = "CONSUMER_KILL_SWITCH"
+const killswitchChain = "CONSUMER_KILL_SWITCH"
 
 type refCount struct {
 	count int

--- a/firewall/outgoing_blocker_iptables.go
+++ b/firewall/outgoing_blocker_iptables.go
@@ -39,7 +39,7 @@ type outgoingBlockerIptables struct {
 	referenceTracker map[string]refCount
 }
 
-// Setup tries to setup all changes made by setup and leave system in the state before setup
+// Setup tries to setup all changes made by setup and leave system in the state before setup.
 func (obi *outgoingBlockerIptables) Setup() error {
 	if err := obi.checkIptablesVersion(); err != nil {
 		return err
@@ -50,14 +50,14 @@ func (obi *outgoingBlockerIptables) Setup() error {
 	return obi.setupKillSwitchChain()
 }
 
-// Teardown tries to cleanup all changes made by setup and leave system in the state before setup
+// Teardown tries to cleanup all changes made by setup and leave system in the state before setup.
 func (obi *outgoingBlockerIptables) Teardown() {
 	if err := obi.cleanupStaleRules(); err != nil {
 		log.Warn().Err(err).Msg("Error cleaning up iptables rules, you might want to do it yourself")
 	}
 }
 
-// BlockOutgoingTraffic effectively disallows any outgoing traffic from consumer node with specified scope
+// BlockOutgoingTraffic effectively disallows any outgoing traffic from consumer node with specified scope.
 func (obi *outgoingBlockerIptables) BlockOutgoingTraffic(scope Scope, outboundIP string) (OutgoingRuleRemove, error) {
 	if obi.trafficLockScope == Global {
 		// nothing can override global lock
@@ -72,7 +72,7 @@ func (obi *outgoingBlockerIptables) BlockOutgoingTraffic(scope Scope, outboundIP
 	})
 }
 
-// AllowIPAccess adds exception to blocked traffic for specified URL (host part is usually taken)
+// AllowIPAccess adds exception to blocked traffic for specified URL (host part is usually taken).
 func (obi *outgoingBlockerIptables) AllowIPAccess(ip string) (OutgoingRuleRemove, error) {
 	return obi.trackingReferenceCall("allow:"+ip, func() (rule OutgoingRuleRemove, e error) {
 		return iptables.AddRuleWithRemoval(
@@ -81,7 +81,7 @@ func (obi *outgoingBlockerIptables) AllowIPAccess(ip string) (OutgoingRuleRemove
 	})
 }
 
-// AllowURLAccess adds URL based exception to underlying blocker implementation
+// AllowURLAccess adds URL based exception to underlying blocker implementation.
 func (obi *outgoingBlockerIptables) AllowURLAccess(rawURLs ...string) (OutgoingRuleRemove, error) {
 	var ruleRemovers []func()
 	removeAll := func() {

--- a/firewall/outgoing_blocker_iptables.go
+++ b/firewall/outgoing_blocker_iptables.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const killswitchChain = "CONSUMER_KILL_SWITCH"
+const killswitchChain = "MYST_CONSUMER_KILL_SWITCH"
 
 type refCount struct {
 	count int
@@ -146,7 +146,7 @@ func (obi *outgoingBlockerIptables) cleanupStaleRules() error {
 		return err
 	}
 	for _, rule := range rules {
-		// detect if any references exist in OUTPUT chain like -j CONSUMER_KILL_SWITCH
+		// detect if any references exist in OUTPUT chain like -j MYST_CONSUMER_KILL_SWITCH
 		if strings.HasSuffix(rule, killswitchChain) {
 			deleteRule := strings.Replace(rule, "-A", "-D", 1)
 			deleteRuleArgs := strings.Split(deleteRule, " ")

--- a/firewall/outgoing_blocker_iptables_test.go
+++ b/firewall/outgoing_blocker_iptables_test.go
@@ -31,7 +31,7 @@ func TestBlockerBlocksAllOutgoingTraffic(t *testing.T) {
 	}
 	iptables.Exec = mockedExec.Exec
 
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 
@@ -49,7 +49,7 @@ func TestSessionTrafficBlockIsNoopWhenGlobalBlockWasCalled(t *testing.T) {
 	}
 	iptables.Exec = mockedExec.Exec
 
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 
@@ -69,7 +69,7 @@ func TestSessionTrafficBlockIsNoopWhenGlobalBlockWasCalled(t *testing.T) {
 }
 
 func TestAllowIPAccessIsAddedAndRemoved(t *testing.T) {
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 
@@ -80,7 +80,7 @@ func TestAllowIPAccessIsAddedAndRemoved(t *testing.T) {
 }
 
 func TestHostsFromMultipleURLsAreAllowed(t *testing.T) {
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 
@@ -93,7 +93,7 @@ func TestHostsFromMultipleURLsAreAllowed(t *testing.T) {
 }
 
 func TestRuleIsRemovedOnlyAfterLastRemovalCall(t *testing.T) {
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 
@@ -125,7 +125,7 @@ func TestBlockerSetupIsSuccessful(t *testing.T) {
 	}
 	iptables.Exec = mockedExec.Exec
 
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 	assert.NoError(t, blocker.Setup())
@@ -158,7 +158,7 @@ func TestBlockerSetupIsSucessfulIfPreviousCleanupFailed(t *testing.T) {
 	}
 	iptables.Exec = mockedExec.Exec
 
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 	assert.NoError(t, blocker.Setup())
@@ -194,7 +194,7 @@ func TestBlockerResetIsSuccessful(t *testing.T) {
 	}
 	iptables.Exec = mockedExec.Exec
 
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 	blocker.Teardown()
@@ -209,7 +209,7 @@ func TestBlockerAddsAllowedIP(t *testing.T) {
 	}
 	iptables.Exec = mockedExec.Exec
 
-	blocker := &iptablesTrafficBlocker{
+	blocker := &outgoingBlockerIptables{
 		referenceTracker: make(map[string]refCount),
 	}
 

--- a/firewall/outgoing_blocker_iptables_test.go
+++ b/firewall/outgoing_blocker_iptables_test.go
@@ -142,15 +142,15 @@ func TestBlockerSetupIsSucessfulIfPreviousCleanupFailed(t *testing.T) {
 				output: []string{
 					"-P OUTPUT ACCEPT",
 					// leftover - kill switch is still enabled
-					"-A OUTPUT -s 5.5.5.5 -j CONSUMER_KILL_SWITCH",
+					"-A OUTPUT -s 5.5.5.5 -j MYST_CONSUMER_KILL_SWITCH",
 				},
 			},
 			// kill switch chain still exists
-			"-S CONSUMER_KILL_SWITCH": {
+			"-S MYST_CONSUMER_KILL_SWITCH": {
 				output: []string{
 					// with some allowed ips
-					"-A CONSUMER_KILL_SWITCH -d 2.2.2.2 -j ACCEPT",
-					"-A CONSUMER_KILL_SWITCH -j REJECT",
+					"-A MYST_CONSUMER_KILL_SWITCH -d 2.2.2.2 -j ACCEPT",
+					"-A MYST_CONSUMER_KILL_SWITCH -j REJECT",
 				},
 			},
 		},
@@ -176,17 +176,17 @@ func TestBlockerResetIsSuccessful(t *testing.T) {
 				output: []string{
 					"-P OUTPUT ACCEPT",
 					// kill switch is enabled
-					"-A OUTPUT -s 1.1.1.1 -j CONSUMER_KILL_SWITCH",
+					"-A OUTPUT -s 1.1.1.1 -j MYST_CONSUMER_KILL_SWITCH",
 				},
 			},
-			"-S CONSUMER_KILL_SWITCH": {
+			"-S MYST_CONSUMER_KILL_SWITCH": {
 				output: []string{
 					//first allowed address
-					"-A CONSUMER_KILL_SWITCH -d 2.2.2.2 -j ACCEPT",
+					"-A MYST_CONSUMER_KILL_SWITCH -d 2.2.2.2 -j ACCEPT",
 					//second allowed address
-					"-A CONSUMER_KILL_SWITCH -d 3.3.3.3 -j ACCEPT",
+					"-A MYST_CONSUMER_KILL_SWITCH -d 3.3.3.3 -j ACCEPT",
 					//drop everything else
-					"-A CONSUMER_KILL_SWITCH -j REJECT",
+					"-A MYST_CONSUMER_KILL_SWITCH -j REJECT",
 				},
 			},
 		},

--- a/firewall/outgoing_blocker_noop.go
+++ b/firewall/outgoing_blocker_noop.go
@@ -21,21 +21,21 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// outgoingBlockerNoop is a Vendor implementation which only logs allow requests with no effects
-// used by default
+// outgoingBlockerNoop is a Vendor implementation which only logs allow requests with no effects.
+// Used by default.
 type outgoingBlockerNoop struct{}
 
-// Setup noop setup (just log call)
+// Setup noop setup (just log call).
 func (obn *outgoingBlockerNoop) Setup() error {
 	return nil
 }
 
-// Teardown noop cleanup (just log call)
+// Teardown noop cleanup (just log call).
 func (obn *outgoingBlockerNoop) Teardown() {
 	log.Info().Msg("Rules reset was requested")
 }
 
-// BlockOutgoingTraffic just logs the call
+// BlockOutgoingTraffic just logs the call.
 func (obn *outgoingBlockerNoop) BlockOutgoingTraffic(scope Scope, outboundIP string) (OutgoingRuleRemove, error) {
 	log.Info().Msg("Outgoing traffic block requested")
 	return func() {
@@ -43,7 +43,7 @@ func (obn *outgoingBlockerNoop) BlockOutgoingTraffic(scope Scope, outboundIP str
 	}, nil
 }
 
-// AllowIPAccess logs IP for which access was requested
+// AllowIPAccess logs IP for which access was requested.
 func (obn *outgoingBlockerNoop) AllowIPAccess(ip string) (OutgoingRuleRemove, error) {
 	log.Info().Msgf("Allow IP %s access", ip)
 	return func() {
@@ -51,7 +51,7 @@ func (obn *outgoingBlockerNoop) AllowIPAccess(ip string) (OutgoingRuleRemove, er
 	}, nil
 }
 
-// AllowIPAccess logs URL for which access was requested
+// AllowIPAccess logs URL for which access was requested.
 func (obn *outgoingBlockerNoop) AllowURLAccess(rawURLs ...string) (OutgoingRuleRemove, error) {
 	for _, rawURL := range rawURLs {
 		log.Info().Msgf("Allow URL %s access", rawURL)

--- a/firewall/outgoing_blocker_noop.go
+++ b/firewall/outgoing_blocker_noop.go
@@ -21,22 +21,22 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// noopTrafficBlocker is a Vendor implementation which only logs allow requests with no effects
+// outgoingBlockerNoop is a Vendor implementation which only logs allow requests with no effects
 // used by default
-type noopTrafficBlocker struct{}
+type outgoingBlockerNoop struct{}
 
 // Setup noop setup (just log call)
-func (ntb *noopTrafficBlocker) Setup() error {
+func (obn *outgoingBlockerNoop) Setup() error {
 	return nil
 }
 
 // Teardown noop cleanup (just log call)
-func (ntb *noopTrafficBlocker) Teardown() {
+func (obn *outgoingBlockerNoop) Teardown() {
 	log.Info().Msg("Rules reset was requested")
 }
 
 // BlockOutgoingTraffic just logs the call
-func (ntb *noopTrafficBlocker) BlockOutgoingTraffic(scope Scope, outboundIP string) (RemoveRule, error) {
+func (obn *outgoingBlockerNoop) BlockOutgoingTraffic(scope Scope, outboundIP string) (RemoveRule, error) {
 	log.Info().Msg("Outgoing traffic block requested")
 	return func() {
 		log.Info().Msg("Outgoing traffic block removed")
@@ -44,7 +44,7 @@ func (ntb *noopTrafficBlocker) BlockOutgoingTraffic(scope Scope, outboundIP stri
 }
 
 // AllowIPAccess logs IP for which access was requested
-func (ntb *noopTrafficBlocker) AllowIPAccess(ip string) (RemoveRule, error) {
+func (obn *outgoingBlockerNoop) AllowIPAccess(ip string) (RemoveRule, error) {
 	log.Info().Msgf("Allow IP %s access", ip)
 	return func() {
 		log.Info().Msgf("Rule for IP: %s removed", ip)
@@ -52,7 +52,7 @@ func (ntb *noopTrafficBlocker) AllowIPAccess(ip string) (RemoveRule, error) {
 }
 
 // AllowIPAccess logs URL for which access was requested
-func (ntb *noopTrafficBlocker) AllowURLAccess(rawURLs ...string) (RemoveRule, error) {
+func (obn *outgoingBlockerNoop) AllowURLAccess(rawURLs ...string) (RemoveRule, error) {
 	for _, rawURL := range rawURLs {
 		log.Info().Msgf("Allow URL %s access", rawURL)
 	}
@@ -63,4 +63,4 @@ func (ntb *noopTrafficBlocker) AllowURLAccess(rawURLs ...string) (RemoveRule, er
 	}, nil
 }
 
-var _ TrafficBlocker = &noopTrafficBlocker{}
+var _ OutgoingTrafficBlocker = &outgoingBlockerNoop{}

--- a/localnet/node/Dockerfile
+++ b/localnet/node/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-alpine
 
 # Install packages
-RUN apk add --update --no-cache iptables ca-certificates openvpn wireguard-tools bash sudo openresolv gcc musl-dev make linux-headers vim curl tcpdump
+RUN apk add --update --no-cache iptables ipset ca-certificates openvpn wireguard-tools bash sudo openresolv gcc musl-dev make linux-headers vim curl tcpdump
 
 COPY ./bin/helpers/prepare-run-env.sh /usr/local/bin/prepare-run-env.sh
 COPY ./bin/package/config/common /etc/mysterium-node

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/firewall"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/nat"
 	"github.com/mysteriumnetwork/node/nat/mapping"
@@ -53,6 +54,7 @@ func NewManager(nodeOptions node.Options,
 	portPool port.ServicePortSupplier,
 	bus eventBus,
 	portMapper mapping.PortMapper,
+	trafficBlocker firewall.IncomingTrafficBlocker,
 ) *Manager {
 	clientMap := openvpn_session.NewClientMap(sessionMap)
 
@@ -83,6 +85,7 @@ func NewManager(nodeOptions node.Options,
 		ports:                          portPool,
 		eventListener:                  bus,
 		portMapper:                     portMapper,
+		trafficBlocker:                 trafficBlocker,
 		location:                       location,
 	}
 }


### PR DESCRIPTION
Updates: #1597

- When provider now start Openvpn service we setup firewall to inspect incoming consumer packets (based on iptables so just for Linux)
- This enables provider possibilities to share his internet by filtering consumer packets by port, destination or any other filters. Make these cases possible:  
-- block all & allow by whitelist
-- allow all & block by blacklist
- Currently no rules are enabled just prepares custom iptables chain wo activating it for a device