### PR TITLE
Improve test stability

### DIFF
--- a/core/policy/repository_test.go
+++ b/core/policy/repository_test.go
@@ -233,12 +233,15 @@ func Test_PolicyRepository_StartSyncsPolicies(t *testing.T) {
 	repo.Start()
 	defer repo.Stop()
 
-	time.Sleep(10 * time.Millisecond)
-	policiesRules, err := repo.RulesForPolicies([]market.AccessPolicy{
-		repo.Policy("1"),
-		repo.Policy("2"),
-	})
-	assert.NoError(t, err)
+	var policiesRules []market.AccessPolicyRuleSet
+	assert.Eventually(t, func() bool {
+		var err error
+		policiesRules, err = repo.RulesForPolicies([]market.AccessPolicy{
+			repo.Policy("1"),
+			repo.Policy("2"),
+		})
+		return err == nil && len(policiesRules) == 2
+	}, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRulesUpdated, policyTwoRulesUpdated}, policiesRules)
 }
 

--- a/core/promise/methods/noop/promise_processor_test.go
+++ b/core/promise/methods/noop/promise_processor_test.go
@@ -47,7 +47,7 @@ func TestPromiseProcessor_Start_SendsBalanceMessages(t *testing.T) {
 	defer processor.Stop()
 
 	assert.NoError(t, err)
-	waitForBalanceState(t, processor, balanceNotifying)
+	assert.Eventually(t, balanceStateMatches(processor, balanceNotifying), 1*time.Second, 1*time.Millisecond)
 
 	lastMessage, err := dialog.waitSendMessage()
 	assert.NoError(t, err)
@@ -68,19 +68,15 @@ func TestPromiseProcessor_Stop_StopsBalanceMessages(t *testing.T) {
 	}
 	err := processor.Start(proposal)
 	assert.NoError(t, err)
-	waitForBalanceState(t, processor, balanceNotifying)
+	assert.Eventually(t, balanceStateMatches(processor, balanceNotifying), 1*time.Second, 1*time.Millisecond)
 
 	err = processor.Stop()
 	assert.NoError(t, err)
-	waitForBalanceState(t, processor, balanceStopped)
+	assert.Eventually(t, balanceStateMatches(processor, balanceStopped), 1*time.Second, 1*time.Millisecond)
 }
 
-func waitForBalanceState(t *testing.T, processor *PromiseProcessor, expectedState balanceState) {
-	for i := 0; i < 10; i++ {
-		if processor.getBalanceState() == expectedState {
-			return
-		}
-		time.Sleep(time.Millisecond)
+func balanceStateMatches(processor *PromiseProcessor, expected balanceState) func() bool {
+	return func() bool {
+		return processor.getBalanceState() == expected
 	}
-	assert.Fail(t, "State expected to be ", string(expectedState))
 }

--- a/session/event_based_storage_test.go
+++ b/session/event_based_storage_test.go
@@ -26,91 +26,39 @@ import (
 )
 
 func TestEventBasedStorage_PublishesEventsOnCreate(t *testing.T) {
-	instance := expectedSession
+	session := expectedSession
 	mp := &mockPublisher{}
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
 
-	sessionStore.Add(instance)
+	sessionStore.Add(session)
 
-	// since we're shooting the event in an asynchronous fashion, try every millisecond to see if we already have it
-	attempts := 0
-	for range time.After(time.Millisecond) {
-		if attempts > 50 {
-			assert.Fail(t, "no change after a 50 attempts")
-			break
-		}
-		attempts++
-		if mp.getLast().Action == sessionEvent.Created {
-			break
-		}
-	}
-
-	assert.Equal(t, sessionEvent.Payload{
-		Action: sessionEvent.Created,
-		ID:     string(expectedID),
-	}, mp.published)
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Created), 100*time.Millisecond, 1*time.Millisecond)
 }
 
 func TestEventBasedStorage_PublishesEventsOnDelete(t *testing.T) {
-	instance := expectedSession
+	session := expectedSession
 	mp := &mockPublisher{}
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
-	sessionStore.Add(instance)
+	sessionStore.Add(session)
 
 	time.Sleep(time.Millisecond * 5)
 
-	sessionStore.Remove(instance.ID)
+	sessionStore.Remove(session.ID)
 
-	// since we're shooting the event in an asynchronous fashion, try every microsecond to see if we already have it
-	attempts := 0
-
-	for range time.After(time.Millisecond) {
-		if attempts > 50 {
-			assert.Fail(t, "no change after a 50 attempts")
-			break
-		}
-		attempts++
-		t.Log("attempts", attempts)
-		if mp.getLast().Action == sessionEvent.Removed {
-			break
-		}
-	}
-
-	assert.Equal(t, sessionEvent.Payload{
-		Action: sessionEvent.Removed,
-		ID:     string(expectedID),
-	}, mp.published)
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Removed), 100*time.Millisecond, 1*time.Millisecond)
 }
 
 func TestEventBasedStorage_PublishesEventsOnDataTransferUpdate(t *testing.T) {
-	instance := expectedSession
+	session := expectedSession
 	mp := &mockPublisher{}
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
-	sessionStore.Add(instance)
+	sessionStore.Add(session)
 
 	time.Sleep(time.Millisecond * 5)
 
-	sessionStore.UpdateDataTransfer(instance.ID, 1, 2)
+	sessionStore.UpdateDataTransfer(session.ID, 1, 2)
 
-	// since we're shooting the event in an asynchronous fashion, try every microsecond to see if we already have it
-	attempts := 0
-
-	for range time.After(time.Millisecond) {
-		if attempts > 50 {
-			assert.Fail(t, "no change after a 50 attempts")
-			break
-		}
-		attempts++
-		t.Log("attempts", attempts)
-		if mp.getLast().Action == sessionEvent.Updated {
-			break
-		}
-	}
-
-	assert.Equal(t, sessionEvent.Payload{
-		Action: sessionEvent.Updated,
-		ID:     string(expectedID),
-	}, mp.published)
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Updated), 100*time.Millisecond, 1*time.Millisecond)
 }
 
 func TestNewEventBasedStorage_HandlesAppEventTokensEarned(t *testing.T) {
@@ -134,39 +82,25 @@ func TestNewEventBasedStorage_HandlesAppEventTokensEarned(t *testing.T) {
 	storedSession, ok = sessionStore.Find(session.ID)
 	assert.True(t, ok)
 	assert.EqualValues(t, 500, storedSession.TokensEarned)
-	assert.Eventually(t, func() bool {
-		evt := mp.getLast()
-		return evt.ID == string(session.ID) && evt.Action == sessionEvent.Updated
-	}, 1*time.Second, 5*time.Millisecond)
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Updated), 1*time.Second, 5*time.Millisecond)
 }
 
 func TestEventBasedStorage_PublishesEventsOnRemoveForService(t *testing.T) {
-	instance := expectedSession
+	session := expectedSession
 	mp := &mockPublisher{}
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
-	sessionStore.Add(instance)
+	sessionStore.Add(session)
 
 	time.Sleep(time.Millisecond * 5)
 
 	sessionStore.RemoveForService("whatever")
 
-	// since we're shooting the event in an asynchronous fashion, try every microsecond to see if we already have it
-	attempts := 0
+	assert.Eventually(t, lastEventMatches(mp, "", sessionEvent.Removed), 100*time.Millisecond, 1*time.Millisecond)
+}
 
-	for range time.After(time.Millisecond) {
-		if attempts > 50 {
-			assert.Fail(t, "no change after a 50 attempts")
-			break
-		}
-		attempts++
-		t.Log("attempts", attempts)
-		if mp.getLast().Action == sessionEvent.Removed {
-			break
-		}
+func lastEventMatches(mp *mockPublisher, id ID, action sessionEvent.Action) func() bool {
+	return func() bool {
+		evt := mp.getLast()
+		return evt.ID == string(id) && evt.Action == action
 	}
-
-	assert.Equal(t, sessionEvent.Payload{
-		Action: sessionEvent.Removed,
-		ID:     "",
-	}, mp.published)
 }


### PR DESCRIPTION
Replaced homegrown retry logic and sleeps with `assert.Eventually` where async behavior was being tested.

Fixes: #1664