### PR TITLE
Increase stats send interval in unit tests 

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -265,6 +265,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options, ser
 			di.Transactor,
 			nodeOptions.Payments.PaymentsDisabled,
 			di.AccountantPromiseSettler,
+			di.HTTPClient,
 		)
 
 		return session.NewDialogHandler(

--- a/mobile/mysterium/wireguard_connection_setup.go
+++ b/mobile/mysterium/wireguard_connection_setup.go
@@ -160,10 +160,10 @@ func (c *wireguardConnection) Stop() {
 		c.device.Stop()
 		c.stateCh <- connection.NotConnected
 
-		close(c.done)
 		close(c.statsCheckerStop)
 		close(c.pingerStop)
 		close(c.stateCh)
+		close(c.done)
 	})
 }
 

--- a/mobile/mysterium/wireguard_connection_setup_test.go
+++ b/mobile/mysterium/wireguard_connection_setup_test.go
@@ -91,7 +91,7 @@ func TestConnectionStopOnceAfterHandshakeErrorAndStopCall(t *testing.T) {
 
 func newConn(t *testing.T) *wireguardConnection {
 	opts := wireGuardOptions{
-		statsUpdateInterval: 1 * time.Microsecond,
+		statsUpdateInterval: 1 * time.Millisecond,
 	}
 	conn, err := NewWireGuardConnection(opts, &mockWireGuardDevice{}, ip.NewResolverMock("172.44.1.12"), traversal.NewNoopPinger(), &mockHandshakeWaiter{})
 	assert.NoError(t, err)

--- a/services/wireguard/connection/connection_test.go
+++ b/services/wireguard/connection/connection_test.go
@@ -95,7 +95,7 @@ func newConn(t *testing.T) *Connection {
 	}
 	opts := Options{
 		DNSConfigDir:        "/dns/dir",
-		StatsUpdateInterval: 1 * time.Microsecond,
+		StatsUpdateInterval: 1 * time.Millisecond,
 	}
 	conn, err := NewConnection(opts, ip.NewResolverMock("172.44.1.12"), traversal.NewNoopPinger(), endpointFactory, &mockDnsManager{}, &mockHandshakeWaiter{})
 	assert.NoError(t, err)


### PR DESCRIPTION
In unit tests stats check period is very small (1 micro second). Sometimes stats channel can become full too fast and Stop will block forever since it tried to send last stats.

Fixes https://github.com/mysteriumnetwork/node/issues/1665