### PR TITLE
Whitelist myst domains to provider firewall

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -658,7 +658,14 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 
 	di.MysteriumAPI = mysterium.NewClient(di.HTTPClient, network.MysteriumAPIAddress)
 
-	if di.BrokerConnection, err = di.BrokerConnector.Connect(di.NetworkDefinition.BrokerAddress); err != nil {
+	brokerURL, err := nats.ParseServerURI(di.NetworkDefinition.BrokerAddress)
+	if err != nil {
+		return err
+	}
+	if _, err := di.ServiceFirewall.AllowURLAccess(brokerURL.String()); err != nil {
+		return err
+	}
+	if di.BrokerConnection, err = di.BrokerConnector.Connect(brokerURL.String()); err != nil {
 		return err
 	}
 

--- a/dns/handler_whitelist_test.go
+++ b/dns/handler_whitelist_test.go
@@ -183,6 +183,10 @@ func (tbn *trafficBlockerMock) BlockIncomingTraffic(net.IPNet) (firewall.Incomin
 	return nil, nil
 }
 
+func (tbn *trafficBlockerMock) AllowURLAccess(rawURLs ...string) (firewall.IncomingRuleRemove, error) {
+	return nil, nil
+}
+
 func (tbn *trafficBlockerMock) AllowIPAccess(ip net.IP) (firewall.IncomingRuleRemove, error) {
 	ipString := ip.String()
 	if _, called := tbn.allowIPCalls[ipString]; !called {

--- a/firewall/incoming_firewall_interface.go
+++ b/firewall/incoming_firewall_interface.go
@@ -26,6 +26,7 @@ type IncomingTrafficFirewall interface {
 	Setup() error
 	Teardown()
 	BlockIncomingTraffic(network net.IPNet) (IncomingRuleRemove, error)
+	AllowURLAccess(rawURLs ...string) (IncomingRuleRemove, error)
 	AllowIPAccess(ip net.IP) (IncomingRuleRemove, error)
 }
 

--- a/firewall/incoming_firewall_noop.go
+++ b/firewall/incoming_firewall_noop.go
@@ -47,6 +47,19 @@ func (ifn *incomingFirewallNoop) BlockIncomingTraffic(network net.IPNet) (Incomi
 	}, nil
 }
 
+// AllowIPAccess logs URL for which access was requested.
+func (ifn *incomingFirewallNoop) AllowURLAccess(rawURLs ...string) (IncomingRuleRemove, error) {
+	for _, rawURL := range rawURLs {
+		log.Info().Msgf("Allow URL %s access", rawURL)
+	}
+	return func() error {
+		for _, rawURL := range rawURLs {
+			log.Info().Msgf("Rule for URL: %s removed", rawURL)
+		}
+		return nil
+	}, nil
+}
+
 // AllowIPAccess logs IP for which access was requested.
 func (ifn *incomingFirewallNoop) AllowIPAccess(ip net.IP) (IncomingRuleRemove, error) {
 	log.Info().Msgf("Allow IP %s access", ip)


### PR DESCRIPTION
Updates: #1597

When Consumer is connected to Provider, consumer exits to internet not only with his originated traffic, but his node generates external traffic also (metrics, discovery, etc.), which needs to be whitelisted by default.

```
                                                ---> allow by policies
Consumer packets ---> Provider   ---> firewall                          ---> internet
                                                ---> allow myst domains
```