### PR TITLE
Allow for recovery of lost promised amount on consumer side

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -678,6 +678,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 		network.EtherClientRPC,
 		network.MysteriumAPIAddress,
 		options.Transactor.TransactorEndpointAddress,
+		options.Accountant.AccountantEndpointAddress,
 	); err != nil {
 		return err
 	}

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -490,6 +490,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		return err
 	}
 
+	consumerDataGetter := pingpong.NewAccountantCaller(requests.NewHTTPClient(nodeOptions.BindAddress, time.Second*5), nodeOptions.Accountant.AccountantEndpointAddress).GetConsumerData
 	di.ConsumerBalanceTracker = pingpong.NewConsumerBalanceTracker(
 		di.EventBus,
 		common.HexToAddress(nodeOptions.Payments.MystSCAddress),
@@ -499,7 +500,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 			nodeOptions.Transactor.ChannelImplementation,
 			nodeOptions.Transactor.RegistryAddress,
 		),
-		pingpong.NewAccountantCaller(requests.NewHTTPClient(nodeOptions.BindAddress, time.Second*5), nodeOptions.Accountant.AccountantEndpointAddress).GetConsumerData,
+		consumerDataGetter,
 	)
 
 	err := di.ConsumerBalanceTracker.Subscribe(di.EventBus)
@@ -517,7 +518,9 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 			di.ConsumerTotalsStorage,
 			nodeOptions.Transactor.ChannelImplementation,
 			nodeOptions.Transactor.RegistryAddress,
-			di.EventBus),
+			di.EventBus,
+			consumerDataGetter,
+		),
 		di.ConnectionRegistry.CreateConnection,
 		di.EventBus,
 		connectivity.NewStatusSender(),

--- a/session/pingpong/consumer_totals_storage.go
+++ b/session/pingpong/consumer_totals_storage.go
@@ -39,18 +39,18 @@ func NewConsumerTotalsStorage(bolt persistentStorage) *ConsumerTotalsStorage {
 }
 
 // Store stores the given amount as promised for the given channel.
-func (cts *ConsumerTotalsStorage) Store(providerAddress string, amount uint64) error {
+func (cts *ConsumerTotalsStorage) Store(consumerAddress, accountantAddress string, amount uint64) error {
 	cts.lock.Lock()
 	defer cts.lock.Unlock()
-	return cts.bolt.SetValue(consumerTotalStorageBucketName, providerAddress, amount)
+	return cts.bolt.SetValue(consumerTotalStorageBucketName, consumerAddress+accountantAddress, amount)
 }
 
 // Get fetches the amount as promised for the given channel.
-func (cts *ConsumerTotalsStorage) Get(providerAddress string) (uint64, error) {
+func (cts *ConsumerTotalsStorage) Get(consumerAddress, accountantAddress string) (uint64, error) {
 	cts.lock.Lock()
 	defer cts.lock.Unlock()
 	var res uint64
-	err := cts.bolt.GetValue(consumerTotalStorageBucketName, providerAddress, &res)
+	err := cts.bolt.GetValue(consumerTotalStorageBucketName, consumerAddress+accountantAddress, &res)
 	if err != nil {
 		// wrap the error to an error we can check for
 		if err.Error() == errBoltNotFound {

--- a/session/pingpong/consumer_totals_storage_test.go
+++ b/session/pingpong/consumer_totals_storage_test.go
@@ -38,39 +38,40 @@ func TestConsumerTotalStorage(t *testing.T) {
 	consumerTotalsStorage := NewConsumerTotalsStorage(bolt)
 
 	channelAddress := "someAddress"
+	accountantAddress := "someOtherAddress"
 	var amount uint64 = 12
 
 	// check if errors are wrapped correctly
-	_, err = consumerTotalsStorage.Get(channelAddress)
+	_, err = consumerTotalsStorage.Get(channelAddress, accountantAddress)
 	assert.Equal(t, ErrNotFound, err)
 
 	// store and check that total is stored correctly
-	err = consumerTotalsStorage.Store(channelAddress, amount)
+	err = consumerTotalsStorage.Store(channelAddress, accountantAddress, amount)
 	assert.NoError(t, err)
 
-	a, err := consumerTotalsStorage.Get(channelAddress)
+	a, err := consumerTotalsStorage.Get(channelAddress, accountantAddress)
 	assert.NoError(t, err)
 	assert.Equal(t, amount, a)
 
 	var newAmount uint64 = 123
 	// overwrite the amount, check if it is overwritten
-	err = consumerTotalsStorage.Store(channelAddress, newAmount)
+	err = consumerTotalsStorage.Store(channelAddress, accountantAddress, newAmount)
 	assert.NoError(t, err)
 
-	a, err = consumerTotalsStorage.Get(channelAddress)
+	a, err = consumerTotalsStorage.Get(channelAddress, accountantAddress)
 	assert.NoError(t, err)
 	assert.EqualValues(t, newAmount, a)
 
 	someOtherChannel := "someOtherChannel"
 	// store two amounts, check if both are gotten correctly
-	err = consumerTotalsStorage.Store(someOtherChannel, amount)
+	err = consumerTotalsStorage.Store(someOtherChannel, accountantAddress, amount)
 	assert.NoError(t, err)
 
-	a, err = consumerTotalsStorage.Get(channelAddress)
+	a, err = consumerTotalsStorage.Get(channelAddress, accountantAddress)
 	assert.NoError(t, err)
 	assert.EqualValues(t, newAmount, a)
 
-	a, err = consumerTotalsStorage.Get(someOtherChannel)
+	a, err = consumerTotalsStorage.Get(someOtherChannel, accountantAddress)
 	assert.NoError(t, err)
 	assert.EqualValues(t, amount, a)
 }

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -113,7 +113,9 @@ func BackwardsCompatibleExchangeFactoryFunc(
 	signer identity.SignerFactory,
 	totalStorage consumerTotalsStorage,
 	channelImplementation string,
-	registryAddress string, publisher eventbus.Publisher) func(paymentInfo *promise.PaymentInfo,
+	registryAddress string,
+	publisher eventbus.Publisher,
+	getConsumerInfo getConsumerInfo) func(paymentInfo *promise.PaymentInfo,
 	dialog communication.Dialog,
 	consumer, provider, accountant identity.Identity, proposal market.ServiceProposal) (connection.PaymentIssuer, error) {
 	return func(paymentInfo *promise.PaymentInfo,
@@ -162,6 +164,8 @@ func BackwardsCompatibleExchangeFactoryFunc(
 				PaymentInfo:               rate,
 				ChannelAddressCalculator:  NewChannelAddressCalculator(accountant.Address, channelImplementation, registryAddress),
 				Publisher:                 publisher,
+				AccountantAddress:         accountant,
+				ConsumerInfoGetter:        getConsumerInfo,
 			}
 			payments = NewExchangeMessageTracker(deps)
 		} else {


### PR DESCRIPTION
The consumer will now ask accountant in case his promised total gets lost.

Consumer totals storage now also stores data for consumer+accountant combo.

Fixes #1587