### PR TITLE
Get rid of flakiness for good

### DIFF
--- a/session/event_based_storage_test.go
+++ b/session/event_based_storage_test.go
@@ -40,8 +40,7 @@ func TestEventBasedStorage_PublishesEventsOnDelete(t *testing.T) {
 	mp := &mockPublisher{}
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
 	sessionStore.Add(session)
-
-	time.Sleep(time.Millisecond * 5)
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Created), 1*time.Second, 5*time.Millisecond)
 
 	sessionStore.Remove(session.ID)
 
@@ -54,7 +53,7 @@ func TestEventBasedStorage_PublishesEventsOnDataTransferUpdate(t *testing.T) {
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
 	sessionStore.Add(session)
 
-	time.Sleep(time.Millisecond * 5)
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Created), 1*time.Second, 5*time.Millisecond)
 
 	sessionStore.UpdateDataTransfer(session.ID, 1, 2)
 
@@ -67,6 +66,8 @@ func TestNewEventBasedStorage_HandlesAppEventTokensEarned(t *testing.T) {
 	mp := &mockPublisher{}
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
 	sessionStore.Add(session)
+
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Created), 1*time.Second, 5*time.Millisecond)
 
 	storedSession, ok := sessionStore.Find(session.ID)
 	assert.True(t, ok)
@@ -90,8 +91,7 @@ func TestEventBasedStorage_PublishesEventsOnRemoveForService(t *testing.T) {
 	mp := &mockPublisher{}
 	sessionStore := NewEventBasedStorage(mp, NewStorageMemory())
 	sessionStore.Add(session)
-
-	time.Sleep(time.Millisecond * 5)
+	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.Created), 1*time.Second, 5*time.Millisecond)
 
 	sessionStore.RemoveForService("whatever")
 

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -47,7 +47,7 @@ var (
 
 type mockPublisher struct {
 	published sessionEvent.Payload
-	lock      sync.Mutex
+	lock      sync.RWMutex
 }
 
 func (mp *mockPublisher) Publish(topic string, data interface{}) {
@@ -61,8 +61,8 @@ func (mp *mockPublisher) SubscribeAsync(topic string, f interface{}) error {
 }
 
 func (mp *mockPublisher) getLast() sessionEvent.Payload {
-	mp.lock.Lock()
-	defer mp.lock.Unlock()
+	mp.lock.RLock()
+	defer mp.lock.RUnlock()
 	return mp.published
 }
 


### PR DESCRIPTION
Use eventually to make sure we're catching the previous event before resuming the execution of tests

fixes #1664