### PR TITLE
Fix proposal panic

### DIFF
--- a/core/discovery/brokerdiscovery/repository.go
+++ b/core/discovery/brokerdiscovery/repository.go
@@ -104,6 +104,10 @@ func (r *Repository) Stop() {
 }
 
 func (r *Repository) proposalRegisterMessage(message registerMessage) error {
+	if !message.Proposal.IsSupported() {
+		return nil
+	}
+
 	r.storage.AddProposal(message.Proposal)
 
 	r.watchdogLock.Lock()
@@ -124,6 +128,10 @@ func (r *Repository) proposalUnregisterMessage(message unregisterMessage) error 
 }
 
 func (r *Repository) proposalPingMessage(message pingMessage) error {
+	if !message.Proposal.IsSupported() {
+		return nil
+	}
+
 	r.storage.AddProposal(message.Proposal)
 
 	r.watchdogLock.Lock()

--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -89,7 +89,7 @@ services:
       - ./e2e/blockchain/keystore:/keystore
 
   accountant:
-    image: mysteriumnetwork/accountant:latest
+    image: mysteriumnetwork/accountant:0.0.2
     environment:
       PORT: 8889
     expose:

--- a/docker-compose.e2e-compatibility.yml
+++ b/docker-compose.e2e-compatibility.yml
@@ -89,7 +89,7 @@ services:
       - ./e2e/blockchain/keystore:/keystore
 
   accountant:
-    image: mysteriumnetwork/accountant:latest
+    image: mysteriumnetwork/accountant:0.0.2
     environment:
       PORT: 8889
     expose:

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -178,7 +178,7 @@ services:
         ipv4_address: 172.31.0.203
 
   accountant:
-    image: mysteriumnetwork/accountant:latest
+    image: mysteriumnetwork/accountant:0.0.2
     environment:
       PORT: 8889
     expose:

--- a/docker-compose.localnet.yml
+++ b/docker-compose.localnet.yml
@@ -178,7 +178,7 @@ services:
         ipv4_address: 172.31.0.203
 
   accountant:
-    image: mysteriumnetwork/accountant:latest
+    image: mysteriumnetwork/accountant:0.0.2
     environment:
       PORT: 8889
     expose:

--- a/market/payment_method.go
+++ b/market/payment_method.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/mysteriumnetwork/node/money"
+	"github.com/rs/zerolog/log"
 )
 
 // PaymentMethod is a interface for all types of payment methods
@@ -42,18 +43,24 @@ type PaymentRate struct {
 type UnsupportedPaymentMethod struct {
 }
 
-// GetPrice returns a zero price
+// GetPrice should not be called
 func (UnsupportedPaymentMethod) GetPrice() money.Money {
+	//this should never be called
+	log.Error().Msg("Unsupported proposal GetPrice should not be called")
 	return money.Money{}
 }
 
-// GetType returns unsupported
+// GetType should not be called
 func (UnsupportedPaymentMethod) GetType() string {
+	//this should never be called
+	log.Error().Msg("Unsupported proposal GetType should not be called")
 	return "UNSUPPORTED"
 }
 
-// GetRate returns zero payment rate
+// GetRate should not be called
 func (UnsupportedPaymentMethod) GetRate() PaymentRate {
+	//this should never be called
+	log.Error().Msg("Unsupported proposal GetRate should not be called")
 	return PaymentRate{}
 }
 

--- a/market/service_definition.go
+++ b/market/service_definition.go
@@ -17,7 +17,11 @@
 
 package market
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/rs/zerolog/log"
+)
 
 // ServiceDefinition interface is interface for all service definition types
 type ServiceDefinition interface {
@@ -28,10 +32,11 @@ type ServiceDefinition interface {
 type UnsupportedServiceDefinition struct {
 }
 
-// GetLocation always panics on unsupported service types
+// GetLocation should not be called for unsupported service types
 func (UnsupportedServiceDefinition) GetLocation() Location {
 	//no location available - should never be called
-	panic("not supported")
+	log.Error().Msg("Unsupported proposal GetLocation should not be called")
+	return Location{}
 }
 
 var _ ServiceDefinition = UnsupportedServiceDefinition{}


### PR DESCRIPTION
When proposals was added from broker to storage it was not validated if it's supported. Now adding to storage is no op if proposal is not supported. Also removed some panic and added error logging instead.

Fixes https://github.com/mysteriumnetwork/node/issues/1784