### PR TITLE
Check valid until & send transactor fee

### DIFF
--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -141,7 +141,7 @@ services:
       --transactor.registry-address=0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       --transactor.channel-implementation=0x599d43715DF3070f83355D9D90AE62c159E62A75
       --accountant.accountant-id=0xf2e2c77D2e7207d8341106E6EfA469d1940FD0d8
-      --accountant.address=http://accountant:8889/api/v1
+      --accountant.address=http://accountant:8889/api/v2
       --transactor.address=http://transactor:8888/api/v1
       --keystore.lightweight
       --log-level=debug

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -241,7 +241,7 @@ services:
       --transactor.channel-implementation=0x599d43715DF3070f83355D9D90AE62c159E62A75
       --transactor.registry-address=0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       --accountant.accountant-id=0xf2e2c77D2e7207d8341106E6EfA469d1940FD0d8
-      --accountant.address=http://accountant:8889/api/v1
+      --accountant.address=http://accountant:8889/api/v2
       --transactor.address=http://transactor:8888/api/v1
       --quality.address=http://morqa:8085/api/v1
       --quality-oracle.address=http://morqa:8085/api/v1
@@ -286,7 +286,7 @@ services:
       --transactor.registry-address=0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       --transactor.channel-implementation=0x599d43715DF3070f83355D9D90AE62c159E62A75
       --accountant.accountant-id=0xf2e2c77D2e7207d8341106E6EfA469d1940FD0d8
-      --accountant.address=http://accountant:8889/api/v1
+      --accountant.address=http://accountant:8889/api/v2
       --transactor.address=http://transactor:8888/api/v1
       --keystore.lightweight
       --log-level=debug

--- a/identity/registry/transactor.go
+++ b/identity/registry/transactor.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/eventbus"
@@ -63,7 +64,13 @@ func NewTransactor(httpClient *requests.HTTPClient, endpointAddress, registryAdd
 
 // FeesResponse represents fees applied by Transactor
 type FeesResponse struct {
-	Fee uint64 `json:"fee"`
+	Fee        uint64    `json:"fee"`
+	ValidUntil time.Time `json:"valid_until"`
+}
+
+// IsValid returns false if the fee has already expired and should be re-requested
+func (fr FeesResponse) IsValid() bool {
+	return time.Now().After(fr.ValidUntil)
 }
 
 // IdentityRegistrationRequestDTO represents the identity registration user input parameters

--- a/localnet/consumer.sh
+++ b/localnet/consumer.sh
@@ -17,7 +17,7 @@ exec /node/build/myst/myst \
   --transactor.channel-implementation=0x599d43715DF3070f83355D9D90AE62c159E62A75 \
   --transactor.registry-address=0xbe180c8CA53F280C7BE8669596fF7939d933AA10 \
   --accountant.accountant-id=0xf2e2c77D2e7207d8341106E6EfA469d1940FD0d8 \
-  --accountant.address=http://accountant:8889/api/v1 \
+  --accountant.address=http://accountant:8889/api/v2 \
   --transactor.address=http://transactor:8888/api/v1 \
   --quality.address=http://morqa:8085/api/v1 \
   --quality-oracle.address=http://morqa:8085/api/v1 \

--- a/localnet/provider.sh
+++ b/localnet/provider.sh
@@ -20,7 +20,7 @@ exec /node/build/myst/myst \
   --transactor.registry-address=0xbe180c8CA53F280C7BE8669596fF7939d933AA10 \
   --transactor.channel-implementation=0x599d43715DF3070f83355D9D90AE62c159E62A75 \
   --accountant.accountant-id=0xf2e2c77D2e7207d8341106E6EfA469d1940FD0d8 \
-  --accountant.address=http://accountant:8889/api/v1 \
+  --accountant.address=http://accountant:8889/api/v2 \
   --transactor.address=http://transactor:8888/api/v1 \
   --quality.address=http://morqa:8085/api/v1 \
   --quality-oracle.address=http://morqa:8085/api/v1 \

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -43,7 +43,7 @@ var TestnetDefinition = NetworkDefinition{
 	RegistryAddress:           "0x3dD81545F3149538EdCb6691A4FfEE1898Bd2ef0",
 	ChannelImplAddress:        "0x3026eB9622e2C5bdC157C6b117F7f4aC2C2Db3b5",
 	AccountantID:              "0x0214281cf15C1a66b51990e2E65e1f7b7C363318",
-	AccountantAddress:         "https://testnet-accountant.mysterium.network/api/v1",
+	AccountantAddress:         "https://testnet-accountant.mysterium.network/api/v2",
 	MMNAddress:                "https://my.mysterium.network/api/v1",
 }
 

--- a/session/pingpong/accountant_caller.go
+++ b/session/pingpong/accountant_caller.go
@@ -49,9 +49,15 @@ func NewAccountantCaller(transport *requests.HTTPClient, accountantBaseURI strin
 	}
 }
 
+// RequestPromise represents the request for a new accountant promise
+type RequestPromise struct {
+	ExchangeMessage crypto.ExchangeMessage `json:"exchange_message"`
+	TransactorFee   uint64                 `json:"transactor_fee"`
+}
+
 // RequestPromise requests a promise from accountant.
-func (ac *AccountantCaller) RequestPromise(em crypto.ExchangeMessage) (crypto.Promise, error) {
-	req, err := requests.NewPostRequest(ac.accountantBaseURI, "request_promise", em)
+func (ac *AccountantCaller) RequestPromise(rp RequestPromise) (crypto.Promise, error) {
+	req, err := requests.NewPostRequest(ac.accountantBaseURI, "request_promise", rp)
 	if err != nil {
 		return crypto.Promise{}, errors.Wrap(err, "could not form request_promise request")
 	}

--- a/session/pingpong/accountant_caller_test.go
+++ b/session/pingpong/accountant_caller_test.go
@@ -51,7 +51,7 @@ func TestAccountantCaller_RequestPromise_OK(t *testing.T) {
 
 	c := requests.NewHTTPClient("0.0.0.0", time.Second)
 	caller := NewAccountantCaller(c, server.URL)
-	p, err := caller.RequestPromise(crypto.ExchangeMessage{})
+	p, err := caller.RequestPromise(RequestPromise{})
 	assert.Nil(t, err)
 
 	assert.EqualValues(t, promise, p)
@@ -65,7 +65,7 @@ func TestAccountantCaller_RequestPromise_Error(t *testing.T) {
 
 	c := requests.NewHTTPClient("0.0.0.0", time.Second)
 	caller := NewAccountantCaller(c, server.URL)
-	_, err := caller.RequestPromise(crypto.ExchangeMessage{})
+	_, err := caller.RequestPromise(RequestPromise{})
 	assert.NotNil(t, err)
 }
 

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -414,7 +414,7 @@ func (it *InvoiceTracker) sendInvoice() error {
 	}
 
 	r := it.generateR()
-	invoice := crypto.CreateInvoice(it.agreementID, shouldBe, it.transactorFee, r)
+	invoice := crypto.CreateInvoice(it.agreementID, shouldBe, 0, r)
 	invoice.Provider = it.deps.ProviderID.Address
 	err := it.deps.PeerInvoiceSender.Send(invoice)
 	if err != nil {

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -56,7 +56,7 @@ func (mpis *MockPeerInvoiceSender) Send(invoice crypto.Invoice) error {
 
 type mockAccountantCaller struct{}
 
-func (mac *mockAccountantCaller) RequestPromise(em crypto.ExchangeMessage) (crypto.Promise, error) {
+func (mac *mockAccountantCaller) RequestPromise(rp RequestPromise) (crypto.Promise, error) {
 	return crypto.Promise{}, nil
 }
 


### PR DESCRIPTION
Up till now the provider was not sending the settlement fee to accountant, which meant that the transactor would get no cut from the promises.

This means that consumer does not have to set a transactor fee in its promise, while we need to ask for one from accountant.

Fixes #1435
Fixes #1628