### PR TITLE
Bump xgomobile version

### DIFF
--- a/bin/package_android
+++ b/bin/package_android
@@ -29,7 +29,7 @@ docker run --rm \
     -e TARGETS=android/. \
     -e EXT_GOPATH=/ext-go/1 \
     -e GO111MODULE=off \
-    mysteriumnetwork/xgomobile:1.13.6 github.com/mysteriumnetwork/node/mobile/mysterium
+    mysteriumnetwork/xgomobile:1.13.8 github.com/mysteriumnetwork/node/mobile/mysterium
 
 print_success "Android package '$PACKAGE_FILE' complete!"
 exit 0


### PR DESCRIPTION
This image will use new go 1.13.8 with patched go runtime to support monotonic + boot time timers.