### PR TITLE
Prefix all event bus topics with `AppTopic`

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -279,7 +279,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options, ser
 	)
 
 	serviceCleaner := service.Cleaner{SessionStorage: di.ServiceSessionStorage}
-	if err := di.EventBus.Subscribe(service.StatusTopic, serviceCleaner.HandleServiceStatus); err != nil {
+	if err := di.EventBus.Subscribe(service.AppTopicServiceStatus, serviceCleaner.HandleServiceStatus); err != nil {
 		log.Error().Msg("Failed to subscribe service cleaner")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -124,7 +124,7 @@ func (cfg *Config) SetDefault(key string, value interface{}) {
 // SetUser sets user configuration value for key.
 func (cfg *Config) SetUser(key string, value interface{}) {
 	if cfg.eventBus != nil {
-		cfg.eventBus.Publish(Topic(key), value)
+		cfg.eventBus.Publish(AppTopicConfig(key), value)
 	}
 	cfg.set(&cfg.user, key, value)
 }
@@ -334,7 +334,7 @@ func GetFloat64(flag cli.Float64Flag) float64 {
 	return Current.GetFloat64(flag.Name)
 }
 
-// Topic returns event bus topic for the given config key to listen for its updates.
-func Topic(configKey string) string {
+// AppTopicConfig returns event bus topic for the given config key to listen for its updates.
+func AppTopicConfig(configKey string) string {
 	return "config:" + configKey
 }

--- a/core/connection/event.go
+++ b/core/connection/event.go
@@ -21,12 +21,12 @@ import "github.com/mysteriumnetwork/node/consumer"
 
 // Topic represents the different topics a consumer can subscribe to
 const (
-	// StateEventTopic represents the connection state change topic
-	StateEventTopic = "State"
-	// StatisticsEventTopic represents the connection stats topic
-	StatisticsEventTopic = "Statistics"
-	// SessionEventTopic represents the session event
-	SessionEventTopic = "Session"
+	// AppTopicConsumerConnectionState represents the connection state change topic
+	AppTopicConsumerConnectionState = "State"
+	// AppTopicConsumerStatistics represents the connection stats topic
+	AppTopicConsumerStatistics = "Statistics"
+	// AppTopicConsumerSession represents the session event
+	AppTopicConsumerSession = "Session"
 )
 
 // StateEvent is the struct we'll emit on a StateEvent topic event

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -354,7 +354,7 @@ func (manager *connectionManager) createSession(c Connection, dialog communicati
 	}
 	manager.setCurrentSession(sessionInfo)
 
-	manager.eventPublisher.Publish(SessionEventTopic, SessionEvent{
+	manager.eventPublisher.Publish(AppTopicConsumerSession, SessionEvent{
 		Status:      SessionCreatedStatus,
 		SessionInfo: manager.getCurrentSession(),
 	})
@@ -362,7 +362,7 @@ func (manager *connectionManager) createSession(c Connection, dialog communicati
 	manager.cleanup = append(manager.cleanup, func() error {
 		log.Trace().Msg("Cleaning: publishing session ended status")
 		defer log.Trace().Msg("Cleaning: publishing session ended status DONE")
-		manager.eventPublisher.Publish(SessionEventTopic, SessionEvent{
+		manager.eventPublisher.Publish(AppTopicConsumerSession, SessionEvent{
 			Status:      SessionEndedStatus,
 			SessionInfo: manager.getCurrentSession(),
 		})
@@ -524,7 +524,7 @@ func (manager *connectionManager) consumeStats(statisticsChannel <-chan consumer
 		for {
 			select {
 			case stats := <-statisticsChannel:
-				manager.eventPublisher.Publish(StatisticsEventTopic, SessionStatsEvent{
+				manager.eventPublisher.Publish(AppTopicConsumerStatistics, SessionStatsEvent{
 					Stats:       stats,
 					SessionInfo: manager.getCurrentSession(),
 				})
@@ -574,7 +574,7 @@ func (manager *connectionManager) setupTrafficBlock(disableKillSwitch bool) erro
 }
 
 func (manager *connectionManager) publishStateEvent(state State) {
-	manager.eventPublisher.Publish(StateEventTopic, StateEvent{
+	manager.eventPublisher.Publish(AppTopicConsumerConnectionState, StateEvent{
 		State:       state,
 		SessionInfo: manager.getCurrentSession(),
 	})

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -308,7 +308,7 @@ func (tc *testContext) Test_SessionEndPublished_OnConnectError() {
 	found := false
 
 	for _, v := range history {
-		if v.calledWithTopic == SessionEventTopic {
+		if v.calledWithTopic == AppTopicConsumerSession {
 			event := v.calledWithData.(SessionEvent)
 			if event.Status == SessionEndedStatus {
 				found = true
@@ -357,12 +357,12 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 	assert.Len(tc.T(), history, 4)
 
 	for _, v := range history {
-		if v.calledWithTopic == StatisticsEventTopic {
+		if v.calledWithTopic == AppTopicConsumerStatistics {
 			event := v.calledWithData.(SessionStatsEvent)
 			assert.True(tc.T(), event.Stats.BytesReceived == tc.mockStatistics.BytesReceived)
 			assert.True(tc.T(), event.Stats.BytesSent == tc.mockStatistics.BytesSent)
 		}
-		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == Connected {
+		if v.calledWithTopic == AppTopicConsumerConnectionState && v.calledWithData.(StateEvent).State == Connected {
 			event := v.calledWithData.(StateEvent)
 			assert.Equal(tc.T(), Connected, event.State)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
@@ -370,7 +370,7 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 			assert.Equal(tc.T(), activeProposal.ProviderID, event.SessionInfo.Proposal.ProviderID)
 			assert.Equal(tc.T(), activeProposal.ServiceType, event.SessionInfo.Proposal.ServiceType)
 		}
-		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == StateIPNotChanged {
+		if v.calledWithTopic == AppTopicConsumerConnectionState && v.calledWithData.(StateEvent).State == StateIPNotChanged {
 			event := v.calledWithData.(StateEvent)
 			assert.Equal(tc.T(), StateIPNotChanged, event.State)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
@@ -378,7 +378,7 @@ func (tc *testContext) Test_ManagerPublishesEvents() {
 			assert.Equal(tc.T(), activeProposal.ProviderID, event.SessionInfo.Proposal.ProviderID)
 			assert.Equal(tc.T(), activeProposal.ServiceType, event.SessionInfo.Proposal.ServiceType)
 		}
-		if v.calledWithTopic == SessionEventTopic {
+		if v.calledWithTopic == AppTopicConsumerSession {
 			event := v.calledWithData.(SessionEvent)
 			assert.Equal(tc.T(), SessionCreatedStatus, event.Status)
 			assert.Equal(tc.T(), consumerID, event.SessionInfo.ConsumerID)
@@ -405,7 +405,7 @@ func (tc *testContext) Test_ManagerNotifiesAboutSessionIPNotChanged() {
 	history := tc.stubPublisher.GetEventHistory()
 	var ipNotChangedEvent *StubPublisherEvent
 	for _, v := range history {
-		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == StateIPNotChanged {
+		if v.calledWithTopic == AppTopicConsumerConnectionState && v.calledWithData.(StateEvent).State == StateIPNotChanged {
 			ipNotChangedEvent = &v
 		}
 	}
@@ -440,7 +440,7 @@ func (tc *testContext) Test_ManagerNotifiesAboutSuccessfulConnection() {
 	history := tc.stubPublisher.GetEventHistory()
 	var ipNotChangedEvent *StubPublisherEvent
 	for _, v := range history {
-		if v.calledWithTopic == StateEventTopic && v.calledWithData.(StateEvent).State == StateIPNotChanged {
+		if v.calledWithTopic == AppTopicConsumerConnectionState && v.calledWithData.(StateEvent).State == StateIPNotChanged {
 			ipNotChangedEvent = &v
 		}
 	}

--- a/core/discovery/brokerdiscovery/storage.go
+++ b/core/discovery/brokerdiscovery/storage.go
@@ -88,14 +88,14 @@ func (s *ProposalStorage) Set(proposals []market.ServiceProposal) {
 	for _, p := range proposals {
 		index, exist := s.getProposalIndex(proposalsOld, p.UniqueID())
 		if exist {
-			go s.eventPublisher.Publish(discovery.EventTopicProposalUpdated, p)
+			go s.eventPublisher.Publish(discovery.AppTopicProposalUpdated, p)
 			proposalsOld = append(proposalsOld[:index], proposalsOld[index+1:]...)
 		} else {
-			go s.eventPublisher.Publish(discovery.EventTopicProposalAdded, p)
+			go s.eventPublisher.Publish(discovery.AppTopicProposalAdded, p)
 		}
 	}
 	for _, p := range proposalsOld {
-		go s.eventPublisher.Publish(discovery.EventTopicProposalRemoved, p)
+		go s.eventPublisher.Publish(discovery.AppTopicProposalRemoved, p)
 	}
 	s.proposals = proposals
 }
@@ -128,10 +128,10 @@ func (s *ProposalStorage) AddProposal(proposals ...market.ServiceProposal) {
 
 	for _, p := range proposals {
 		if index, exist := s.getProposalIndex(s.proposals, p.UniqueID()); !exist {
-			s.eventPublisher.Publish(discovery.EventTopicProposalAdded, p)
+			s.eventPublisher.Publish(discovery.AppTopicProposalAdded, p)
 			s.proposals = append(s.proposals, p)
 		} else {
-			s.eventPublisher.Publish(discovery.EventTopicProposalUpdated, p)
+			s.eventPublisher.Publish(discovery.AppTopicProposalUpdated, p)
 			s.proposals[index] = p
 		}
 	}
@@ -143,7 +143,7 @@ func (s *ProposalStorage) RemoveProposal(id market.ProposalID) {
 	defer s.mutex.Unlock()
 
 	if index, exist := s.getProposalIndex(s.proposals, id); exist {
-		go s.eventPublisher.Publish(discovery.EventTopicProposalRemoved, s.proposals[index])
+		go s.eventPublisher.Publish(discovery.AppTopicProposalRemoved, s.proposals[index])
 		s.proposals = append(s.proposals[:index], s.proposals[index+1:]...)
 	}
 }

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -184,7 +184,7 @@ func (d *Discovery) handleRegistrationEvent(rep registry.RegistrationEventPayloa
 
 func (d *Discovery) registerIdentity() {
 	log.Info().Msg("Waiting for registration success event")
-	d.eventBus.Subscribe(registry.RegistrationEventTopic, d.handleRegistrationEvent)
+	d.eventBus.Subscribe(registry.AppTopicRegistration, d.handleRegistrationEvent)
 	d.changeStatus(WaitingForRegistration)
 }
 
@@ -196,7 +196,7 @@ func (d *Discovery) registerProposal() {
 		d.changeStatus(RegisterProposal)
 		return
 	}
-	d.eventBus.Publish(EventTopicProposalAnnounce, d.proposal)
+	d.eventBus.Publish(AppTopicProposalAnnounce, d.proposal)
 	d.changeStatus(PingProposal)
 }
 
@@ -206,7 +206,7 @@ func (d *Discovery) pingProposal() {
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to ping proposal")
 	}
-	d.eventBus.Publish(EventTopicProposalAnnounce, d.proposal)
+	d.eventBus.Publish(AppTopicProposalAnnounce, d.proposal)
 	d.changeStatus(PingProposal)
 }
 

--- a/core/discovery/discovery_test.go
+++ b/core/discovery/discovery_test.go
@@ -69,7 +69,7 @@ func TestStartRegistersIdentitySuccessfully(t *testing.T) {
 	actualStatus := observeStatus(d, WaitingForRegistration)
 	assert.Equal(t, WaitingForRegistration, actualStatus)
 
-	d.eventBus.Publish(identityregistry.RegistrationEventTopic, identityregistry.RegistrationEventPayload{
+	d.eventBus.Publish(identityregistry.AppTopicRegistration, identityregistry.RegistrationEventPayload{
 		ID:     providerID,
 		Status: identityregistry.RegisteredProvider,
 	})
@@ -89,7 +89,7 @@ func TestStartRegisterIdentityCancelled(t *testing.T) {
 	actualStatus := observeStatus(d, WaitingForRegistration)
 	assert.Equal(t, WaitingForRegistration, actualStatus)
 
-	d.eventBus.Publish(identityregistry.RegistrationEventTopic, identityregistry.RegistrationEventPayload{
+	d.eventBus.Publish(identityregistry.AppTopicRegistration, identityregistry.RegistrationEventPayload{
 		ID:     providerID,
 		Status: identityregistry.RegistrationError,
 	})

--- a/core/discovery/event.go
+++ b/core/discovery/event.go
@@ -19,12 +19,12 @@ package discovery
 
 // Topic represents the different topics a consumer can subscribe to
 const (
-	// EventTopicProposalAdded represents newly announced proposal
-	EventTopicProposalAdded = "ProposalAdded"
-	// EventTopicProposalUpdated represents re-announced proposal
-	EventTopicProposalUpdated = "ProposalUpdated"
-	// EventTopicProposalRemoved represents newly de-announced proposal
-	EventTopicProposalRemoved = "ProposalRemoved"
-	// EventTopicProposalAnnounce represent proposal events topic.
-	EventTopicProposalAnnounce = "proposalEvent"
+	// AppTopicProposalAdded represents newly announced proposal
+	AppTopicProposalAdded = "ProposalAdded"
+	// AppTopicProposalUpdated represents re-announced proposal
+	AppTopicProposalUpdated = "ProposalUpdated"
+	// AppTopicProposalRemoved represents newly de-announced proposal
+	AppTopicProposalRemoved = "ProposalRemoved"
+	// AppTopicProposalAnnounce represent proposal events topic.
+	AppTopicProposalAnnounce = "proposalEvent"
 )

--- a/core/node/event/event.go
+++ b/core/node/event/event.go
@@ -18,8 +18,8 @@
 package event
 
 const (
-	// Topic represents the topic we're gonna be publishing and subscribing on
-	Topic = "Node"
+	// AppTopicNode represents the topic we're gonna be publishing and subscribing on
+	AppTopicNode = "Node"
 	// StatusStarted is published once node is started
 	StatusStarted Status = "Started"
 	// StatusStopped is published once node is stopped

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -78,7 +78,7 @@ func (node *Node) Start() error {
 		}
 	}()
 
-	node.publisher.Publish(event.Topic, event.Payload{Status: event.StatusStarted})
+	node.publisher.Publish(event.AppTopicNode, event.Payload{Status: event.StatusStarted})
 
 	go node.natPinger.Start()
 
@@ -87,7 +87,7 @@ func (node *Node) Start() error {
 
 // Wait blocks until Mysterium node is stopped
 func (node *Node) Wait() error {
-	defer node.publisher.Publish(event.Topic, event.Payload{Status: event.StatusStopped})
+	defer node.publisher.Publish(event.AppTopicNode, event.Payload{Status: event.StatusStopped})
 	return node.httpAPIServer.Wait()
 }
 

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -123,7 +123,7 @@ func TestManager_StopSendsEvent_SucceedsAndPublishesEvent(t *testing.T) {
 	eventBus.lock.Lock()
 	defer eventBus.lock.Unlock()
 
-	assert.Equal(t, StatusTopic, eventBus.publishedTopic)
+	assert.Equal(t, AppTopicServiceStatus, eventBus.publishedTopic)
 
 	var matchFound bool
 	expectedPayload := EventPayload{ID: string(serviceID), ProviderID: "", Type: "", Status: "NotRunning"}

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -188,7 +188,7 @@ func (i *Instance) setState(newState State) {
 	defer i.stateLock.Unlock()
 	i.state = newState
 
-	i.eventPublisher.Publish(StatusTopic, i.toEvent())
+	i.eventPublisher.Publish(AppTopicServiceStatus, i.toEvent())
 }
 
 // toEvent returns an event representation of the instance

--- a/core/service/status.go
+++ b/core/service/status.go
@@ -17,8 +17,8 @@
 
 package service
 
-// StatusTopic is used in event bus to announce the service status
-const StatusTopic = "Service status"
+// AppTopicServiceStatus is used in event bus to announce the service status
+const AppTopicServiceStatus = "Service status"
 
 // EventPayload represents the service event related information
 type EventPayload struct {

--- a/core/shaper/shaper_linux.go
+++ b/core/shaper/shaper_linux.go
@@ -39,7 +39,7 @@ func create(listener eventListener) *linuxShaper {
 	return &linuxShaper{
 		ws:          ws,
 		listener:    listener,
-		listenTopic: config.Topic(config.FlagShaperEnabled.Name),
+		listenTopic: config.AppTopicConfig(config.FlagShaperEnabled.Name),
 	}
 }
 

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -23,8 +23,8 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 )
 
-// Topic is the topic that we use to announce state changes to via the event bus
-const Topic = "State change"
+// AppTopicState is the topic that we use to announce state changes to via the event bus
+const AppTopicState = "State change"
 
 // State represents the node state at the current moment. It's a read only object, used only to display data.
 type State struct {

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -93,7 +93,7 @@ func NewKeeper(natStatusProvider natStatusProvider, publisher publisher, service
 func (k *Keeper) announceState(_ interface{}) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	k.publisher.Publish(stateEvent.Topic, *k.state)
+	k.publisher.Publish(stateEvent.AppTopicState, *k.state)
 }
 
 func (k *Keeper) updateServiceState(_ interface{}) {

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -31,8 +31,8 @@ import (
 	"github.com/mysteriumnetwork/node/eventbus"
 )
 
-// IdentityUnlockTopic is the channel name for identity unlock event
-const IdentityUnlockTopic = "identity-unlocked"
+// AppTopicIdentityUnlock is the channel name for identity unlock event
+const AppTopicIdentityUnlock = "identity-unlocked"
 
 type identityManager struct {
 	keystoreManager Keystore
@@ -120,7 +120,7 @@ func (idm *identityManager) Unlock(address string, passphrase string) error {
 	log.Debug().Msgf("Caching unlocked address: %s", address)
 	idm.unlocked[address] = true
 
-	go idm.eventBus.Publish(IdentityUnlockTopic, address)
+	go idm.eventBus.Publish(AppTopicIdentityUnlock, address)
 
 	return nil
 }

--- a/identity/registry/provider_registrar.go
+++ b/identity/registry/provider_registrar.go
@@ -79,11 +79,11 @@ func NewProviderRegistrar(transactor txer, registrationStatusChecker registratio
 
 // Subscribe subscribes the provider registrar to service state change events
 func (pr *ProviderRegistrar) Subscribe(eb eventbus.EventBus) error {
-	err := eb.SubscribeAsync(event.Topic, pr.handleNodeStartupEvents)
+	err := eb.SubscribeAsync(event.AppTopicNode, pr.handleNodeStartupEvents)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to node events")
 	}
-	return eb.SubscribeAsync(service.StatusTopic, pr.consumeServiceEvent)
+	return eb.SubscribeAsync(service.AppTopicServiceStatus, pr.consumeServiceEvent)
 }
 
 func (pr *ProviderRegistrar) handleNodeStartupEvents(e event.Payload) {

--- a/identity/registry/registry_contract.go
+++ b/identity/registry/registry_contract.go
@@ -97,12 +97,12 @@ func NewIdentityRegistryContract(contractBackend bind.ContractBackend, registryA
 
 // Subscribe subscribes the contract registry to relevant events
 func (registry *contractRegistry) Subscribe(eb eventbus.Subscriber) error {
-	err := eb.SubscribeAsync(event.Topic, registry.handleNodeEvent)
+	err := eb.SubscribeAsync(event.AppTopicNode, registry.handleNodeEvent)
 	if err != nil {
 		return err
 	}
 
-	return eb.Subscribe(TransactorRegistrationTopic, registry.handleRegistrationEvent)
+	return eb.Subscribe(AppTopicTransactorRegistration, registry.handleRegistrationEvent)
 }
 
 // GetRegistrationStatus returns the registration status of the provided identity
@@ -199,7 +199,7 @@ func (registry *contractRegistry) subscribeToRegistrationEvent(identity identity
 		sink := make(chan *bindings.RegistryRegisteredIdentity)
 		subscription, err := registry.filterer.WatchRegisteredIdentity(filterOps, sink, userIdentities, accountantIdentities)
 		if err != nil {
-			registry.publisher.Publish(RegistrationEventTopic, RegistrationEventPayload{
+			registry.publisher.Publish(AppTopicRegistration, RegistrationEventPayload{
 				ID:     identity,
 				Status: RegistrationError,
 			})
@@ -231,7 +231,7 @@ func (registry *contractRegistry) subscribeToRegistrationEvent(identity identity
 			}
 
 			log.Debug().Msgf("Sending registration success event for %v", identity)
-			registry.publisher.Publish(RegistrationEventTopic, RegistrationEventPayload{
+			registry.publisher.Publish(AppTopicRegistration, RegistrationEventPayload{
 				ID:     identity,
 				Status: status,
 			})
@@ -244,7 +244,7 @@ func (registry *contractRegistry) subscribeToRegistrationEvent(identity identity
 				log.Error().Err(err).Msg("Could not store registration status")
 			}
 		case err := <-subscription.Err():
-			registry.publisher.Publish(RegistrationEventTopic, RegistrationEventPayload{
+			registry.publisher.Publish(AppTopicRegistration, RegistrationEventPayload{
 				ID:     identity,
 				Status: RegistrationError,
 			})

--- a/identity/registry/status.go
+++ b/identity/registry/status.go
@@ -69,8 +69,8 @@ func (srs StoredRegistrationStatus) FromEvent(status RegistrationStatus, ev Iden
 	}
 }
 
-// RegistrationEventTopic represents the registration event topic
-const RegistrationEventTopic = "registration_event_topic"
+// AppTopicRegistration represents the registration event topic
+const AppTopicRegistration = "registration_event_topic"
 
 // RegistrationEventPayload represents the registration event payload
 type RegistrationEventPayload struct {

--- a/identity/registry/transactor.go
+++ b/identity/registry/transactor.go
@@ -31,11 +31,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TransactorRegistrationTopic represents the registration topic to which events regarding registration attempts on transactor will occur
-const TransactorRegistrationTopic = "transactor_identity_registration"
+// AppTopicTransactorRegistration represents the registration topic to which events regarding registration attempts on transactor will occur
+const AppTopicTransactorRegistration = "transactor_identity_registration"
 
-// TransactorTopUpTopic represents the top up topic to which events regarding top up attempts are sent.
-const TransactorTopUpTopic = "transactor_top_up"
+// AppTopicTransactorTopUp represents the top up topic to which events regarding top up attempts are sent.
+const AppTopicTransactorTopUp = "transactor_top_up"
 
 // Transactor allows for convenient calls to the transactor service
 type Transactor struct {
@@ -154,7 +154,7 @@ func (t *Transactor) TopUp(id string) error {
 	}
 
 	// This is left as a synchronous call on purpose.
-	t.publisher.Publish(TransactorTopUpTopic, id)
+	t.publisher.Publish(AppTopicTransactorTopUp, id)
 
 	return t.httpClient.DoRequest(req)
 }
@@ -196,7 +196,7 @@ func (t *Transactor) RegisterIdentity(id string, regReqDTO *IdentityRegistration
 
 	// This is left as a synchronous call on purpose.
 	// We need to notify registry before returning.
-	t.publisher.Publish(TransactorRegistrationTopic, regReq)
+	t.publisher.Publish(AppTopicTransactorRegistration, regReq)
 
 	return t.httpClient.DoRequest(req)
 }

--- a/mmn/mmn.go
+++ b/mmn/mmn.go
@@ -43,7 +43,7 @@ func NewMMN(collector *Collector, client *client) *MMN {
 // Subscribe subscribes to node events and reports them to MMN
 func (m *MMN) Subscribe(eventBus eventbus.EventBus) error {
 	err := eventBus.SubscribeAsync(
-		identity.IdentityUnlockTopic,
+		identity.AppTopicIdentityUnlock,
 		m.handleRegistration,
 	)
 	if err != nil {
@@ -51,7 +51,7 @@ func (m *MMN) Subscribe(eventBus eventbus.EventBus) error {
 	}
 
 	err = eventBus.SubscribeAsync(
-		service.StatusTopic,
+		service.AppTopicServiceStatus,
 		m.handleProvider,
 	)
 	if err != nil {
@@ -59,7 +59,7 @@ func (m *MMN) Subscribe(eventBus eventbus.EventBus) error {
 	}
 
 	err = eventBus.SubscribeAsync(
-		connection.SessionEventTopic,
+		connection.AppTopicConsumerSession,
 		m.handleClient,
 	)
 	if err != nil {

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -218,7 +218,7 @@ type ProposalChangeCallback interface {
 
 // RegisterProposalAddedCallback registers callback which is called on newly announced proposals
 func (mb *MobileNode) RegisterProposalAddedCallback(cb ProposalChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(discovery.EventTopicProposalAdded, func(proposal market.ServiceProposal) {
+	_ = mb.eventBus.SubscribeAsync(discovery.AppTopicProposalAdded, func(proposal market.ServiceProposal) {
 		proposalPayload, err := mb.proposalsManager.mapToProposalResponse(&proposal)
 		log.Error().Err(err).Msg("Proposal mapping failed")
 		cb.OnChange(proposalPayload)
@@ -227,7 +227,7 @@ func (mb *MobileNode) RegisterProposalAddedCallback(cb ProposalChangeCallback) {
 
 // RegisterProposalUpdatedCallback registers callback which is called on re-announced proposals
 func (mb *MobileNode) RegisterProposalUpdatedCallback(cb ProposalChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(discovery.EventTopicProposalUpdated, func(proposal market.ServiceProposal) {
+	_ = mb.eventBus.SubscribeAsync(discovery.AppTopicProposalUpdated, func(proposal market.ServiceProposal) {
 		proposalPayload, err := mb.proposalsManager.mapToProposalResponse(&proposal)
 		log.Error().Err(err).Msg("Proposal mapping failed")
 		cb.OnChange(proposalPayload)
@@ -236,7 +236,7 @@ func (mb *MobileNode) RegisterProposalUpdatedCallback(cb ProposalChangeCallback)
 
 // RegisterProposalRemovedCallback registers callback which is called on de-announced proposals
 func (mb *MobileNode) RegisterProposalRemovedCallback(cb ProposalChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(discovery.EventTopicProposalRemoved, func(proposal market.ServiceProposal) {
+	_ = mb.eventBus.SubscribeAsync(discovery.AppTopicProposalRemoved, func(proposal market.ServiceProposal) {
 		proposalPayload, err := mb.proposalsManager.mapToProposalResponse(&proposal)
 		log.Error().Err(err).Msg("Proposal mapping failed")
 		cb.OnChange(proposalPayload)
@@ -287,7 +287,7 @@ type StatisticsChangeCallback interface {
 // RegisterStatisticsChangeCallback registers callback which is called on active connection
 // statistics change.
 func (mb *MobileNode) RegisterStatisticsChangeCallback(cb StatisticsChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(connection.StatisticsEventTopic, func(e connection.SessionStatsEvent) {
+	_ = mb.eventBus.SubscribeAsync(connection.AppTopicConsumerStatistics, func(e connection.SessionStatsEvent) {
 		duration := mb.statisticsTracker.GetSessionDuration()
 		cb.OnChange(int64(duration.Seconds()), int64(e.Stats.BytesReceived), int64(e.Stats.BytesSent))
 	})
@@ -301,7 +301,7 @@ type ConnectionStatusChangeCallback interface {
 // RegisterConnectionStatusChangeCallback registers callback which is called on active connection
 // status change.
 func (mb *MobileNode) RegisterConnectionStatusChangeCallback(cb ConnectionStatusChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(connection.StateEventTopic, func(e connection.StateEvent) {
+	_ = mb.eventBus.SubscribeAsync(connection.AppTopicConsumerConnectionState, func(e connection.StateEvent) {
 		cb.OnChange(string(e.State))
 	})
 }
@@ -313,7 +313,7 @@ type BalanceChangeCallback interface {
 
 // RegisterBalanceChangeCallback registers callback which is called on identity balance change.
 func (mb *MobileNode) RegisterBalanceChangeCallback(cb BalanceChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(pingpong.BalanceChangedTopic, func(e pingpong.BalanceChangedEvent) {
+	_ = mb.eventBus.SubscribeAsync(pingpong.AppTopicBalanceChanged, func(e pingpong.BalanceChangedEvent) {
 		cb.OnChange(e.Identity.Address, int64(e.Current))
 	})
 }
@@ -325,7 +325,7 @@ type IdentityRegistrationChangeCallback interface {
 
 // RegisterIdentityRegistrationChangeCallback registers callback which is called on identity registration status change.
 func (mb *MobileNode) RegisterIdentityRegistrationChangeCallback(cb IdentityRegistrationChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(registry.RegistrationEventTopic, func(e registry.RegistrationEventPayload) {
+	_ = mb.eventBus.SubscribeAsync(registry.AppTopicRegistration, func(e registry.RegistrationEventPayload) {
 		cb.OnChange(e.ID.Address, e.Status.String())
 	})
 }
@@ -509,7 +509,7 @@ func (mb *MobileNode) OverrideOpenvpnConnection(tunnelSetup Openvpn3TunnelSetup)
 			mb.ipResolver,
 		)
 	}
-	_ = mb.eventBus.Subscribe(connection.StateEventTopic, st.handleState)
+	_ = mb.eventBus.Subscribe(connection.AppTopicConsumerConnectionState, st.handleState)
 	mb.connectionRegistry.Register("openvpn", factory)
 	return st
 }

--- a/nat/event/tracker.go
+++ b/nat/event/tracker.go
@@ -23,8 +23,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Topic the topic that traversal events are published on
-const Topic = "Traversal"
+// AppTopicTraversal the topic that traversal events are published on
+const AppTopicTraversal = "Traversal"
 
 // Tracker is able to track NAT traversal events
 type Tracker struct {

--- a/nat/mapping/port_mapping.go
+++ b/nat/mapping/port_mapping.go
@@ -101,9 +101,9 @@ func (p *portMapper) Map(protocol string, port int, name string) (release func()
 
 func (p *portMapper) notify(err error) {
 	if err != nil {
-		p.publisher.Publish(event.Topic, event.BuildFailureEvent(StageName, err))
+		p.publisher.Publish(event.AppTopicTraversal, event.BuildFailureEvent(StageName, err))
 	} else {
-		p.publisher.Publish(event.Topic, event.BuildSuccessfulEvent(StageName))
+		p.publisher.Publish(event.AppTopicTraversal, event.BuildSuccessfulEvent(StageName))
 	}
 }
 

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -209,7 +209,7 @@ func (p *Pinger) ping(conn *net.UDPConn, stop <-chan struct{}) error {
 
 			err := p.sendPingRequest(conn, ttl)
 			if err != nil {
-				p.eventPublisher.Publish(event.Topic, event.BuildFailureEvent(StageName, err))
+				p.eventPublisher.Publish(event.AppTopicTraversal, event.BuildFailureEvent(StageName, err))
 				return err
 			}
 
@@ -217,7 +217,7 @@ func (p *Pinger) ping(conn *net.UDPConn, stop <-chan struct{}) error {
 
 			if time.Duration(i)*p.pingConfig.Interval > p.pingConfig.Timeout {
 				err := errors.New("timeout while waiting for ping ack, trying to continue")
-				p.eventPublisher.Publish(event.Topic, event.BuildFailureEvent(StageName, err))
+				p.eventPublisher.Publish(event.AppTopicTraversal, event.BuildFailureEvent(StageName, err))
 				return err
 			}
 		}
@@ -339,7 +339,7 @@ func (p *Pinger) pingTargetConsumer(pingParams *Params) {
 		return
 	}
 
-	p.eventPublisher.Publish(event.Topic, event.BuildSuccessfulEvent(StageName))
+	p.eventPublisher.Publish(event.AppTopicTraversal, event.BuildSuccessfulEvent(StageName))
 
 	log.Info().Msg("Ping received, waiting for a new connection")
 

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -61,7 +61,7 @@ func NewManager(nodeOptions node.Options,
 	callback := func(sbc bytecount.SessionByteCount) {
 		sessions := clientMap.GetClientSessions(sbc.ClientID)
 		if len(sessions) == 1 {
-			bus.Publish(event.DataTransfered, event.DataTransferEventPayload{
+			bus.Publish(event.AppTopicDataTransfered, event.DataTransferEventPayload{
 				ID:   string(sessions[0]),
 				Up:   sbc.BytesOut,
 				Down: sbc.BytesIn,

--- a/session/event/event.go
+++ b/session/event/event.go
@@ -17,11 +17,11 @@
 
 package event
 
-// Topic represents the session change topic
-const Topic = "Session change"
+// AppTopicSession represents the session change topic
+const AppTopicSession = "Session change"
 
-// DataTransfered represents the data transfer topic
-const DataTransfered = "Session data transfered"
+// AppTopicDataTransfered represents the data transfer topic
+const AppTopicDataTransfered = "Session data transfered"
 
 // DataTransferEventPayload represents the data transfer event
 type DataTransferEventPayload struct {

--- a/session/event_based_storage.go
+++ b/session/event_based_storage.go
@@ -50,7 +50,7 @@ func NewEventBasedStorage(bus eventPublisher, storage storage) *EventBasedStorag
 // Add adds a session and publishes a creation event
 func (ebs *EventBasedStorage) Add(sessionInstance Session) {
 	ebs.storage.Add(sessionInstance)
-	go ebs.bus.Publish(event.Topic, event.Payload{
+	go ebs.bus.Publish(event.AppTopicSession, event.Payload{
 		ID:     string(sessionInstance.ID),
 		Action: event.Created,
 	})
@@ -71,7 +71,7 @@ func (ebs *EventBasedStorage) consumeDataTransferedEvent(e event.DataTransferEve
 // UpdateDataTransfer updates the data transfer for a session
 func (ebs *EventBasedStorage) UpdateDataTransfer(id ID, up, down uint64) {
 	ebs.storage.UpdateDataTransfer(id, up, down)
-	go ebs.bus.Publish(event.Topic, event.Payload{
+	go ebs.bus.Publish(event.AppTopicSession, event.Payload{
 		ID:     string(id),
 		Action: event.Updated,
 	})
@@ -85,7 +85,7 @@ func (ebs *EventBasedStorage) Find(id ID) (Session, bool) {
 // Remove removes the session and publishes a removal event
 func (ebs *EventBasedStorage) Remove(id ID) {
 	ebs.storage.Remove(id)
-	go ebs.bus.Publish(event.Topic, event.Payload{
+	go ebs.bus.Publish(event.AppTopicSession, event.Payload{
 		ID:     string(id),
 		Action: event.Removed,
 	})
@@ -94,7 +94,7 @@ func (ebs *EventBasedStorage) Remove(id ID) {
 // RemoveForService removes all the sessions for a service and publishes a delete event
 func (ebs *EventBasedStorage) RemoveForService(serviceID string) {
 	ebs.storage.RemoveForService(serviceID)
-	go ebs.bus.Publish(event.Topic, event.Payload{
+	go ebs.bus.Publish(event.AppTopicSession, event.Payload{
 		ID:     "",
 		Action: event.Removed,
 	})
@@ -102,5 +102,5 @@ func (ebs *EventBasedStorage) RemoveForService(serviceID string) {
 
 // Subscribe subscribes the ebs to relevant events
 func (ebs *EventBasedStorage) Subscribe() error {
-	return ebs.bus.SubscribeAsync(event.DataTransfered, ebs.consumeDataTransferedEvent)
+	return ebs.bus.SubscribeAsync(event.AppTopicDataTransfered, ebs.consumeDataTransferedEvent)
 }

--- a/session/manager.go
+++ b/session/manager.go
@@ -206,7 +206,7 @@ func (manager *Manager) Acknowledge(consumerID identity.Identity, sessionID stri
 		return ErrorWrongSessionOwner
 	}
 
-	manager.publisher.Publish(sevent.Topic, sevent.Payload{
+	manager.publisher.Publish(sevent.AppTopicSession, sevent.Payload{
 		Action: sevent.Acknowledged,
 		ID:     sessionID,
 	})

--- a/session/pingpong/accountant_promise_settler.go
+++ b/session/pingpong/accountant_promise_settler.go
@@ -143,22 +143,22 @@ func (aps *AccountantPromiseSettler) resyncState(addr identity.Identity) error {
 
 // Subscribe subscribes the accountant promise settler to the appropriate events
 func (aps *AccountantPromiseSettler) Subscribe(sub eventbus.Subscriber) error {
-	err := sub.SubscribeAsync(nodevent.Topic, aps.handleNodeEvent)
+	err := sub.SubscribeAsync(nodevent.AppTopicNode, aps.handleNodeEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to node status event")
 	}
 
-	err = sub.SubscribeAsync(registry.RegistrationEventTopic, aps.handleRegistrationEvent)
+	err = sub.SubscribeAsync(registry.AppTopicRegistration, aps.handleRegistrationEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to registration event")
 	}
 
-	err = sub.SubscribeAsync(service.StatusTopic, aps.handleServiceEvent)
+	err = sub.SubscribeAsync(service.AppTopicServiceStatus, aps.handleServiceEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to service status event")
 	}
 
-	err = sub.SubscribeAsync(AccountantPromiseTopic, aps.handleAccountantPromiseReceived)
+	err = sub.SubscribeAsync(AppTopicAccountantPromise, aps.handleAccountantPromiseReceived)
 	return errors.Wrap(err, "could not subscribe to accountant promise event")
 }
 

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -75,11 +75,11 @@ type Balance struct {
 
 // Subscribe subscribes the consumer balance tracker to relevant events
 func (cbt *ConsumerBalanceTracker) Subscribe(bus eventbus.Subscriber) error {
-	err := bus.SubscribeAsync(registry.RegistrationEventTopic, cbt.handleRegistrationEvent)
+	err := bus.SubscribeAsync(registry.AppTopicRegistration, cbt.handleRegistrationEvent)
 	if err != nil {
 		return err
 	}
-	err = bus.SubscribeAsync(registry.TransactorTopUpTopic, cbt.handleTopUpEvent)
+	err = bus.SubscribeAsync(registry.AppTopicTransactorTopUp, cbt.handleTopUpEvent)
 	if err != nil {
 		return err
 	}
@@ -87,11 +87,11 @@ func (cbt *ConsumerBalanceTracker) Subscribe(bus eventbus.Subscriber) error {
 	if err != nil {
 		return err
 	}
-	err = bus.SubscribeAsync(ExchangeMessageTopic, cbt.handleExchangeMessageEvent)
+	err = bus.SubscribeAsync(AppTopicExchangeMessage, cbt.handleExchangeMessageEvent)
 	if err != nil {
 		return err
 	}
-	return bus.SubscribeAsync(identity.IdentityUnlockTopic, cbt.handleUnlockEvent)
+	return bus.SubscribeAsync(identity.AppTopicIdentityUnlock, cbt.handleUnlockEvent)
 }
 
 // GetBalance gets the current balance for given identity
@@ -109,7 +109,7 @@ func (cbt *ConsumerBalanceTracker) handleExchangeMessageEvent(event ExchangeMess
 }
 
 func (cbt *ConsumerBalanceTracker) publishChangeEvent(id identity.Identity, before, after uint64) {
-	cbt.publisher.Publish(BalanceChangedTopic, BalanceChangedEvent{
+	cbt.publisher.Publish(AppTopicBalanceChanged, BalanceChangedEvent{
 		Identity: id,
 		Previous: before,
 		Current:  after,

--- a/session/pingpong/consumer_balance_tracker_test.go
+++ b/session/pingpong/consumer_balance_tracker_test.go
@@ -56,11 +56,11 @@ func TestConsumerBalanceTracker(t *testing.T) {
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
 
-	bus.Publish(registry.RegistrationEventTopic, registry.RegistrationEventPayload{
+	bus.Publish(registry.AppTopicRegistration, registry.RegistrationEventPayload{
 		ID:     id1,
 		Status: registry.RegisteredProvider,
 	})
-	bus.Publish(registry.RegistrationEventTopic, registry.RegistrationEventPayload{
+	bus.Publish(registry.AppTopicRegistration, registry.RegistrationEventPayload{
 		ID:     id2,
 		Status: registry.RegistrationError,
 	})
@@ -71,13 +71,13 @@ func TestConsumerBalanceTracker(t *testing.T) {
 	err = waitForBalance(cbt, id2, 0)
 	assert.Nil(t, err)
 
-	bus.Publish(identity.IdentityUnlockTopic, id2.Address)
+	bus.Publish(identity.AppTopicIdentityUnlock, id2.Address)
 
 	err = waitForBalance(cbt, id2, initialBalance)
 	assert.Nil(t, err)
 
 	var promised uint64 = 100
-	bus.Publish(ExchangeMessageTopic, ExchangeMessageEventPayload{
+	bus.Publish(AppTopicExchangeMessage, ExchangeMessageEventPayload{
 		Identity:       id1,
 		AmountPromised: promised,
 	})

--- a/session/pingpong/event.go
+++ b/session/pingpong/event.go
@@ -22,27 +22,27 @@ import (
 	"github.com/mysteriumnetwork/payments/crypto"
 )
 
-// AccountantPromiseTopic represents a topic to which we send accountant promise events.
-const AccountantPromiseTopic = "accountant_promise_received"
+// AppTopicAccountantPromise represents a topic to which we send accountant promise events.
+const AppTopicAccountantPromise = "accountant_promise_received"
 
-// AccountantPromiseEventPayload represents the payload that is sent on the AccountantPromiseTopic.
+// AccountantPromiseEventPayload represents the payload that is sent on the AppTopicAccountantPromise.
 type AccountantPromiseEventPayload struct {
 	Promise      crypto.Promise
 	AccountantID identity.Identity
 	ProviderID   identity.Identity
 }
 
-// ExchangeMessageTopic represents a topic where exchange messages are sent.
-const ExchangeMessageTopic = "exchange_message_topic"
+// AppTopicExchangeMessage represents a topic where exchange messages are sent.
+const AppTopicExchangeMessage = "exchange_message_topic"
 
-// ExchangeMessageEventPayload represents the messages that are sent on the ExchangeMessageTopic.
+// ExchangeMessageEventPayload represents the messages that are sent on the AppTopicExchangeMessage.
 type ExchangeMessageEventPayload struct {
 	Identity       identity.Identity
 	AmountPromised uint64
 }
 
-// BalanceChangedTopic represents the balance change topic
-const BalanceChangedTopic = "balance_change"
+// AppTopicBalanceChanged represents the balance change topic
+const AppTopicBalanceChanged = "balance_change"
 
 // BalanceChangedEvent represents a balance change event
 type BalanceChangedEvent struct {

--- a/session/pingpong/exchange_message_tracker.go
+++ b/session/pingpong/exchange_message_tracker.go
@@ -244,7 +244,7 @@ func (emt *ExchangeMessageTracker) issueExchangeMessage(invoice crypto.Invoice) 
 		log.Warn().Err(err).Msg("Failed to send exchange message")
 	}
 
-	defer emt.deps.Publisher.Publish(ExchangeMessageTopic, ExchangeMessageEventPayload{
+	defer emt.deps.Publisher.Publish(AppTopicExchangeMessage, ExchangeMessageEventPayload{
 		Identity:       emt.deps.Identity,
 		AmountPromised: diff,
 	})

--- a/session/pingpong/exchange_message_tracker_test.go
+++ b/session/pingpong/exchange_message_tracker_test.go
@@ -634,7 +634,7 @@ func TestExchangeMessageTracker_issueExchangeMessage_publishesEvents(t *testing.
 	})
 	assert.NoError(t, err)
 	ev := <-mp.publicationChan
-	assert.Equal(t, ExchangeMessageTopic, ev.name)
+	assert.Equal(t, AppTopicExchangeMessage, ev.name)
 	assert.EqualValues(t, ExchangeMessageEventPayload{
 		Identity:       emt.deps.Identity,
 		AmountPromised: 5,

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -260,7 +260,7 @@ func (it *InvoiceTracker) requestPromise(r []byte, pm crypto.ExchangeMessage) er
 	}
 
 	promise.R = r
-	it.deps.Publisher.Publish(AccountantPromiseTopic, AccountantPromiseEventPayload{
+	it.deps.Publisher.Publish(AppTopicAccountantPromise, AccountantPromiseEventPayload{
 		Promise:      promise,
 		AccountantID: it.deps.AccountantID,
 		ProviderID:   it.deps.ProviderID,


### PR DESCRIPTION
Easily searchable via IDE: Cmd+Alt+o (search symbols).
Also distinguishable from NATS.

Added some clarifications, e.g. `SessionEventTopic` → `AppTopicConsumerSession`