### PR TITLE
Fix backward compatibility with previous NAT hole punching

### DIFF
--- a/mobile/mysterium/openvpn_connection_setup.go
+++ b/mobile/mysterium/openvpn_connection_setup.go
@@ -155,7 +155,7 @@ func (c *openvpnConnection) Start(options connection.ConnectOptions) error {
 
 	// TODO this backward compatibility check needs to be removed once we will start using port ranges for all peers.
 	if sessionConfig.LocalPort > 0 || len(sessionConfig.Ports) > 0 {
-		if len(c.ports) == 0 {
+		if len(sessionConfig.Ports) == 0 || len(c.ports) == 0 {
 			c.ports = []int{sessionConfig.LocalPort}
 			sessionConfig.Ports = []int{sessionConfig.RemotePort}
 		}

--- a/mobile/mysterium/wireguard_connection_setup.go
+++ b/mobile/mysterium/wireguard_connection_setup.go
@@ -127,6 +127,11 @@ func (c *wireguardConnection) Start(options connection.ConnectOptions) (err erro
 
 	// TODO this backward compatibility check needs to be removed once we will start using port ranges for all peers.
 	if config.LocalPort > 0 || len(config.Ports) > 0 {
+		if len(config.Ports) == 0 || len(c.ports) == 0 {
+			c.ports = []int{config.LocalPort}
+			config.Ports = []int{config.RemotePort}
+		}
+
 		ip := config.Provider.Endpoint.IP.String()
 		localPorts := c.ports
 		remotePorts := config.Ports

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -122,6 +122,11 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 
 	// TODO this backward compatibility check needs to be removed once we will start using port ranges for all peers.
 	if config.LocalPort > 0 || len(config.Ports) > 0 {
+		if len(config.Ports) == 0 || len(c.ports) == 0 {
+			c.ports = []int{config.LocalPort}
+			config.Ports = []int{config.RemotePort}
+		}
+
 		ip := config.Provider.Endpoint.IP.String()
 		localPorts := c.ports
 		remotePorts := config.Ports


### PR DESCRIPTION
It was failing with a `number of local and remote ports does not match` for wireguard connections.