### PR TITLE
Enable traffic blocking while starting Wireguard service

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -106,7 +106,9 @@ func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options) {
 				di.EventBus,
 				wgOptions,
 				portPool,
-				portMapper)
+				portMapper,
+				di.ServiceFirewall,
+			)
 			return svc, wireguard_service.GetProposal(loc), nil
 		},
 	)

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -140,6 +140,7 @@ func NewInstance(
 	state State,
 	service RunnableService,
 	proposal market.ServiceProposal,
+	policies *policy.Repository,
 	dialog communication.DialogWaiter,
 	discovery Discovery,
 ) *Instance {
@@ -148,6 +149,7 @@ func NewInstance(
 		state:        state,
 		service:      service,
 		proposal:     proposal,
+		policies:     policies,
 		dialogWaiter: dialog,
 		discovery:    discovery,
 	}

--- a/dns/handler_whitelist.go
+++ b/dns/handler_whitelist.go
@@ -18,7 +18,6 @@
 package dns
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -70,8 +69,6 @@ func (wh *whitelistHandler) whitelistByAnswer(response *dns.Msg) error {
 			if err := wh.whitelistByARecord(recordValue); err != nil {
 				return err
 			}
-		default:
-			return fmt.Errorf("unknown record type: %s", dns.Type(record.Header().Rrtype))
 		}
 	}
 	return nil

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -53,7 +53,7 @@ func NewManager(nodeOptions node.Options,
 	portPool port.ServicePortSupplier,
 	bus eventBus,
 	portMapper mapping.PortMapper,
-	trafficBlocker firewall.IncomingTrafficFirewall,
+	trafficFirewall firewall.IncomingTrafficFirewall,
 ) *Manager {
 	clientMap := openvpn_session.NewClientMap(sessionMap)
 
@@ -83,7 +83,7 @@ func NewManager(nodeOptions node.Options,
 		ports:           portPool,
 		eventListener:   bus,
 		portMapper:      portMapper,
-		trafficBlocker:  trafficBlocker,
+		trafficFirewall: trafficFirewall,
 		country:         country,
 		ipResolver:      ipResolver,
 	}

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -73,7 +73,7 @@ type Manager struct {
 	dnsProxy        *dns.Proxy
 	eventListener   eventListener
 	portMapper      mapping.PortMapper
-	trafficBlocker  firewall.IncomingTrafficFirewall
+	trafficFirewall firewall.IncomingTrafficFirewall
 	vpnNetwork      net.IPNet
 	vpnServerPort   int
 	processLauncher *processLauncher
@@ -100,8 +100,8 @@ func (m *Manager) Serve(instance *service.Instance) (err error) {
 	dnsHandler, err := dns.ResolveViaSystem()
 	if err == nil {
 		if instance.Policies().HasDNSRules() {
-			dnsHandler = dns.WhitelistAnswers(dnsHandler, m.trafficBlocker, instance.Policies())
-			removeRule, err := m.trafficBlocker.BlockIncomingTraffic(m.vpnNetwork)
+			dnsHandler = dns.WhitelistAnswers(dnsHandler, m.trafficFirewall, instance.Policies())
+			removeRule, err := m.trafficFirewall.BlockIncomingTraffic(m.vpnNetwork)
 			if err != nil {
 				return errors.Wrap(err, "failed to enable traffic blocking")
 			}

--- a/services/wireguard/endpoint/endpoint.go
+++ b/services/wireguard/endpoint/endpoint.go
@@ -99,11 +99,10 @@ func (ce *connectionEndpoint) StartProviderMode(config wg.ProviderModeConfig) (e
 	if err != nil {
 		return errors.Wrap(err, "could not generate private key")
 	}
-	ce.ipAddr, err = ce.resourceAllocator.AllocateIPNet()
-	if err != nil {
-		return errors.Wrap(err, "could not allocate IP NET")
-	}
+
+	ce.ipAddr = config.Network
 	ce.ipAddr.IP = netutil.FirstIP(ce.ipAddr)
+
 	ce.endpoint = net.UDPAddr{IP: net.ParseIP(config.PublicIP), Port: config.ListenPort}
 
 	deviceConfig := wg.DeviceConfig{
@@ -160,10 +159,6 @@ func (ce *connectionEndpoint) ConfigureRoutes(ip net.IP) error {
 // Stop closes wireguard client and destroys wireguard network interface.
 func (ce *connectionEndpoint) Stop() error {
 	if err := ce.wgClient.Close(); err != nil {
-		return err
-	}
-
-	if err := ce.resourceAllocator.ReleaseIPNet(ce.ipAddr); err != nil {
 		return err
 	}
 

--- a/services/wireguard/service/service_test.go
+++ b/services/wireguard/service/service_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/location"
+	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
@@ -60,9 +61,18 @@ func Test_GetProposal(t *testing.T) {
 
 func Test_Manager_Stop(t *testing.T) {
 	manager := newManagerStub(pubIP, outIP, country)
+	service := service.NewInstance(
+		"",
+		service.Running,
+		nil,
+		market.ServiceProposal{},
+		policy.NewRepository(),
+		nil,
+		nil,
+	)
 
 	go func() {
-		err := manager.Serve(&service.Instance{})
+		err := manager.Serve(service)
 		assert.NoError(t, err)
 	}()
 

--- a/services/wireguard/wireguard.go
+++ b/services/wireguard/wireguard.go
@@ -72,6 +72,7 @@ type ConsumerModeConfig struct {
 
 // ProviderModeConfig is provider endpoint startup configuration.
 type ProviderModeConfig struct {
+	Network    net.IPNet
 	ListenPort int
 	PublicIP   string
 }

--- a/tequilapi/endpoints/service_test.go
+++ b/tequilapi/endpoints/service_test.go
@@ -72,9 +72,9 @@ var (
 		ProviderID:        "0xProviderId",
 		AccessPolicies:    &ap,
 	}
-	mockServiceRunning                 = service.NewInstance(mockServiceOptions, service.Running, nil, mockProposal, nil, nil)
-	mockServiceStopped                 = service.NewInstance(mockServiceOptions, service.NotRunning, nil, mockProposal, nil, nil)
-	mockServiceRunningWithAccessPolicy = service.NewInstance(mockServiceOptions, service.Running, nil, mockProposalWithAccessPolicy, nil, nil)
+	mockServiceRunning                 = service.NewInstance(mockServiceOptions, service.Running, nil, mockProposal, nil, nil, nil)
+	mockServiceStopped                 = service.NewInstance(mockServiceOptions, service.NotRunning, nil, mockProposal, nil, nil, nil)
+	mockServiceRunningWithAccessPolicy = service.NewInstance(mockServiceOptions, service.Running, nil, mockProposalWithAccessPolicy, nil, nil, nil)
 )
 
 type fancyServiceOptions struct {


### PR DESCRIPTION
Closes: #1597

- When provider now start Wireguard service we setup firewall to inspect incoming consumer packets (based on iptables so just for Linux)
- Hostname rules takes places only when services are started with new TrustOracle policies:

```
myst service \\
  --agreed-terms-and-conditions \\
  --access-policy.address=https://testnet-trust.mysterium.network/api/v2/access-policies \
  --access-policy.list=ipinfo \
  openvpn,wireguard
```