### PR TITLE
Support dynamic IP changes

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -133,30 +133,9 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 		if err != nil {
 			return nil, market.ServiceProposal{}, err
 		}
-		outIP, err := di.IPResolver.GetOutboundIPAsString()
-		if err != nil {
-			return nil, market.ServiceProposal{}, err
-		}
-
-		currentLocation := market.Location{
-			Continent: loc.Continent,
-			Country:   loc.Country,
-			City:      loc.City,
-
-			ASN:      loc.ASN,
-			ISP:      loc.ISP,
-			NodeType: loc.NodeType,
-		}
 
 		transportOptions := serviceOptions.(openvpn_service.Options)
-
-		locationInfo := location.ServiceLocationInfo{
-			OutIP:   outIP,
-			PubIP:   loc.IP,
-			Country: loc.Country,
-		}
-
-		proposal := openvpn_discovery.NewServiceProposalWithLocation(currentLocation, transportOptions.Protocol)
+		proposal := openvpn_discovery.NewServiceProposalWithLocation(loc, transportOptions.Protocol)
 
 		var portPool port.ServicePortSupplier
 		var natPinger traversal.NATPinger
@@ -173,7 +152,8 @@ func (di *Dependencies) bootstrapServiceOpenvpn(nodeOptions node.Options) {
 		manager := openvpn_service.NewManager(
 			nodeOptions,
 			transportOptions,
-			locationInfo,
+			loc.Country,
+			di.IPResolver,
 			di.ServiceSessionStorage,
 			di.NATService,
 			natPinger,

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -28,7 +28,6 @@ import (
 	nats_dialog "github.com/mysteriumnetwork/node/communication/nats/dialog"
 	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/connection"
-	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/core/port"
@@ -81,10 +80,6 @@ func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options) {
 			if err != nil {
 				return nil, market.ServiceProposal{}, err
 			}
-			outIP, err := di.IPResolver.GetOutboundIPAsString()
-			if err != nil {
-				return nil, market.ServiceProposal{}, err
-			}
 
 			wgOptions := serviceOptions.(wireguard_service.Options)
 
@@ -99,18 +94,12 @@ func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options) {
 				natPinger = di.NATPinger
 			}
 
-			locationInfo := location.ServiceLocationInfo{
-				OutIP:   outIP,
-				PubIP:   loc.IP,
-				Country: loc.Country,
-			}
-
 			portmapConfig := mapping.DefaultConfig()
 			portMapper := mapping.NewPortMapper(portmapConfig, di.EventBus)
 
 			svc := wireguard_service.NewManager(
 				di.IPResolver,
-				locationInfo,
+				loc.Country,
 				di.NATService,
 				natPinger,
 				di.NATTracker,
@@ -284,7 +273,7 @@ func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options) {
 	handshakeWaiter := wireguard_connection.NewHandshakeWaiter()
 	endpointFactory := func() (wireguard.ConnectionEndpoint, error) {
 		resourceAllocator := resources.NewAllocator(nil, wireguard_service.DefaultOptions.Subnet)
-		return endpoint.NewConnectionEndpoint(nil, resourceAllocator, 0)
+		return endpoint.NewConnectionEndpoint(resourceAllocator)
 	}
 	connFactory := func() (connection.Connection, error) {
 		opts := wireguard_connection.Options{

--- a/services/openvpn/discovery/factory.go
+++ b/services/openvpn/discovery/factory.go
@@ -18,6 +18,7 @@
 package discovery
 
 import (
+	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/services/openvpn"
@@ -27,9 +28,18 @@ import (
 
 // NewServiceProposalWithLocation creates service proposal description for openvpn service
 func NewServiceProposalWithLocation(
-	serviceLocation market.Location,
+	loc location.Location,
 	protocol string,
 ) market.ServiceProposal {
+	serviceLocation := market.Location{
+		Continent: loc.Continent,
+		Country:   loc.Country,
+		City:      loc.City,
+		ASN:       loc.ASN,
+		ISP:       loc.ISP,
+		NodeType:  loc.NodeType,
+	}
+
 	return market.ServiceProposal{
 		ServiceType: openvpn.ServiceType,
 		ServiceDefinition: dto.ServiceDefinition{

--- a/services/openvpn/discovery/factory_test.go
+++ b/services/openvpn/discovery/factory_test.go
@@ -20,6 +20,7 @@ package discovery
 import (
 	"testing"
 
+	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/services/openvpn/discovery/dto"
 	"github.com/mysteriumnetwork/node/session/pingpong"
@@ -27,14 +28,13 @@ import (
 )
 
 var (
-	locationLTTelia = market.Location{
+	locationLTTelia = location.Location{
 		Continent: "EU",
 		Country:   "LT",
 		City:      "Vilnius",
-
-		ASN:      8764,
-		ISP:      "Telia Lietuva, AB",
-		NodeType: "residential",
+		ASN:       8764,
+		ISP:       "Telia Lietuva, AB",
+		NodeType:  "residential",
 	}
 	protocol = "tcp"
 )
@@ -47,8 +47,8 @@ func Test_NewServiceProposalWithLocation(t *testing.T) {
 		market.ServiceProposal{
 			ServiceType: "openvpn",
 			ServiceDefinition: dto.ServiceDefinition{
-				Location:          locationLTTelia,
-				LocationOriginate: locationLTTelia,
+				Location:          proposal.ServiceDefinition.GetLocation(),
+				LocationOriginate: proposal.ServiceDefinition.GetLocation(),
 				SessionBandwidth:  83886080,
 				Protocol:          "tcp",
 			},

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -24,7 +24,8 @@ import (
 	"github.com/mysteriumnetwork/go-openvpn/openvpn"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/tls"
 	"github.com/mysteriumnetwork/node/config"
-	"github.com/mysteriumnetwork/node/core/location"
+	"github.com/mysteriumnetwork/node/core/ip"
+	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/core/port"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/shaper"
@@ -43,19 +44,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// ServerConfigFactory callback generates session config for remote client
-type ServerConfigFactory func(secPrimitives *tls.Primitives, port int) *openvpn_service.ServerConfig
-
 // ProposalFactory prepares service proposal during runtime
 type ProposalFactory func(currentLocation market.Location) market.ServiceProposal
-
-// SessionConfigNegotiatorFactory initiates ConfigProvider instance during runtime
-type SessionConfigNegotiatorFactory func(secPrimitives *tls.Primitives, dnsIP net.IP, outboundIP, publicIP string, port int) ConfigNegotiator
-
-// ConfigNegotiator creates OpenVPN configuration
-type ConfigNegotiator interface {
-	ProvideVPNConfig() *openvpn_service.VPNConfig
-}
 
 // NATPinger defined Pinger interface for Provider
 type NATPinger interface {
@@ -75,6 +65,9 @@ type eventListener interface {
 
 // Manager represents entrypoint for Openvpn service with top level components
 type Manager struct {
+	nodeOptions    node.Options
+	serviceOptions Options
+
 	natService     nat.NATService
 	ports          port.ServicePortSupplier
 	natPingerPorts port.ServicePortSupplier
@@ -85,17 +78,19 @@ type Manager struct {
 	portMapper     mapping.PortMapper
 	trafficBlocker firewall.IncomingTrafficFirewall
 
-	sessionConfigNegotiatorFactory SessionConfigNegotiatorFactory
+	vpnNetwork      net.IPNet
+	vpnServerPort   int
+	processLauncher *processLauncher
+	openvpnProcess  openvpn.Process
 
-	vpnNetwork               net.IPNet
-	vpnServerPort            int
-	vpnServerConfigFactory   ServerConfigFactory
-	vpnServiceConfigProvider ConfigNegotiator
-	processLauncher          *processLauncher
-	openvpnProcess           openvpn.Process
+	outboundIP string
+	ipResolver ip.Resolver
 
-	location       location.ServiceLocationInfo
-	serviceOptions Options
+	// These fields assigned during serve.
+	country       string
+	dnsIP         net.IP
+	dnsOK         bool
+	tlsPrimitives *tls.Primitives
 }
 
 // Serve starts service - does block
@@ -105,8 +100,6 @@ func (m *Manager) Serve(instance *service.Instance) (err error) {
 		Mask: net.IPMask(net.ParseIP(m.serviceOptions.Netmask).To4()),
 	}
 
-	var dnsOK bool
-	var dnsIP net.IP
 	var dnsPort = 11153
 	dnsHandler, err := dns.ResolveViaSystem()
 	if err == nil {
@@ -127,8 +120,8 @@ func (m *Manager) Serve(instance *service.Instance) (err error) {
 		if err := m.dnsProxy.Run(); err != nil {
 			log.Warn().Err(err).Msg("Provider DNS will not be available")
 		} else {
-			dnsOK = true
-			dnsIP = netutil.FirstIP(m.vpnNetwork)
+			m.dnsOK = true
+			m.dnsIP = netutil.FirstIP(m.vpnNetwork)
 		}
 	} else {
 		log.Warn().Err(err).Msg("Provider DNS will not be available")
@@ -140,25 +133,41 @@ func (m *Manager) Serve(instance *service.Instance) (err error) {
 	}
 	m.vpnServerPort = servicePort.Num()
 
-	if releasePorts, ok := m.tryAddPortMapping(m.vpnServerPort); ok {
-		defer releasePorts()
+	pubIP, err := m.ipResolver.GetPublicIP()
+	if err != nil {
+		return errors.Wrap(err, "could not get public IP")
 	}
 
-	primitives, err := primitiveFactory(m.location.Country, instance.Proposal().ProviderID)
+	if !m.behindNAT(pubIP) {
+		if releasePorts, ok := m.tryAddPortMapping(m.vpnServerPort); ok {
+			defer releasePorts()
+		}
+	}
+
+	m.tlsPrimitives, err = primitiveFactory(m.country, instance.Proposal().ProviderID)
 	if err != nil {
 		return
 	}
 
-	m.vpnServiceConfigProvider = m.sessionConfigNegotiatorFactory(primitives, dnsIP, m.location.OutIP, m.location.PubIP, m.vpnServerPort)
-
-	vpnServerConfig := m.vpnServerConfigFactory(primitives, m.vpnServerPort)
 	stateChannel := make(chan openvpn.State, 10)
 
 	protectedNetworks := stringutil.Split(config.GetString(config.FlagFirewallProtectedNetworks), ',')
 	var openvpnFilterAllow []string
-	if dnsOK {
-		openvpnFilterAllow = []string{dnsIP.String()}
+	if m.dnsOK {
+		openvpnFilterAllow = []string{m.dnsIP.String()}
 	}
+
+	vpnServerConfig := openvpn_service.NewServerConfig(
+		m.nodeOptions.Directories.Runtime,
+		m.nodeOptions.Directories.Config,
+		m.serviceOptions.Subnet,
+		m.serviceOptions.Netmask,
+		m.tlsPrimitives,
+		m.nodeOptions.BindAddress,
+		m.vpnServerPort,
+		m.serviceOptions.Protocol,
+	)
+
 	m.openvpnProcess = m.processLauncher.launch(launchOpts{
 		config:       vpnServerConfig,
 		filterAllow:  openvpnFilterAllow,
@@ -185,9 +194,9 @@ func (m *Manager) Serve(instance *service.Instance) (err error) {
 
 	if _, err := m.natService.Setup(nat.Options{
 		VPNNetwork:        m.vpnNetwork,
-		ProviderExtIP:     net.ParseIP(m.location.OutIP),
-		EnableDNSRedirect: dnsOK,
-		DNSIP:             dnsIP,
+		ProviderExtIP:     net.ParseIP(m.outboundIP),
+		EnableDNSRedirect: m.dnsOK,
+		DNSIP:             m.dnsIP,
 		DNSPort:           dnsPort,
 	}); err != nil {
 		return errors.Wrap(err, "failed to setup NAT/firewall rules")
@@ -205,10 +214,6 @@ func (m *Manager) Serve(instance *service.Instance) (err error) {
 }
 
 func (m *Manager) tryAddPortMapping(port int) (release func(), ok bool) {
-	if !m.location.BehindNAT() {
-		return nil, false
-	}
-
 	release, ok = m.portMapper.Map(
 		m.serviceOptions.Protocol,
 		port,
@@ -234,9 +239,6 @@ func (m *Manager) Stop() error {
 
 // ProvideConfig takes session creation config from end consumer and provides the service configuration to the end consumer
 func (m *Manager) ProvideConfig(_ string, sessionConfig json.RawMessage) (*session.ConfigParams, error) {
-	if m.vpnServiceConfigProvider == nil {
-		return nil, errors.New("Config provider not initialized")
-	}
 	if m.vpnServerPort == 0 {
 		return nil, errors.New("Service port not initialized")
 	}
@@ -245,7 +247,23 @@ func (m *Manager) ProvideConfig(_ string, sessionConfig json.RawMessage) (*sessi
 		Cancel:       make(chan struct{}),
 		ProviderPort: m.vpnServerPort,
 	}
-	vpnConfig := m.vpnServiceConfigProvider.ProvideVPNConfig()
+
+	publicIP, err := m.ipResolver.GetPublicIP()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get public IP")
+	}
+
+	serverIP := vpnServerIP(m.serviceOptions.Port, m.outboundIP, publicIP, m.nodeOptions.OptionsNetwork.Localnet)
+	vpnConfig := &openvpn_service.VPNConfig{
+		RemoteIP:        serverIP,
+		RemotePort:      m.vpnServerPort,
+		RemoteProtocol:  m.serviceOptions.Protocol,
+		TLSPresharedKey: m.tlsPrimitives.PresharedKey.ToPEMFormat(),
+		CACertificate:   m.tlsPrimitives.CertificateAuthority.ToPEMFormat(),
+	}
+	if m.dnsOK {
+		vpnConfig.DNSIPs = m.dnsIP.String()
+	}
 
 	// Older clients do not send any sessionConfig, but we should keep back compatibility and not fail in this case.
 	if sessionConfig != nil && len(sessionConfig) > 0 && m.natPinger.Valid() {
@@ -255,7 +273,7 @@ func (m *Manager) ProvideConfig(_ string, sessionConfig json.RawMessage) (*sessi
 			return nil, errors.Wrap(err, "could not parse consumer config")
 		}
 
-		if m.location.BehindNAT() && m.portMappingFailed() {
+		if m.behindNAT(publicIP) && m.portMappingFailed() {
 			pp, err := m.natPingerPorts.Acquire()
 			if err != nil {
 				return nil, err
@@ -283,7 +301,7 @@ func (m *Manager) ProvideConfig(_ string, sessionConfig json.RawMessage) (*sessi
 }
 
 func (m *Manager) startServer(server openvpn.Process, stateChannel chan openvpn.State) error {
-	if err := m.openvpnProcess.Start(); err != nil {
+	if err := server.Start(); err != nil {
 		return err
 	}
 
@@ -324,4 +342,8 @@ func (m *Manager) portMappingFailed() bool {
 		return true
 	}
 	return lastEvent.Stage == mapping.StageName && !lastEvent.Successful
+}
+
+func (m *Manager) behindNAT(pubIP string) bool {
+	return m.outboundIP != pubIP
 }

--- a/services/openvpn/service/manager_test.go
+++ b/services/openvpn/service/manager_test.go
@@ -20,7 +20,6 @@ package service
 import (
 	"testing"
 
-	openvpn_service "github.com/mysteriumnetwork/node/services/openvpn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,22 +27,4 @@ func TestManager_StopNotPanic(t *testing.T) {
 	m := Manager{}
 	err := m.Stop()
 	assert.NoError(t, err)
-}
-
-func TestManager_ProvideConfigNotFailOnEmptyConfig(t *testing.T) {
-	m := Manager{vpnServiceConfigProvider: &mockConfigProvider{}, vpnServerPort: 1000}
-	_, err := m.ProvideConfig("", []byte(""))
-	assert.NoError(t, err)
-}
-
-func TestManager_ProvideConfigNotFailOnNilConfig(t *testing.T) {
-	m := Manager{vpnServiceConfigProvider: &mockConfigProvider{}, vpnServerPort: 1000}
-	_, err := m.ProvideConfig("", nil)
-	assert.NoError(t, err)
-}
-
-type mockConfigProvider struct{}
-
-func (cp *mockConfigProvider) ProvideVPNConfig() *openvpn_service.VPNConfig {
-	return &openvpn_service.VPNConfig{}
 }

--- a/services/wireguard/wireguard.go
+++ b/services/wireguard/wireguard.go
@@ -73,6 +73,7 @@ type ConsumerModeConfig struct {
 // ProviderModeConfig is provider endpoint startup configuration.
 type ProviderModeConfig struct {
 	ListenPort int
+	PublicIP   string
 }
 
 // ConsumerConfig is used for sending the public key and IP from consumer to provider


### PR DESCRIPTION
Now when consumer connects provider will always sends his newest IP. Before public IP was resolved once on startup, but it could change especially on mobile network.