### PR TITLE
Decouple policy repository from Oracle rules fetching

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -127,7 +127,7 @@ type Dependencies struct {
 	IPResolver       ip.Resolver
 	LocationResolver *location.Cache
 
-	PolicyRepository *policy.Repository
+	PolicyOracle *policy.Oracle
 
 	StatisticsTracker                *statistics.SessionStatisticsTracker
 	StatisticsReporter               *statistics.SessionStatisticsReporter
@@ -343,8 +343,8 @@ func (di *Dependencies) Shutdown() (err error) {
 		}
 	}
 
-	if di.PolicyRepository != nil {
-		di.PolicyRepository.Stop()
+	if di.PolicyOracle != nil {
+		di.PolicyOracle.Stop()
 	}
 
 	if di.NATService != nil {

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -239,7 +239,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options, ser
 	di.ServiceSessionStorage = storage
 
 	di.PolicyOracle = policy.NewOracle(di.HTTPClient, servicesOptions.AccessPolicyAddress, servicesOptions.AccessPolicyFetchInterval)
-	di.PolicyOracle.Start()
+	go di.PolicyOracle.Start()
 
 	newDialogWaiter := func(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy, policiesRules *policy.Repository) (communication.DialogWaiter, error) {
 		return nats_dialog.NewDialogWaiter(

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -241,12 +241,12 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options, ser
 	di.PolicyOracle = policy.NewOracle(di.HTTPClient, servicesOptions.AccessPolicyAddress, servicesOptions.AccessPolicyFetchInterval)
 	go di.PolicyOracle.Start()
 
-	newDialogWaiter := func(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy, policiesRules *policy.Repository) (communication.DialogWaiter, error) {
+	newDialogWaiter := func(providerID identity.Identity, serviceType string, policies *policy.Repository) (communication.DialogWaiter, error) {
 		return nats_dialog.NewDialogWaiter(
 			di.BrokerConnection,
 			fmt.Sprintf("%v.%v", providerID.Address, serviceType),
 			di.SignerFactory(providerID),
-			policy.ValidateAllowedIdentity(policiesRules, policies),
+			policy.ValidateAllowedIdentity(policies),
 		), nil
 	}
 	newDialogHandler := func(proposal market.ServiceProposal, configProvider session.ConfigProvider, serviceID string) (communication.DialogHandler, error) {

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -238,15 +238,15 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options, ser
 	}
 	di.ServiceSessionStorage = storage
 
-	di.PolicyRepository = policy.NewRepository(di.HTTPClient, servicesOptions.AccessPolicyAddress, servicesOptions.AccessPolicyFetchInterval)
-	di.PolicyRepository.Start()
+	di.PolicyOracle = policy.NewOracle(di.HTTPClient, servicesOptions.AccessPolicyAddress, servicesOptions.AccessPolicyFetchInterval)
+	di.PolicyOracle.Start()
 
-	newDialogWaiter := func(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy) (communication.DialogWaiter, error) {
+	newDialogWaiter := func(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy, policiesRules *policy.Repository) (communication.DialogWaiter, error) {
 		return nats_dialog.NewDialogWaiter(
 			di.BrokerConnection,
 			fmt.Sprintf("%v.%v", providerID.Address, serviceType),
 			di.SignerFactory(providerID),
-			policy.ValidateAllowedIdentity(di.PolicyRepository, policies),
+			policy.ValidateAllowedIdentity(policiesRules, policies),
 		), nil
 	}
 	newDialogHandler := func(proposal market.ServiceProposal, configProvider session.ConfigProvider, serviceID string) (communication.DialogHandler, error) {
@@ -282,7 +282,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options, ser
 		newDialogHandler,
 		di.DiscoveryFactory,
 		di.EventBus,
-		di.PolicyRepository,
+		di.PolicyOracle,
 	)
 
 	serviceCleaner := service.Cleaner{SessionStorage: di.ServiceSessionStorage}

--- a/core/policy/oracle.go
+++ b/core/policy/oracle.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mysteriumnetwork/node/logconfig/httptrace"
+	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/requests"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type policySubscription struct {
+	policy      market.AccessPolicy
+	eTag        string
+	subscribers []*Repository
+}
+
+// Oracle represents async policy fetcher from TrustOracle
+type Oracle struct {
+	client             *requests.HTTPClient
+	fetchURL           string
+	fetchInterval      time.Duration
+	fetchLock          sync.RWMutex
+	fetchSubscriptions []policySubscription
+
+	fetchShutdown     chan struct{}
+	fetchShutdownOnce sync.Once
+}
+
+// NewOracle create instance of policy fetcher
+func NewOracle(client *requests.HTTPClient, policyURL string, interval time.Duration) *Oracle {
+	return &Oracle{
+		client:             client,
+		fetchURL:           policyURL,
+		fetchInterval:      interval,
+		fetchSubscriptions: make([]policySubscription, 0),
+		fetchShutdown:      make(chan struct{}),
+	}
+}
+
+// Start begins fetching policies to to subscribers
+func (pr *Oracle) Start() {
+	go pr.fetchLoop()
+}
+
+// Stop ends fetching policies to subscribers
+func (pr *Oracle) Stop() {
+	pr.fetchShutdownOnce.Do(func() {
+		close(pr.fetchShutdown)
+	})
+}
+
+// Policy converts given value to valid policy rule
+func (pr *Oracle) Policy(policyID string) market.AccessPolicy {
+	policyURL := pr.fetchURL
+	if !strings.HasSuffix(policyURL, "/") {
+		policyURL += "/"
+	}
+	return market.AccessPolicy{
+		ID:     policyID,
+		Source: fmt.Sprintf("%v%v", policyURL, policyID),
+	}
+}
+
+// Policies converts given values to list of valid policies
+func (pr *Oracle) Policies(policyIDs []string) []market.AccessPolicy {
+	policies := make([]market.AccessPolicy, len(policyIDs))
+	for i, policyID := range policyIDs {
+		policies[i] = pr.Policy(policyID)
+	}
+	return policies
+}
+
+// SubscribePolicies adds given policies to repository and syncs changes of it's rules from TrustOracle
+func (pr *Oracle) SubscribePolicies(policies []market.AccessPolicy, repository *Repository) error {
+	pr.fetchLock.Lock()
+	defer pr.fetchLock.Unlock()
+
+	subscriptionsNew := make([]policySubscription, len(pr.fetchSubscriptions))
+	copy(subscriptionsNew, pr.fetchSubscriptions)
+
+	for _, policy := range policies {
+		index, exist := pr.getPolicyIndex(subscriptionsNew, policy)
+		if !exist {
+			index = len(subscriptionsNew)
+			subscriptionsNew = append(subscriptionsNew, policySubscription{
+				policy:      policy,
+				subscribers: []*Repository{repository},
+			})
+		}
+
+		var err error
+		if err = pr.fetchPolicyRules(&subscriptionsNew[index]); err != nil {
+			return errors.Wrap(err, "initial fetch failed")
+		}
+	}
+
+	pr.fetchSubscriptions = subscriptionsNew
+	return nil
+}
+
+func (pr *Oracle) getPolicyIndex(policyList []policySubscription, policy market.AccessPolicy) (int, bool) {
+	for index, policyMeta := range policyList {
+		if policyMeta.policy == policy {
+			return index, true
+		}
+	}
+
+	return 0, false
+}
+
+func (pr *Oracle) fetchPolicyRules(subscription *policySubscription) error {
+	req, err := requests.NewGetRequest(subscription.policy.Source, "", nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create policy request")
+	}
+	req.Header.Add("If-None-Match", subscription.eTag)
+
+	res, err := pr.client.Do(req)
+	if err != nil {
+		return errors.Wrapf(err, "failed fetch policy rule %s", subscription.policy)
+	}
+	defer res.Body.Close()
+
+	httptrace.TraceRequestResponse(req, res)
+
+	if res.StatusCode == http.StatusNotModified {
+		return nil
+	}
+	if err := requests.ParseResponseError(res); err != nil {
+		return errors.Wrapf(err, "failed to fetch policy rule %s", subscription.policy)
+	}
+
+	var rules = market.AccessPolicyRuleSet{}
+	err = requests.ParseResponseJSON(res, &rules)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse policy rule %s", subscription.policy)
+	}
+	subscription.eTag = res.Header.Get("ETag")
+
+	for _, subscriber := range subscription.subscribers {
+		subscriber.SetPolicyRules(subscription.policy, rules)
+	}
+
+	return nil
+}
+
+func (pr *Oracle) fetchLoop() {
+	for {
+		select {
+		case <-pr.fetchShutdown:
+			return
+		case <-time.After(pr.fetchInterval):
+			pr.fetchLock.Lock()
+
+			subscriptionsActive := make([]policySubscription, len(pr.fetchSubscriptions))
+			copy(subscriptionsActive, pr.fetchSubscriptions)
+
+			for index := range subscriptionsActive {
+				var err error
+				if err = pr.fetchPolicyRules(&subscriptionsActive[index]); err != nil {
+					log.Warn().Err(err).Msg("synchronise fetch failed")
+				}
+			}
+			pr.fetchSubscriptions = subscriptionsActive
+
+			pr.fetchLock.Unlock()
+		}
+	}
+}

--- a/core/policy/oracle.go
+++ b/core/policy/oracle.go
@@ -112,7 +112,7 @@ func (pr *Oracle) Policies(policyIDs []string) []market.AccessPolicy {
 	return policies
 }
 
-// SubscribePolicies adds given policies to repository and syncs changes of it's rules from TrustOracle
+// SubscribePolicies adds given policies to repository and syncs changes of it's items from TrustOracle
 func (pr *Oracle) SubscribePolicies(policies []market.AccessPolicy, repository *Repository) error {
 	pr.fetchLock.Lock()
 	defer pr.fetchLock.Unlock()

--- a/core/policy/oracle_test.go
+++ b/core/policy/oracle_test.go
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/requests"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Oracle_Policy(t *testing.T) {
+	repo := &Oracle{fetchURL: "http://policy.localhost"}
+	assert.Equal(
+		t,
+		market.AccessPolicy{ID: "1", Source: "http://policy.localhost/1"},
+		repo.Policy("1"),
+	)
+
+	repo = &Oracle{fetchURL: "http://policy.localhost/"}
+	assert.Equal(
+		t,
+		market.AccessPolicy{ID: "2", Source: "http://policy.localhost/2"},
+		repo.Policy("2"),
+	)
+}
+
+func Test_Oracle_Policies(t *testing.T) {
+	repo := &Oracle{fetchURL: "http://policy.localhost"}
+	assert.Equal(
+		t,
+		[]market.AccessPolicy{
+			{ID: "1", Source: "http://policy.localhost/1"},
+		},
+		repo.Policies([]string{"1"}),
+	)
+
+	repo = &Oracle{fetchURL: "http://policy.localhost/"}
+	assert.Equal(
+		t,
+		[]market.AccessPolicy{
+			{ID: "2", Source: "http://policy.localhost/2"},
+			{ID: "3", Source: "http://policy.localhost/3"},
+		},
+		repo.Policies([]string{"2", "3"}),
+	)
+}
+
+func Test_Oracle_SubscribePolicies_WhenEndpointFails(t *testing.T) {
+	repo := NewRepository()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	oracle := createEmptyOracle(server.URL)
+	err := oracle.SubscribePolicies(
+		[]market.AccessPolicy{oracle.Policy("1"), oracle.Policy("3")},
+		repo,
+	)
+	assert.EqualError(
+		t,
+		err,
+		fmt.Sprintf("initial fetch failed: failed to fetch policy rule {1 %s/1}: server response invalid: 500 Internal Server Error (%s/1)", server.URL, server.URL),
+	)
+	assert.Equal(t, []market.AccessPolicy{}, repo.Policies())
+}
+
+func Test_Oracle_SubscribePolicies_Race(t *testing.T) {
+	repo := NewRepository()
+	server := mockPolicyServer()
+	defer server.Close()
+	oracle := createEmptyOracle(server.URL)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		err := oracle.SubscribePolicies(
+			[]market.AccessPolicy{oracle.Policy("1"), oracle.Policy("3")},
+			repo,
+		)
+		assert.NoError(t, err)
+	}()
+	go func() {
+		defer wg.Done()
+		err := oracle.SubscribePolicies([]market.AccessPolicy{oracle.Policy("2")}, repo)
+		assert.NoError(t, err)
+	}()
+	wg.Wait()
+
+	policiesRules, err := repo.RulesForPolicies([]market.AccessPolicy{
+		oracle.Policy("1"),
+		oracle.Policy("2"),
+		oracle.Policy("3"),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, policiesRules, 3)
+}
+
+func Test_Oracle_SubscribePolicies_WhenEndpointSucceeds(t *testing.T) {
+	repo := NewRepository()
+	server := mockPolicyServer()
+	defer server.Close()
+
+	oracle := createEmptyOracle(server.URL)
+	err := oracle.SubscribePolicies(
+		[]market.AccessPolicy{oracle.Policy("1"), oracle.Policy("3")},
+		repo,
+	)
+	assert.NoError(t, err)
+	policiesRules, err := repo.RulesForPolicies([]market.AccessPolicy{
+		oracle.Policy("1"),
+		oracle.Policy("3"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		[]market.AccessPolicyRuleSet{policyOneRulesUpdated, policyThreeRulesUpdated},
+		policiesRules,
+	)
+
+	oracle = createFilledOracle(server.URL, time.Minute, repo)
+	err = oracle.SubscribePolicies(
+		[]market.AccessPolicy{oracle.Policy("1"), oracle.Policy("3")},
+		repo,
+	)
+	assert.NoError(t, err)
+
+	policiesRules, err = repo.RulesForPolicies([]market.AccessPolicy{
+		oracle.Policy("1"),
+		oracle.Policy("3"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		[]market.AccessPolicyRuleSet{policyOneRulesUpdated, policyThreeRulesUpdated},
+		policiesRules,
+	)
+}
+
+func Test_Oracle_StartSyncsPolicies(t *testing.T) {
+	repo := NewRepository()
+	server := mockPolicyServer()
+	defer server.Close()
+
+	oracle := createFilledOracle(server.URL, 1*time.Millisecond, repo)
+	oracle.Start()
+	defer oracle.Stop()
+
+	var policiesRules []market.AccessPolicyRuleSet
+	assert.Eventually(t, func() bool {
+		var err error
+		policiesRules, err = repo.RulesForPolicies([]market.AccessPolicy{
+			oracle.Policy("1"),
+			oracle.Policy("2"),
+		})
+		return err == nil && len(policiesRules) == 2
+	}, 2*time.Second, 10*time.Millisecond)
+	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRulesUpdated, policyTwoRulesUpdated}, policiesRules)
+}
+
+func Test_PolicyRepository_StartMultipleTimes(t *testing.T) {
+	oracle := NewOracle(requests.NewHTTPClient("0.0.0.0", time.Second), "http://policy.localhost", time.Minute)
+	oracle.Start()
+	oracle.Stop()
+
+	oracle.Start()
+	oracle.Stop()
+}
+
+func createEmptyOracle(mockServerURL string) *Oracle {
+	return NewOracle(
+		requests.NewHTTPClient("0.0.0.0", 100*time.Millisecond),
+		mockServerURL+"/",
+		time.Minute,
+	)
+}
+
+func createFilledOracle(mockServerURL string, interval time.Duration, repo *Repository) *Oracle {
+	oracle := NewOracle(
+		requests.NewHTTPClient("0.0.0.0", time.Second),
+		mockServerURL+"/",
+		interval,
+	)
+	oracle.SubscribePolicies(
+		[]market.AccessPolicy{oracle.Policy("1"), oracle.Policy("2")},
+		repo,
+	)
+	return oracle
+}
+
+func mockPolicyServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/1" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": "1",
+				"title": "One (updated)",
+				"description": "",
+				"allow": [
+					{"type": "identity", "value": "0x1"}
+				]
+			}`))
+		} else if r.URL.Path == "/2" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": "2",
+				"title": "Two (updated)",
+				"description": "",
+				"allow": [
+					{"type": "dns_hostname", "value": "ipinfo.io"}
+				]
+			}`))
+		} else if r.URL.Path == "/3" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": "3",
+				"title": "Three (updated)",
+				"description": "",
+				"allow": [
+					{"type": "dns_zone", "value": "ipinfo.io"}
+				]
+			}`))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}

--- a/core/policy/oracle_test.go
+++ b/core/policy/oracle_test.go
@@ -166,7 +166,7 @@ func Test_Oracle_StartSyncsPolicies(t *testing.T) {
 	defer server.Close()
 
 	oracle := createFilledOracle(server.URL, 1*time.Millisecond, repo)
-	oracle.Start()
+	go oracle.Start()
 	defer oracle.Stop()
 
 	var policiesRules []market.AccessPolicyRuleSet
@@ -183,10 +183,10 @@ func Test_Oracle_StartSyncsPolicies(t *testing.T) {
 
 func Test_PolicyRepository_StartMultipleTimes(t *testing.T) {
 	oracle := NewOracle(requests.NewHTTPClient("0.0.0.0", time.Second), "http://policy.localhost", time.Minute)
-	oracle.Start()
+	go oracle.Start()
 	oracle.Stop()
 
-	oracle.Start()
+	go oracle.Start()
 	oracle.Stop()
 }
 
@@ -213,7 +213,8 @@ func createFilledOracle(mockServerURL string, interval time.Duration, repo *Repo
 
 func mockPolicyServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/1" {
+		switch r.URL.Path {
+		case "/1":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{
 				"id": "1",
@@ -223,7 +224,7 @@ func mockPolicyServer() *httptest.Server {
 					{"type": "identity", "value": "0x1"}
 				]
 			}`))
-		} else if r.URL.Path == "/2" {
+		case "/2":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{
 				"id": "2",
@@ -233,7 +234,7 @@ func mockPolicyServer() *httptest.Server {
 					{"type": "dns_hostname", "value": "ipinfo.io"}
 				]
 			}`))
-		} else if r.URL.Path == "/3" {
+		case "/3":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{
 				"id": "3",
@@ -243,7 +244,7 @@ func mockPolicyServer() *httptest.Server {
 					{"type": "dns_zone", "value": "ipinfo.io"}
 				]
 			}`))
-		} else {
+		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))

--- a/core/policy/oracle_test.go
+++ b/core/policy/oracle_test.go
@@ -110,13 +110,7 @@ func Test_Oracle_SubscribePolicies_Race(t *testing.T) {
 	}()
 	wg.Wait()
 
-	policiesRules, err := repo.RulesForPolicies([]market.AccessPolicy{
-		oracle.Policy("1"),
-		oracle.Policy("2"),
-		oracle.Policy("3"),
-	})
-	assert.NoError(t, err)
-	assert.Len(t, policiesRules, 3)
+	assert.Len(t, repo.Rules(), 3)
 }
 
 func Test_Oracle_SubscribePolicies_WhenEndpointSucceeds(t *testing.T) {
@@ -130,15 +124,10 @@ func Test_Oracle_SubscribePolicies_WhenEndpointSucceeds(t *testing.T) {
 		repo,
 	)
 	assert.NoError(t, err)
-	policiesRules, err := repo.RulesForPolicies([]market.AccessPolicy{
-		oracle.Policy("1"),
-		oracle.Policy("3"),
-	})
-	assert.NoError(t, err)
 	assert.Equal(
 		t,
 		[]market.AccessPolicyRuleSet{policyOneRulesUpdated, policyThreeRulesUpdated},
-		policiesRules,
+		repo.Rules(),
 	)
 
 	oracle = createFilledOracle(server.URL, time.Minute, repo)
@@ -148,15 +137,10 @@ func Test_Oracle_SubscribePolicies_WhenEndpointSucceeds(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	policiesRules, err = repo.RulesForPolicies([]market.AccessPolicy{
-		oracle.Policy("1"),
-		oracle.Policy("3"),
-	})
-	assert.NoError(t, err)
 	assert.Equal(
 		t,
-		[]market.AccessPolicyRuleSet{policyOneRulesUpdated, policyThreeRulesUpdated},
-		policiesRules,
+		[]market.AccessPolicyRuleSet{policyOneRulesUpdated, policyThreeRulesUpdated, policyTwoRulesUpdated},
+		repo.Rules(),
 	)
 }
 
@@ -171,12 +155,8 @@ func Test_Oracle_StartSyncsPolicies(t *testing.T) {
 
 	var policiesRules []market.AccessPolicyRuleSet
 	assert.Eventually(t, func() bool {
-		var err error
-		policiesRules, err = repo.RulesForPolicies([]market.AccessPolicy{
-			oracle.Policy("1"),
-			oracle.Policy("2"),
-		})
-		return err == nil && len(policiesRules) == 2
+		policiesRules = repo.Rules()
+		return len(policiesRules) == 2
 	}, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRulesUpdated, policyTwoRulesUpdated}, policiesRules)
 }

--- a/core/policy/repository.go
+++ b/core/policy/repository.go
@@ -19,193 +19,73 @@ package policy
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
 	"sync"
-	"time"
 
-	"github.com/mysteriumnetwork/node/logconfig/httptrace"
 	"github.com/mysteriumnetwork/node/market"
-	"github.com/mysteriumnetwork/node/requests"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 )
-
-type policyMetadata struct {
-	policy market.AccessPolicy
-	eTag   string
-	rules  market.AccessPolicyRuleSet
-}
 
 // Repository represents async policy fetcher from TrustOracle
 type Repository struct {
-	client *requests.HTTPClient
-
-	policyURL  string
-	policyLock sync.RWMutex
-	policyList []policyMetadata
-
-	fetchInterval time.Duration
-	fetchShutdown chan struct{}
+	lock          sync.RWMutex
+	rulesByPolicy map[market.AccessPolicy]market.AccessPolicyRuleSet
 }
 
 // NewRepository create instance of policy repository
-func NewRepository(client *requests.HTTPClient, policyURL string, interval time.Duration) *Repository {
+func NewRepository() *Repository {
 	return &Repository{
-		client:        client,
-		policyURL:     policyURL,
-		policyList:    make([]policyMetadata, 0),
-		fetchInterval: interval,
-		fetchShutdown: make(chan struct{}),
+		rulesByPolicy: make(map[market.AccessPolicy]market.AccessPolicyRuleSet),
 	}
 }
 
-// Start begins fetching policies to repository
-func (pr *Repository) Start() {
-	go pr.fetchLoop()
+// SetPolicyRules set policy ant it's rules to repository
+func (pr *Repository) SetPolicyRules(policy market.AccessPolicy, policyRules market.AccessPolicyRuleSet) {
+	pr.lock.Lock()
+	defer pr.lock.Unlock()
+
+	pr.rulesByPolicy[policy] = policyRules
 }
 
-// Stop ends fetching policies to repository
-func (pr *Repository) Stop() {
-	pr.fetchShutdown <- struct{}{}
-}
+// Policies list policies in repository
+func (pr *Repository) Policies() []market.AccessPolicy {
+	pr.lock.RLock()
+	defer pr.lock.RUnlock()
 
-// Policy converts given value to valid policy rule
-func (pr *Repository) Policy(policyID string) market.AccessPolicy {
-	policyURL := pr.policyURL
-	if !strings.HasSuffix(policyURL, "/") {
-		policyURL += "/"
-	}
-	return market.AccessPolicy{
-		ID:     policyID,
-		Source: fmt.Sprintf("%v%v", policyURL, policyID),
-	}
-}
-
-// Policies converts given values to list of valid policies
-func (pr *Repository) Policies(policyIDs []string) *[]market.AccessPolicy {
-	policies := make([]market.AccessPolicy, len(policyIDs))
-	for i, policyID := range policyIDs {
-		policies[i] = pr.Policy(policyID)
-	}
-	return &policies
-}
-
-// AddPolicies adds given policy to repository. Also syncs policy rules from TrustOracle
-func (pr *Repository) AddPolicies(policies []market.AccessPolicy) error {
-	pr.policyLock.Lock()
-	defer pr.policyLock.Unlock()
-
-	policyListNew := make([]policyMetadata, len(pr.policyList))
-	copy(policyListNew, pr.policyList)
-
-	for _, policy := range policies {
-		index, exist := pr.getPolicyIndex(policyListNew, policy)
-		if !exist {
-			index = len(policyListNew)
-			policyListNew = append(policyListNew, policyMetadata{policy: policy})
-		}
-
-		var err error
-		if err = pr.fetchPolicyRules(&policyListNew[index]); err != nil {
-			return errors.Wrap(err, "initial fetch failed")
-		}
+	policies := make([]market.AccessPolicy, len(pr.rulesByPolicy))
+	i := 0
+	for policy := range pr.rulesByPolicy {
+		policies[i] = policy
+		i++
 	}
 
-	pr.policyList = policyListNew
-	return nil
+	return policies
 }
 
 // RulesForPolicy gives rules of given policy
 func (pr *Repository) RulesForPolicy(policy market.AccessPolicy) (market.AccessPolicyRuleSet, error) {
-	pr.policyLock.RLock()
-	defer pr.policyLock.RUnlock()
+	pr.lock.RLock()
+	defer pr.lock.RUnlock()
 
-	index, exist := pr.getPolicyIndex(pr.policyList, policy)
+	policyRules, exist := pr.rulesByPolicy[policy]
 	if !exist {
 		return market.AccessPolicyRuleSet{}, fmt.Errorf("unknown policy: %s", policy)
 	}
 
-	return pr.policyList[index].rules, nil
+	return policyRules, nil
 }
 
 // RulesForPolicies gives list of rules of given policies
 func (pr *Repository) RulesForPolicies(policies []market.AccessPolicy) ([]market.AccessPolicyRuleSet, error) {
-	pr.policyLock.RLock()
-	defer pr.policyLock.RUnlock()
+	pr.lock.RLock()
+	defer pr.lock.RUnlock()
 
 	policiesRules := make([]market.AccessPolicyRuleSet, len(policies))
 	for i, policy := range policies {
-		index, exist := pr.getPolicyIndex(pr.policyList, policy)
+		var exist bool
+		policiesRules[i], exist = pr.rulesByPolicy[policy]
 		if !exist {
 			return []market.AccessPolicyRuleSet{}, fmt.Errorf("unknown policy: %s", policy)
 		}
-		policiesRules[i] = pr.policyList[index].rules
 	}
+
 	return policiesRules, nil
-}
-
-func (pr *Repository) getPolicyIndex(policyList []policyMetadata, policy market.AccessPolicy) (int, bool) {
-	for index, policyMeta := range policyList {
-		if policyMeta.policy == policy {
-			return index, true
-		}
-	}
-
-	return 0, false
-}
-
-func (pr *Repository) fetchPolicyRules(policyMeta *policyMetadata) error {
-	req, err := requests.NewGetRequest(policyMeta.policy.Source, "", nil)
-	if err != nil {
-		return errors.Wrap(err, "failed to create policy request")
-	}
-	req.Header.Add("If-None-Match", policyMeta.eTag)
-
-	res, err := pr.client.Do(req)
-	if err != nil {
-		return errors.Wrapf(err, "failed fetch policy rule %s", policyMeta.policy)
-	}
-	defer res.Body.Close()
-
-	httptrace.TraceRequestResponse(req, res)
-
-	if res.StatusCode == http.StatusNotModified {
-		return nil
-	}
-	if err := requests.ParseResponseError(res); err != nil {
-		return errors.Wrapf(err, "failed to fetch policy rule %s", policyMeta.policy)
-	}
-
-	policyMeta.rules = market.AccessPolicyRuleSet{}
-	err = requests.ParseResponseJSON(res, &policyMeta.rules)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse policy rule %s", policyMeta.policy)
-	}
-	policyMeta.eTag = res.Header.Get("ETag")
-	return nil
-}
-
-func (pr *Repository) fetchLoop() {
-	for {
-		select {
-		case <-pr.fetchShutdown:
-			return
-		case <-time.After(pr.fetchInterval):
-			pr.policyLock.Lock()
-
-			policyListActive := make([]policyMetadata, len(pr.policyList))
-			copy(policyListActive, pr.policyList)
-
-			for index := range policyListActive {
-				var err error
-				if err = pr.fetchPolicyRules(&policyListActive[index]); err != nil {
-					log.Warn().Err(err).Msg("synchronise fetch failed")
-				}
-			}
-			pr.policyList = policyListActive
-
-			pr.policyLock.Unlock()
-		}
-	}
 }

--- a/core/policy/repository_test.go
+++ b/core/policy/repository_test.go
@@ -18,19 +18,14 @@
 package policy
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/mysteriumnetwork/node/market"
-	"github.com/mysteriumnetwork/node/requests"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
+	policyOne      = market.AccessPolicy{ID: "1", Source: "http://policy.localhost/1"}
 	policyOneRules = market.AccessPolicyRuleSet{
 		ID:    "1",
 		Title: "One",
@@ -46,6 +41,7 @@ var (
 		},
 	}
 
+	policyTwo      = market.AccessPolicy{ID: "2", Source: "http://policy.localhost/2"}
 	policyTwoRules = market.AccessPolicyRuleSet{
 		ID:    "2",
 		Title: "Two",
@@ -61,6 +57,7 @@ var (
 		},
 	}
 
+	policyThree             = market.AccessPolicy{ID: "3", Source: "http://policy.localhost/3"}
 	policyThreeRulesUpdated = market.AccessPolicyRuleSet{
 		ID:    "3",
 		Title: "Three (updated)",
@@ -70,264 +67,55 @@ var (
 	}
 )
 
-func Test_PolicyRepository_Policy(t *testing.T) {
-	repo := &Repository{policyURL: "http://policy.localhost"}
-	assert.Equal(
-		t,
-		market.AccessPolicy{ID: "1", Source: "http://policy.localhost/1"},
-		repo.Policy("1"),
-	)
-
-	repo = &Repository{policyURL: "http://policy.localhost/"}
-	assert.Equal(
-		t,
-		market.AccessPolicy{ID: "2", Source: "http://policy.localhost/2"},
-		repo.Policy("2"),
-	)
-}
-
-func Test_PolicyRepository_Policies(t *testing.T) {
-	repo := &Repository{policyURL: "http://policy.localhost"}
-	assert.Equal(
-		t,
-		&[]market.AccessPolicy{
-			{ID: "1", Source: "http://policy.localhost/1"},
-		},
-		repo.Policies([]string{"1"}),
-	)
-
-	repo = &Repository{policyURL: "http://policy.localhost/"}
-	assert.Equal(
-		t,
-		&[]market.AccessPolicy{
-			{ID: "2", Source: "http://policy.localhost/2"},
-			{ID: "3", Source: "http://policy.localhost/3"},
-		},
-		repo.Policies([]string{"2", "3"}),
-	)
-}
-
-func Test_PolicyRepository_RulesForPolicy(t *testing.T) {
-	repo := createEmptyRepo("http://policy.localhost")
-	policyRules, err := repo.RulesForPolicy(repo.Policy("1"))
+func Test_Repository_RulesForPolicy(t *testing.T) {
+	repo := createEmptyRepo()
+	policyRules, err := repo.RulesForPolicy(policyOne)
 	assert.EqualError(t, err, "unknown policy: {1 http://policy.localhost/1}")
 	assert.Equal(t, market.AccessPolicyRuleSet{}, policyRules)
 
-	repo = createFullRepo("http://policy.localhost", time.Minute)
-	policyRules, err = repo.RulesForPolicy(repo.Policy("1"))
+	repo = createFullRepo()
+	policyRules, err = repo.RulesForPolicy(policyOne)
 	assert.NoError(t, err)
 	assert.Equal(t, policyOneRules, policyRules)
 }
 
-func Test_PolicyRepository_RulesForPolicies(t *testing.T) {
-	repo := createEmptyRepo("http://policy.localhost")
+func Test_Repository_RulesForPolicies(t *testing.T) {
+	repo := createEmptyRepo()
 	policiesRules, err := repo.RulesForPolicies([]market.AccessPolicy{
-		repo.Policy("1"),
-		repo.Policy("3"),
+		policyOne,
+		policyThree,
 	})
 	assert.EqualError(t, err, "unknown policy: {1 http://policy.localhost/1}")
 	assert.Equal(t, []market.AccessPolicyRuleSet{}, policiesRules)
 
-	repo = createFullRepo("http://policy.localhost", time.Minute)
+	repo = createFullRepo()
 	policiesRules, err = repo.RulesForPolicies([]market.AccessPolicy{
-		repo.Policy("1"),
-		repo.Policy("2"),
+		policyOne,
+		policyTwo,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRules, policyTwoRules}, policiesRules)
 }
 
-func Test_PolicyRepository_AddPolicies_WhenEndpointFails(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	repo := createEmptyRepo(server.URL)
-	err := repo.AddPolicies([]market.AccessPolicy{
-		repo.Policy("1"),
-		repo.Policy("3"),
-	})
-	assert.EqualError(
-		t,
-		err,
-		fmt.Sprintf("initial fetch failed: failed to fetch policy rule {1 %s/1}: server response invalid: 500 Internal Server Error (%s/1)", server.URL, server.URL),
-	)
-	assert.Equal(t, []policyMetadata{}, repo.policyList)
+func createEmptyRepo() *Repository {
+	return NewRepository()
 }
 
-func Test_PolicyRepository_AddPolicies_Race(t *testing.T) {
-	server := mockPolicyServer()
-	defer server.Close()
-	repo := createEmptyRepo(server.URL)
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		err := repo.AddPolicies([]market.AccessPolicy{
-			repo.Policy("1"),
-			repo.Policy("3"),
-		})
-		assert.NoError(t, err)
-	}()
-	go func() {
-		defer wg.Done()
-		err := repo.AddPolicies([]market.AccessPolicy{
-			repo.Policy("2"),
-		})
-		assert.NoError(t, err)
-	}()
-	wg.Wait()
-
-	policiesRules, err := repo.RulesForPolicies([]market.AccessPolicy{
-		repo.Policy("1"),
-		repo.Policy("2"),
-		repo.Policy("3"),
-	})
-	assert.NoError(t, err)
-	assert.Len(t, policiesRules, 3)
-}
-
-func Test_PolicyRepository_AddPolicies_WhenEndpointSucceeds(t *testing.T) {
-	server := mockPolicyServer()
-	defer server.Close()
-
-	repo := createEmptyRepo(server.URL)
-	err := repo.AddPolicies([]market.AccessPolicy{
-		repo.Policy("1"),
-		repo.Policy("3"),
-	})
-	assert.NoError(t, err)
-	assert.Equal(
-		t,
-		[]policyMetadata{
-			{policy: repo.Policy("1"), rules: policyOneRulesUpdated},
-			{policy: repo.Policy("3"), rules: policyThreeRulesUpdated},
+func createFullRepo() *Repository {
+	repo := NewRepository()
+	repo.rulesByPolicy[policyOne] = market.AccessPolicyRuleSet{
+		ID:    "1",
+		Title: "One",
+		Allow: []market.AccessRule{
+			{Type: market.AccessPolicyTypeIdentity, Value: "0x1"},
 		},
-		repo.policyList,
-	)
-
-	repo = createFullRepo(server.URL, time.Minute)
-	err = repo.AddPolicies([]market.AccessPolicy{
-		repo.Policy("1"),
-		repo.Policy("3"),
-	})
-	assert.NoError(t, err)
-	assert.Equal(
-		t,
-		[]policyMetadata{
-			{policy: repo.Policy("1"), rules: policyOneRulesUpdated},
-			{policy: repo.Policy("2"), rules: policyTwoRules},
-			{policy: repo.Policy("3"), rules: policyThreeRulesUpdated},
+	}
+	repo.rulesByPolicy[policyTwo] = market.AccessPolicyRuleSet{
+		ID:    "2",
+		Title: "Two",
+		Allow: []market.AccessRule{
+			{Type: market.AccessPolicyTypeDNSHostname, Value: "ipinfo.io"},
 		},
-		repo.policyList,
-	)
-}
-
-func Test_PolicyRepository_StartSyncsPolicies(t *testing.T) {
-	server := mockPolicyServer()
-	defer server.Close()
-
-	repo := createFullRepo(server.URL, 1*time.Millisecond)
-	repo.Start()
-	defer repo.Stop()
-
-	var policiesRules []market.AccessPolicyRuleSet
-	assert.Eventually(t, func() bool {
-		var err error
-		policiesRules, err = repo.RulesForPolicies([]market.AccessPolicy{
-			repo.Policy("1"),
-			repo.Policy("2"),
-		})
-		return err == nil && len(policiesRules) == 2
-	}, 2*time.Second, 10*time.Millisecond)
-	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRulesUpdated, policyTwoRulesUpdated}, policiesRules)
-}
-
-func Test_PolicyRepository_StartMultipleTimes(t *testing.T) {
-	repo := NewRepository(requests.NewHTTPClient("0.0.0.0", time.Second), "http://policy.localhost", time.Minute)
-	repo.Start()
-	repo.Stop()
-
-	repo.Start()
-	repo.Stop()
-}
-
-func createEmptyRepo(mockServerURL string) *Repository {
-	return NewRepository(
-		requests.NewHTTPClient("0.0.0.0", 100*time.Millisecond),
-		mockServerURL+"/",
-		time.Minute,
-	)
-}
-
-func createFullRepo(mockServerURL string, interval time.Duration) *Repository {
-	repo := NewRepository(
-		requests.NewHTTPClient("0.0.0.0", time.Second),
-		mockServerURL+"/",
-		interval,
-	)
-	repo.policyList = append(
-		repo.policyList,
-		policyMetadata{
-			policy: repo.Policy("1"),
-			rules: market.AccessPolicyRuleSet{
-				ID:    "1",
-				Title: "One",
-				Allow: []market.AccessRule{
-					{Type: market.AccessPolicyTypeIdentity, Value: "0x1"},
-				},
-			},
-		},
-		policyMetadata{
-			policy: repo.Policy("2"),
-			rules: market.AccessPolicyRuleSet{
-				ID:    "2",
-				Title: "Two",
-				Allow: []market.AccessRule{
-					{Type: market.AccessPolicyTypeDNSHostname, Value: "ipinfo.io"},
-				},
-			},
-		},
-	)
+	}
 	return repo
-}
-
-func mockPolicyServer() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/1" {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
-				"id": "1",
-				"title": "One (updated)",
-				"description": "",
-				"allow": [
-					{"type": "identity", "value": "0x1"}
-				]
-			}`))
-		} else if r.URL.Path == "/2" {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
-				"id": "2",
-				"title": "Two (updated)",
-				"description": "",
-				"allow": [
-					{"type": "dns_hostname", "value": "ipinfo.io"}
-				]
-			}`))
-		} else if r.URL.Path == "/3" {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
-				"id": "3",
-				"title": "Three (updated)",
-				"description": "",
-				"allow": [
-					{"type": "dns_zone", "value": "ipinfo.io"}
-				]
-			}`))
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
 }

--- a/core/policy/repository_test.go
+++ b/core/policy/repository_test.go
@@ -97,25 +97,39 @@ func Test_Repository_RulesForPolicies(t *testing.T) {
 	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRules, policyTwoRules}, policiesRules)
 }
 
+func Test_Repository_Rules(t *testing.T) {
+	repo := createEmptyRepo()
+	assert.Equal(t, []market.AccessPolicyRuleSet{}, repo.Rules())
+
+	repo = createFullRepo()
+	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRules, policyTwoRules}, repo.Rules())
+}
+
 func createEmptyRepo() *Repository {
 	return NewRepository()
 }
 
 func createFullRepo() *Repository {
 	repo := NewRepository()
-	repo.rulesByPolicy[policyOne] = market.AccessPolicyRuleSet{
-		ID:    "1",
-		Title: "One",
-		Allow: []market.AccessRule{
-			{Type: market.AccessPolicyTypeIdentity, Value: "0x1"},
+	repo.SetPolicyRules(
+		policyOne,
+		market.AccessPolicyRuleSet{
+			ID:    "1",
+			Title: "One",
+			Allow: []market.AccessRule{
+				{Type: market.AccessPolicyTypeIdentity, Value: "0x1"},
+			},
 		},
-	}
-	repo.rulesByPolicy[policyTwo] = market.AccessPolicyRuleSet{
-		ID:    "2",
-		Title: "Two",
-		Allow: []market.AccessRule{
-			{Type: market.AccessPolicyTypeDNSHostname, Value: "ipinfo.io"},
+	)
+	repo.SetPolicyRules(
+		policyTwo,
+		market.AccessPolicyRuleSet{
+			ID:    "2",
+			Title: "Two",
+			Allow: []market.AccessRule{
+				{Type: market.AccessPolicyTypeDNSHostname, Value: "ipinfo.io"},
+			},
 		},
-	}
+	)
 	return repo
 }

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -47,7 +47,7 @@ type Service interface {
 }
 
 // DialogWaiterFactory initiates communication channel which waits for incoming dialogs
-type DialogWaiterFactory func(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy, policiesRules *policy.Repository) (communication.DialogWaiter, error)
+type DialogWaiterFactory func(providerID identity.Identity, serviceType string, policies *policy.Repository) (communication.DialogWaiter, error)
 
 // DialogHandlerFactory initiates instance which is able to handle incoming dialogs
 type DialogHandlerFactory func(market.ServiceProposal, session.ConfigProvider, string) (communication.DialogHandler, error)
@@ -117,7 +117,7 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 		proposal.SetAccessPolicies(&policies)
 	}
 
-	dialogWaiter, err := manager.dialogWaiterFactory(providerID, serviceType, proposal.AccessPolicies, policyRules)
+	dialogWaiter, err := manager.dialogWaiterFactory(providerID, serviceType, policyRules)
 	if err != nil {
 		return id, err
 	}

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 var (
-	serviceType = "the-very-awesome-test-service-type"
-	mockPolicy  = policy.NewRepository(requests.NewHTTPClient("0.0.0.0", requests.DefaultTimeout), "http://policy.localhost/", 1*time.Minute)
+	serviceType      = "the-very-awesome-test-service-type"
+	mockPolicyOracle = policy.NewOracle(requests.NewHTTPClient("0.0.0.0", requests.DefaultTimeout), "http://policy.localhost/", 1*time.Minute)
 )
 
 func TestManager_StartRemovesServiceFromPoolIfServiceCrashes(t *testing.T) {
@@ -50,7 +50,7 @@ func TestManager_StartRemovesServiceFromPoolIfServiceCrashes(t *testing.T) {
 		MockDialogHandlerFactory,
 		discoveryFactory,
 		&mockPublisher{},
-		mockPolicy,
+		mockPolicyOracle,
 	)
 	_, err := manager.Start(identity.FromAddress(proposalMock.ProviderID), serviceType, nil, struct{}{})
 	assert.Nil(t, err)
@@ -75,7 +75,7 @@ func TestManager_StartDoesNotCrashIfStoppedByUser(t *testing.T) {
 		MockDialogHandlerFactory,
 		discoveryFactory,
 		&mockPublisher{},
-		mockPolicy,
+		mockPolicyOracle,
 	)
 	id, err := manager.Start(identity.FromAddress(proposalMock.ProviderID), serviceType, nil, struct{}{})
 	assert.Nil(t, err)
@@ -102,7 +102,7 @@ func TestManager_StopSendsEvent_SucceedsAndPublishesEvent(t *testing.T) {
 		MockDialogHandlerFactory,
 		discoveryFactory,
 		eventBus,
-		mockPolicy,
+		mockPolicyOracle,
 	)
 
 	id, err := manager.Start(identity.FromAddress(proposalMock.ProviderID), serviceType, nil, struct{}{})

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
@@ -159,6 +160,7 @@ type Instance struct {
 	options        Options
 	service        RunnableService
 	proposal       market.ServiceProposal
+	policies       *policy.Repository
 	dialogWaiter   communication.DialogWaiter
 	discovery      Discovery
 	eventPublisher Publisher
@@ -174,6 +176,11 @@ func (i *Instance) Options() Options {
 // Proposal returns service proposal of the running service instance.
 func (i *Instance) Proposal() market.ServiceProposal {
 	return i.proposal
+}
+
+// Policies returns service policies of the running service instance.
+func (i *Instance) Policies() *policy.Repository {
+	return i.policies
 }
 
 // State returns the service instance state.

--- a/core/service/stub_service.go
+++ b/core/service/stub_service.go
@@ -78,7 +78,7 @@ func (mdw *mockDialogWaiter) Start(_ communication.DialogHandler) error {
 }
 
 // MockDialogWaiterFactory returns a new instance of communication dialog waiter.
-func MockDialogWaiterFactory(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy, policiesRules *policy.Repository) (communication.DialogWaiter, error) {
+func MockDialogWaiterFactory(providerID identity.Identity, serviceType string, policies *policy.Repository) (communication.DialogWaiter, error) {
 	return &mockDialogWaiter{}, nil
 }
 

--- a/core/service/stub_service.go
+++ b/core/service/stub_service.go
@@ -36,7 +36,7 @@ type serviceFake struct {
 	onStartReturnError error
 }
 
-func (service *serviceFake) Serve(identity.Identity) error {
+func (service *serviceFake) Serve(instance *Instance) error {
 	if service.mockProcess != nil {
 		for range service.mockProcess {
 		}

--- a/core/service/stub_service.go
+++ b/core/service/stub_service.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/mysteriumnetwork/node/communication"
+	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat/traversal"
@@ -77,7 +78,7 @@ func (mdw *mockDialogWaiter) Start(_ communication.DialogHandler) error {
 }
 
 // MockDialogWaiterFactory returns a new instance of communication dialog waiter.
-func MockDialogWaiterFactory(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy) (communication.DialogWaiter, error) {
+func MockDialogWaiterFactory(providerID identity.Identity, serviceType string, policies *[]market.AccessPolicy, policiesRules *policy.Repository) (communication.DialogWaiter, error) {
 	return &mockDialogWaiter{}, nil
 }
 

--- a/services/noop/service.go
+++ b/services/noop/service.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 
 	"github.com/mysteriumnetwork/node/core/location"
-	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat/traversal"
 	"github.com/mysteriumnetwork/node/session"
@@ -50,7 +50,7 @@ func (manager *Manager) ProvideConfig(sessionConfig json.RawMessage) (*session.C
 }
 
 // Serve starts service - does block
-func (manager *Manager) Serve(providerID identity.Identity) error {
+func (manager *Manager) Serve(instance *service.Instance) error {
 	manager.process.Add(1)
 	log.Info().Msg("Noop service started successfully")
 	manager.process.Wait()

--- a/services/noop/service_test.go
+++ b/services/noop/service_test.go
@@ -66,7 +66,7 @@ func Test_Manager_ProvideConfig(t *testing.T) {
 func Test_Manager_Serve_Stop(t *testing.T) {
 	manager := NewManager()
 	go func() {
-		err := manager.Serve(providerID)
+		err := manager.Serve(&service.Instance{})
 		assert.NoError(t, err)
 	}()
 

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -26,10 +26,10 @@ import (
 	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/shaper"
 	"github.com/mysteriumnetwork/node/dns"
 	"github.com/mysteriumnetwork/node/firewall"
-	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat"
 	"github.com/mysteriumnetwork/node/nat/event"
@@ -98,7 +98,7 @@ type Manager struct {
 }
 
 // Serve starts service - does block
-func (m *Manager) Serve(providerID identity.Identity) (err error) {
+func (m *Manager) Serve(instance *service.Instance) (err error) {
 	m.vpnNetwork = net.IPNet{
 		IP:   net.ParseIP(m.serviceOptions.Subnet),
 		Mask: net.IPMask(net.ParseIP(m.serviceOptions.Netmask).To4()),
@@ -125,7 +125,7 @@ func (m *Manager) Serve(providerID identity.Identity) (err error) {
 		defer releasePorts()
 	}
 
-	primitives, err := primitiveFactory(m.location.Country, providerID.Address)
+	primitives, err := primitiveFactory(m.location.Country, instance.Proposal().ProviderID)
 	if err != nil {
 		return
 	}

--- a/services/wireguard/service/service_test.go
+++ b/services/wireguard/service/service_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/location"
+	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat"
@@ -63,7 +64,7 @@ func Test_Manager_Stop(t *testing.T) {
 	manager := newManagerStub(pubIP, outIP, country)
 
 	go func() {
-		err := manager.Serve(providerID)
+		err := manager.Serve(&service.Instance{})
 		assert.NoError(t, err)
 	}()
 

--- a/services/wireguard/service/service_unix.go
+++ b/services/wireguard/service/service_unix.go
@@ -28,9 +28,9 @@ import (
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/dns"
 	"github.com/mysteriumnetwork/node/eventbus"
-	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/nat"
 	"github.com/mysteriumnetwork/node/nat/event"
 	"github.com/mysteriumnetwork/node/nat/mapping"
@@ -283,7 +283,7 @@ func (m *Manager) newTraversalParams(natPingerEnabled bool, consumserConfig wg.C
 }
 
 // Serve starts service - does block
-func (m *Manager) Serve(providerID identity.Identity) error {
+func (m *Manager) Serve(instance *service.Instance) error {
 	log.Info().Msg("Wireguard service started successfully now")
 
 	// Start DNS proxy.

--- a/services/wireguard/service/service_windows.go
+++ b/services/wireguard/service/service_windows.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/port"
+	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/firewall"
-	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/nat"
 	"github.com/mysteriumnetwork/node/nat/traversal"
 	wg "github.com/mysteriumnetwork/node/services/wireguard"
@@ -98,7 +98,7 @@ func (manager *Manager) ProvideConfig(publicKey json.RawMessage, traversalParams
 }
 
 // Serve starts service - does block
-func (manager *Manager) Serve(providerID identity.Identity) error {
+func (manager *Manager) Serve(instance *service.Instance) error {
 	manager.wg.Add(1)
 
 	connectionEndpoint, err := endpoint.NewConnectionEndpoint(manager.ipResolver, manager.resourceAllocator, manager.portMap, manager.options.ConnectDelay)


### PR DESCRIPTION
Now it's possible to mock policy rules for running service wo rules actual fetching from Oracle