### PR TITLE
Replace default configuration to new with wireguard enabled

### DIFF
--- a/bin/package/installation/post-install.sh
+++ b/bin/package/installation/post-install.sh
@@ -89,6 +89,9 @@ fi
 # Add defaults file, if it doesn't exist
 if [[ ! -f $DAEMON_DEFAULT ]]; then
     cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
+else
+    # TODO remove this hack when all nodes updated to both services.
+    sed -i -e 's/SERVICE_OPTS="openvpn"/SERVICE_OPTS="openvpn,wireguard"/g' /etc/default/mysterium-node
 fi
 
 # Cleanup old log files (before log file rolling has been fixed)

--- a/debian/postinst
+++ b/debian/postinst
@@ -89,6 +89,9 @@ fi
 # Add defaults file, if it doesn't exist
 if [[ ! -f $DAEMON_DEFAULT ]]; then
     cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
+else
+    # TODO remove this hack when all nodes updated to both services.
+    sed -i -e 's/SERVICE_OPTS="openvpn"/SERVICE_OPTS="openvpn,wireguard"/g' /etc/default/mysterium-node
 fi
 
 # Cleanup old log files (before log file rolling has been fixed)


### PR DESCRIPTION
By default, we are not repacing config on updates.
This will allow enabling both Wireguard and OpenVPN services for users with the default configuration.