### PR TITLE
Reconnect wo destroying NATS state

### DIFF
--- a/bin/release_ppa
+++ b/bin/release_ppa
@@ -38,7 +38,7 @@ if ! [ -x "$(command -v vend)" ]; then
     go get github.com/mysteriumnetwork/vend
 fi
 
-vend
+vend -replace github.com/nats-io/go-nats=github.com/mysteriumnetwork/nats.go
 
 DATE=`date -R`
 

--- a/ci/packages/package.go
+++ b/ci/packages/package.go
@@ -250,7 +250,7 @@ func PackageDockerSwaggerRedoc() error {
 // does not support go modules yet and go mod vendor does not include c dependencies.
 func vendordModules() error {
 	mg.Deps(checkVend)
-	return sh.RunV("vend")
+	return sh.RunV("vend", "-replace", "github.com/nats-io/go-nats=github.com/mysteriumnetwork/nats.go")
 }
 
 func checkVend() error {

--- a/communication/nats/connection_interface.go
+++ b/communication/nats/connection_interface.go
@@ -28,7 +28,6 @@ type Connection interface {
 	Open() error
 	Reopen() error
 	Close()
-	Check() error
 	Servers() []string
 	Publish(subject string, payload []byte) error
 	Subscribe(subject string, handler nats.MsgHandler) (*nats.Subscription, error)

--- a/communication/nats/connection_wrap.go
+++ b/communication/nats/connection_wrap.go
@@ -107,14 +107,6 @@ func (c *ConnectionWrap) Close() {
 	c.onClose()
 }
 
-// Check checks the connection.
-func (c *ConnectionWrap) Check() error {
-	// Flush sends ping request and tries to send all cached data.
-	// It return an error if something wrong happened. All other requests
-	// will be added to queue to be sent after reconnecting.
-	return c.Conn.FlushTimeout(3 * time.Second)
-}
-
 // Servers returns list of currently connected servers.
 func (c *ConnectionWrap) Servers() []string {
 	return c.servers

--- a/communication/nats/connection_wrap.go
+++ b/communication/nats/connection_wrap.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	nats_lib "github.com/nats-io/go-nats"
@@ -71,9 +70,7 @@ func newConnection(serverURIs ...string) (*ConnectionWrap, error) {
 
 // ConnectionWrap defines wrapped connection to NATS server(s).
 type ConnectionWrap struct {
-	conn     *nats_lib.Conn
-	connLock sync.RWMutex
-
+	*nats_lib.Conn
 	servers []string
 	onClose func()
 }
@@ -94,10 +91,7 @@ func (c *ConnectionWrap) connectOptions() nats_lib.Options {
 // Open starts the connection: left for test compatibility.
 // Deprecated: Use nats.BrokerConnector#Connect() instead.
 func (c *ConnectionWrap) Open() (err error) {
-	c.connLock.Lock()
-	defer c.connLock.Unlock()
-
-	c.conn, err = c.connectOptions().Connect()
+	c.Conn, err = c.connectOptions().Connect()
 	if err != nil {
 		return errors.Wrapf(err, `failed to connect to NATS servers "%v"`, c.servers)
 	}
@@ -105,30 +99,10 @@ func (c *ConnectionWrap) Open() (err error) {
 	return nil
 }
 
-// Reopen restarts the connection.
-func (c *ConnectionWrap) Reopen() (err error) {
-	c.connLock.Lock()
-	defer c.connLock.Unlock()
-
-	if c.conn != nil {
-		c.conn.Close()
-	}
-
-	c.conn, err = c.connectOptions().Connect()
-	if err != nil {
-		return errors.Wrapf(err, `failed to reconnect to NATS servers "%v"`, c.servers)
-	}
-
-	return nil
-}
-
 // Close destructs the connection.
 func (c *ConnectionWrap) Close() {
-	c.connLock.Lock()
-	defer c.connLock.Unlock()
-
-	if c.conn != nil {
-		c.conn.Close()
+	if c.Conn != nil {
+		c.Conn.Close()
 	}
 	c.onClose()
 }
@@ -138,34 +112,10 @@ func (c *ConnectionWrap) Check() error {
 	// Flush sends ping request and tries to send all cached data.
 	// It return an error if something wrong happened. All other requests
 	// will be added to queue to be sent after reconnecting.
-	return c.conn.FlushTimeout(3 * time.Second)
+	return c.Conn.FlushTimeout(3 * time.Second)
 }
 
 // Servers returns list of currently connected servers.
 func (c *ConnectionWrap) Servers() []string {
 	return c.servers
-}
-
-// Publish publishes payload  to the given subject.
-func (c *ConnectionWrap) Publish(subject string, payload []byte) error {
-	c.connLock.RLock()
-	defer c.connLock.RUnlock()
-
-	return c.conn.Publish(subject, payload)
-}
-
-// Subscribe will express interest in the given subject.
-func (c *ConnectionWrap) Subscribe(subject string, handler nats_lib.MsgHandler) (*nats_lib.Subscription, error) {
-	c.connLock.RLock()
-	defer c.connLock.RUnlock()
-
-	return c.conn.Subscribe(subject, handler)
-}
-
-// Request will send a request payload and deliver the response message.
-func (c *ConnectionWrap) Request(subject string, payload []byte, timeout time.Duration) (*nats_lib.Msg, error) {
-	c.connLock.RLock()
-	defer c.connLock.RUnlock()
-
-	return c.conn.Request(subject, payload, timeout)
 }

--- a/communication/nats/connection_wrap_test.go
+++ b/communication/nats/connection_wrap_test.go
@@ -57,12 +57,12 @@ func TestParseServerURI(t *testing.T) {
 func TestConnectionWrap_NewConnection(t *testing.T) {
 	connection, err := newConnection("nats://127.0.0.1:4222")
 	assert.NoError(t, err)
-	assert.Nil(t, connection.conn)
+	assert.Nil(t, connection.Conn)
 	assert.Equal(t, []string{"nats://127.0.0.1:4222"}, connection.servers)
 
 	connection, err = newConnection("nats://127.0.0.1")
 	assert.NoError(t, err)
-	assert.Nil(t, connection.conn)
+	assert.Nil(t, connection.Conn)
 	assert.Equal(t, []string{"nats://127.0.0.1:4222"}, connection.servers)
 
 	connection, err = newConnection("nats:// example.com")

--- a/communication/nats/connector.go
+++ b/communication/nats/connector.go
@@ -29,14 +29,14 @@ import (
 
 // BrokerConnector establishes new connections to NATS servers and handles reconnects.
 type BrokerConnector struct {
-	registry map[uuid.UUID]*ConnectionWrap
+	registry map[uuid.UUID]Connection
 	mu       sync.Mutex
 }
 
 // NewBrokerConnector creates a new BrokerConnector.
 func NewBrokerConnector() *BrokerConnector {
 	return &BrokerConnector{
-		registry: make(map[uuid.UUID]*ConnectionWrap),
+		registry: make(map[uuid.UUID]Connection),
 	}
 }
 
@@ -86,7 +86,7 @@ func (b *BrokerConnector) ReconnectAll() {
 	var wg sync.WaitGroup
 	for k, v := range b.registry {
 		wg.Add(1)
-		go func(id uuid.UUID, conn *ConnectionWrap) {
+		go func(id uuid.UUID, conn Connection) {
 			defer wg.Done()
 			log.Info().Msgf("Re-establishing broker connection %v", id)
 			if err := conn.Reopen(); err != nil {

--- a/communication/nats/sender.go
+++ b/communication/nats/sender.go
@@ -53,10 +53,6 @@ func (sender *senderNATS) Send(producer communication.MessageProducer) error {
 		return err
 	}
 
-	if err := sender.connection.Check(); err != nil {
-		log.Warn().Err(err).Msg("Connection failed")
-	}
-
 	log.WithLevel(levelFor(messageTopic)).Msgf("Message %q sending: %s", messageTopic, messageData)
 	err = sender.connection.Publish(messageTopic, messageData)
 	if err != nil {
@@ -75,10 +71,6 @@ func (sender *senderNATS) Request(producer communication.RequestProducer) (respo
 	if err != nil {
 		err = errors.Wrapf(err, "failed to pack request '%s'", requestTopic)
 		return
-	}
-
-	if err := sender.connection.Check(); err != nil {
-		log.Warn().Err(err).Msg("Connection failed")
 	}
 
 	log.WithLevel(levelFor(requestTopic)).Msgf("Request %q sending: %s", requestTopic, requestData)

--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,5 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
+
+replace github.com/nats-io/go-nats v1.4.0 => github.com/mysteriumnetwork/nats.go v1.4.1-0.20200303115848-b4a5324c56ed

--- a/go.sum
+++ b/go.sum
@@ -457,12 +457,12 @@ github.com/mysteriumnetwork/go-wondershaper v1.0.1 h1:vHfeQ5siADk7AOlbEBe6FLRu8N
 github.com/mysteriumnetwork/go-wondershaper v1.0.1/go.mod h1:pWWNkO73g3vPSVb+6O+GzjG8lqv4ByNHR6thSG7WmtY=
 github.com/mysteriumnetwork/metrics v0.0.0-20191002053948-084a00d6c6b2 h1:+MzoNo1V8raIWae/+6ivIOubglAqvAc9gTwICDf+ONk=
 github.com/mysteriumnetwork/metrics v0.0.0-20191002053948-084a00d6c6b2/go.mod h1:QI+154TA1KKdrSYAWpr50FP6AzHsbT3wJvFD5kSEQVE=
+github.com/mysteriumnetwork/nats.go v1.4.1-0.20200303115848-b4a5324c56ed h1:x9CzKvMnu+8VH9z8lvB/6ZldbpwlLkFuraU0ycH4j5U=
+github.com/mysteriumnetwork/nats.go v1.4.1-0.20200303115848-b4a5324c56ed/go.mod h1:Mj4ZoTFxQltcDoC/Mn8EgO7SkK1dUJQixLgX04p0cN0=
 github.com/mysteriumnetwork/payments v0.0.11-0.20191120103343-ed922e3051db h1:OfCcf9GtFBAhTmet4yTnuF0ktdFBmPMq+kbgSUEEQHo=
 github.com/mysteriumnetwork/payments v0.0.11-0.20191120103343-ed922e3051db/go.mod h1:khz9e+0ipI8uVAEBhTdSrvo5ByYcdkWtioqkj14Pf7Q=
 github.com/nats-io/gnatsd v1.4.1 h1:RconcfDeWpKCD6QIIwiVFcvForlXpWeJP7i5/lDLy44=
 github.com/nats-io/gnatsd v1.4.1/go.mod h1:nqco77VO78hLCJpIcVfygDP2rPGfsEHkGTUk94uh5DQ=
-github.com/nats-io/go-nats v1.4.0 h1:HorYtzWLSxkmcEzAFmY6vJ20lFfeAPbrnkoAYgk8GSg=
-github.com/nats-io/go-nats v1.4.0/go.mod h1:+t7RHT5ApZebkrQdnn6AhQJmhJJiKAvJUio1PiiCtj0=
 github.com/nats-io/nats-server v1.4.1 h1:Ul1oSOGNV/L8kjr4v6l2f9Yet6WY+LevH1/7cRZ/qyA=
 github.com/nats-io/nats-server v1.4.1/go.mod h1:c8f/fHd2B6Hgms3LtCaI7y6pC4WD1f4SUxcCud5vhBc=
 github.com/nats-io/nuid v1.0.1-0.20180712044959-3024a71c3cbe h1:y454pIlbL4pIBxdGawtiktXu/HEgCfziHt2QfeQ5bkY=


### PR DESCRIPTION
Closes: #1820

Researched stable way to recreate NATS connection to server or cluster, so removing hack with Flush(), which does unnecessarily ping/pong roundtrip to server