### PR TITLE
Expose proposal prices via tequilapi

### DIFF
--- a/ci/util/docker/docker.go
+++ b/ci/util/docker/docker.go
@@ -21,5 +21,5 @@ import "github.com/mysteriumnetwork/go-ci/shell"
 
 // DockerSystemPrune removes dangling docker data: containers stopped, volumes without containers, images without containers
 func DockerSystemPrune() error {
-	return shell.NewCmd("docker system prune -f").Run()
+	return shell.NewCmd("docker system prune --all --volumes -f").Run()
 }

--- a/mocks/mock_payment_method.go
+++ b/mocks/mock_payment_method.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import (
+	"time"
+
+	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/money"
+)
+
+// PaymentMethod is a test-friendly payment method.
+type PaymentMethod struct {
+	Rate        market.PaymentRate
+	PaymentType string
+	Price       money.Money
+}
+
+// GetPrice returns pre-defined price.
+func (mpm *PaymentMethod) GetPrice() money.Money {
+	return mpm.Price
+}
+
+// GetType returns pre-defined type.
+func (mpm *PaymentMethod) GetType() string {
+	return mpm.PaymentType
+}
+
+// GetRate returns pre-defined rate.
+func (mpm *PaymentMethod) GetRate() market.PaymentRate {
+	return mpm.Rate
+}
+
+// DefaultPaymentMethod is a mock default payment method (workaround package import cycles).
+func DefaultPaymentMethod() *PaymentMethod {
+	return &PaymentMethod{
+		Rate: market.PaymentRate{
+			PerTime: time.Minute,
+			PerByte: 7669584,
+		},
+		PaymentType: "BYTES_TRANSFERRED_WITH_TIME",
+		Price:       money.Money{Amount: 50000, Currency: money.CurrencyMyst},
+	}
+}
+
+// DefaultPaymentMethodType is a mock default.
+const DefaultPaymentMethodType = "BYTES_TRANSFERRED_WITH_TIME"

--- a/tequilapi/endpoints/proposals.go
+++ b/tequilapi/endpoints/proposals.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/discovery/proposal"
 	"github.com/mysteriumnetwork/node/core/quality"
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 )
 
@@ -60,6 +61,17 @@ type metricsRes struct {
 	ConnectCount quality.ConnectCount `json:"connectCount"`
 }
 
+type paymentRateRes struct {
+	PerSeconds uint64 `json:"perSeconds"`
+	PerBytes   uint64 `json:"perBytes"`
+}
+
+type paymentMethodRes struct {
+	Type  string         `json:"type"`
+	Price money.Money    `json:"price"`
+	Rate  paymentRateRes `json:"rate"`
+}
+
 // swagger:model ProposalDTO
 type proposalDTO struct {
 	// per provider unique serial number of service description provided
@@ -82,6 +94,9 @@ type proposalDTO struct {
 
 	// AccessPolicies
 	AccessPolicies *[]market.AccessPolicy `json:"accessPolicies,omitempty"`
+
+	// PaymentMethod
+	PaymentMethod paymentMethodRes `json:"paymentMethod"`
 }
 
 func proposalToRes(p market.ServiceProposal) *proposalDTO {
@@ -101,6 +116,14 @@ func proposalToRes(p market.ServiceProposal) *proposalDTO {
 			},
 		},
 		AccessPolicies: p.AccessPolicies,
+		PaymentMethod: paymentMethodRes{
+			Type:  p.PaymentMethod.GetType(),
+			Price: p.PaymentMethod.GetPrice(),
+			Rate: paymentRateRes{
+				PerSeconds: uint64(p.PaymentMethod.GetRate().PerTime.Seconds()),
+				PerBytes:   p.PaymentMethod.GetRate().PerByte,
+			},
+		},
 	}
 }
 

--- a/tequilapi/endpoints/proposals_test.go
+++ b/tequilapi/endpoints/proposals_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/discovery/proposal"
 	"github.com/mysteriumnetwork/node/core/quality"
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,12 +48,16 @@ var serviceProposals = []market.ServiceProposal{
 		ServiceType:       "testprotocol",
 		ServiceDefinition: TestServiceDefinition{},
 		ProviderID:        "0xProviderId",
+		PaymentMethodType: mocks.DefaultPaymentMethodType,
+		PaymentMethod:     mocks.DefaultPaymentMethod(),
 	},
 	{
 		ID:                1,
 		ServiceType:       "testprotocol",
 		ServiceDefinition: TestServiceDefinition{},
 		ProviderID:        "other_provider",
+		PaymentMethodType: mocks.DefaultPaymentMethodType,
+		PaymentMethod:     mocks.DefaultPaymentMethod(),
 	},
 }
 
@@ -92,7 +97,18 @@ func TestProposalsEndpointListByNodeId(t *testing.T) {
                             "country": "Lithuania",
                             "city": "Vilnius"
                         }
-                    }
+                    },
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount": 50000,
+							"currency": "MYST"
+						},
+						"rate": {
+							"perSeconds": 60,
+							"perBytes": 7669584
+						}
+					}
                 }
             ]
         }`,
@@ -149,7 +165,18 @@ func TestProposalsEndpointAcceptsAccessPolicyParams(t *testing.T) {
                             "country": "Lithuania",
                             "city": "Vilnius"
                         }
-                    }
+                    },
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
+						}
+					}
                 }
             ]
         }`,
@@ -195,7 +222,18 @@ func TestProposalsEndpointList(t *testing.T) {
                             "country": "Lithuania",
                             "city": "Vilnius"
                         }
-                    }
+                    },
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
+						}
+					}
                 },
                 {
                     "id": 1,
@@ -207,7 +245,18 @@ func TestProposalsEndpointList(t *testing.T) {
                             "country": "Lithuania",
                             "city": "Vilnius"
                         }
-                    }
+                    },
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
+						}
+					}
                 }
             ]
         }`,
@@ -246,6 +295,17 @@ func TestProposalsEndpointListFetchConnectCounts(t *testing.T) {
 							"city": "Vilnius"
 						}
 					},
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
+						}
+					},
 					"metrics": {
 						"connectCount": {
 							"success": 5,
@@ -263,6 +323,17 @@ func TestProposalsEndpointListFetchConnectCounts(t *testing.T) {
 							"asn": 123,
 							"country": "Lithuania",
 							"city": "Vilnius"
+						}
+					},
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
 						}
 					}
 				}

--- a/tequilapi/endpoints/service_test.go
+++ b/tequilapi/endpoints/service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,6 +46,8 @@ var (
 		ServiceType:       "testprotocol",
 		ServiceDefinition: TestServiceDefinition{},
 		ProviderID:        "0xProviderId",
+		PaymentMethodType: mocks.DefaultPaymentMethodType,
+		PaymentMethod:     mocks.DefaultPaymentMethod(),
 	}
 	ap = []market.AccessPolicy{
 		{
@@ -71,6 +74,8 @@ var (
 		ServiceDefinition: TestServiceDefinition{},
 		ProviderID:        "0xProviderId",
 		AccessPolicies:    &ap,
+		PaymentMethodType: mocks.DefaultPaymentMethodType,
+		PaymentMethod:     mocks.DefaultPaymentMethod(),
 	}
 	mockServiceRunning                 = service.NewInstance(mockServiceOptions, service.Running, nil, mockProposal, nil, nil, nil)
 	mockServiceStopped                 = service.NewInstance(mockServiceOptions, service.NotRunning, nil, mockProposal, nil, nil, nil)
@@ -146,6 +151,17 @@ func Test_AddRoutesForServiceAddsRoutes(t *testing.T) {
 					"serviceType": "testprotocol",
 					"serviceDefinition": {
 						"locationOriginate": {"asn": 123, "country": "Lithuania", "city": "Vilnius"}
+					},
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
+						}
 					}
 				}
 			}]`,
@@ -167,6 +183,17 @@ func Test_AddRoutesForServiceAddsRoutes(t *testing.T) {
 					"serviceType": "testprotocol",
 					"serviceDefinition": {
 						"locationOriginate": {"asn": 123, "country": "Lithuania", "city": "Vilnius"}
+					},
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
+						}
 					}
 				}
 			}`,
@@ -188,6 +215,17 @@ func Test_AddRoutesForServiceAddsRoutes(t *testing.T) {
 					"serviceType": "testprotocol",
 					"serviceDefinition": {
 						"locationOriginate": {"asn": 123, "country": "Lithuania", "city": "Vilnius"}
+					},
+					"paymentMethod": {
+						"type": "BYTES_TRANSFERRED_WITH_TIME",
+						"price": {
+							"amount":50000,
+							"currency":"MYST"
+						},
+						"rate":{
+							"perSeconds":60,
+							"perBytes":7669584
+						}
 					}
 				}
 			}`,
@@ -365,6 +403,17 @@ func Test_ServiceGetReturnsServiceInfo(t *testing.T) {
 						"country": "Lithuania",
 						"city": "Vilnius"
 					}
+				},
+				"paymentMethod": {
+					"type": "BYTES_TRANSFERRED_WITH_TIME",
+					"price": {
+						"amount":50000,
+						"currency":"MYST"
+					},
+					"rate":{
+						"perSeconds":60,
+						"perBytes":7669584
+					}
 				}
 			}
 		}`,
@@ -443,6 +492,17 @@ func Test_ServiceStart_WithAccessPolicy(t *testing.T) {
 				"serviceType": "mockAccessPolicyService",
 				"serviceDefinition": {
 					"locationOriginate": {"asn": 123, "country": "Lithuania", "city": "Vilnius"}
+				},
+				"paymentMethod": {
+					"type": "BYTES_TRANSFERRED_WITH_TIME",
+					"price": {
+						"amount":50000,
+						"currency":"MYST"
+					},
+					"rate":{
+						"perSeconds":60,
+						"perBytes":7669584
+					}
 				},
 				"accessPolicies": [
 					{


### PR DESCRIPTION
Needed for the desktop app to display proposal pricing.

Exposed `PerTime` duration as `PerSeconds` for easier parsing/calculations for the clients.