### PR TITLE
Revert session tracker to use std time package

### DIFF
--- a/ci/packages/package.go
+++ b/ci/packages/package.go
@@ -111,11 +111,6 @@ func PackageLinuxDebianArm64() error {
 
 // PackageOsxAmd64 builds and stores OSX amd64 package
 func PackageOsxAmd64() error {
-	job.Precondition(func() bool {
-		pr, _ := env.IsPR()
-		fullBuild, _ := env.IsFullBuild()
-		return !pr || fullBuild
-	})
 	logconfig.Bootstrap()
 	if err := packageStandalone("build/myst/myst_darwin_amd64", "darwin", "amd64"); err != nil {
 		return err

--- a/session/mbtime/mbtime_windows.go
+++ b/session/mbtime/mbtime_windows.go
@@ -17,8 +17,13 @@
 
 package mbtime
 
-import "time"
+import (
+	"errors"
+)
 
 func nanotime() (uint64, error) {
-	return uint64(time.Now().UnixNano()), nil
+	// TODO: This is actually incorrect. UnixNano doesn't return monotonic ticks. For Windows we can
+	// TODO: to get nanotime from runtime by using go:linkname nanotime runtime.nanotime but first need
+	// TODO: to fix window compile.
+	return 0, errors.New("not implemented")
 }

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -29,7 +29,6 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/session"
-	"github.com/mysteriumnetwork/node/session/mbtime"
 	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -106,7 +105,7 @@ func InvoiceFactoryCreator(
 		if err != nil {
 			return nil, err
 		}
-		timeTracker := session.NewTracker(mbtime.Now)
+		timeTracker := session.NewTracker(time.Now)
 		deps := InvoiceTrackerDeps{
 			Proposal:                   proposal,
 			Peer:                       dialog.PeerID(),
@@ -164,7 +163,7 @@ func ExchangeFactoryFunc(
 		if err != nil {
 			return nil, err
 		}
-		timeTracker := session.NewTracker(mbtime.Now)
+		timeTracker := session.NewTracker(time.Now)
 		deps := InvoicePayerDeps{
 			InvoiceChan:               invoices,
 			PeerExchangeMessageSender: NewExchangeSender(dialog),

--- a/session/pingpong/invoice_payer_test.go
+++ b/session/pingpong/invoice_payer_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/mysteriumnetwork/node/mocks"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/session"
-	"github.com/mysteriumnetwork/node/session/mbtime"
 	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -66,7 +65,7 @@ func Test_InvoicePayer_Start_Stop(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	totalsStorage := NewConsumerTotalsStorage(bolt)
 	deps := InvoicePayerDeps{
 		InvoiceChan:               invoiceChan,
@@ -117,7 +116,7 @@ func Test_InvoicePayer_SendsMessage(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	totalsStorage := NewConsumerTotalsStorage(bolt)
 	deps := InvoicePayerDeps{
 		InvoiceChan:               invoiceChan,
@@ -191,7 +190,7 @@ func Test_InvoicePayer_SendsMessage_OnFreeService(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	totalsStorage := NewConsumerTotalsStorage(bolt)
 	deps := InvoicePayerDeps{
 		InvoiceChan:               invoiceChan,
@@ -256,7 +255,7 @@ func Test_InvoicePayer_BubblesErrors(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	totalsStorage := NewConsumerTotalsStorage(bolt)
 	deps := InvoicePayerDeps{
 		InvoiceChan:               invoiceChan,

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/mysteriumnetwork/node/mocks"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/session"
-	"github.com/mysteriumnetwork/node/session/mbtime"
 	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -84,7 +83,7 @@ func Test_InvoiceTracker_Start_Stop(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{
@@ -139,7 +138,7 @@ func Test_InvoiceTracker_Start_RefusesUnregisteredUser(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{
@@ -195,7 +194,7 @@ func Test_InvoiceTracker_Start_BubblesRegistrationCheckErrors(t *testing.T) {
 	defer bolt.Close()
 
 	mockError := errors.New("explosions everywhere")
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{
@@ -250,7 +249,7 @@ func Test_InvoiceTracker_Start_RefusesLargeFee(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{
@@ -307,7 +306,7 @@ func Test_InvoiceTracker_Start_BubblesAccountantCheckError(t *testing.T) {
 	defer bolt.Close()
 
 	mockErr := errors.New("explosions everywhere")
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{
@@ -362,7 +361,7 @@ func Test_InvoiceTracker_BubblesErrors(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{
@@ -424,7 +423,7 @@ func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{
@@ -482,7 +481,7 @@ func Test_InvoiceTracker_FreeServiceSendsInvoices(t *testing.T) {
 	assert.Nil(t, err)
 	defer bolt.Close()
 
-	tracker := session.NewTracker(mbtime.Now)
+	tracker := session.NewTracker(time.Now)
 	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
 	accountantPromiseStorage := NewAccountantPromiseStorage(bolt)
 	deps := InvoiceTrackerDeps{

--- a/session/time_tracker.go
+++ b/session/time_tracker.go
@@ -19,20 +19,18 @@ package session
 
 import (
 	"time"
-
-	"github.com/mysteriumnetwork/node/session/mbtime"
 )
 
 // TimeTracker tracks elapsed time from the beginning of the session
 // it's passive (no internal go routines) and simply encapsulates time operation: now - startOfSession expressed as duration
 type TimeTracker struct {
 	started   bool
-	startTime mbtime.Time
-	getTime   func() mbtime.Time
+	startTime time.Time
+	getTime   func() time.Time
 }
 
 // NewTracker initializes TimeTracker with specified monotonically increasing clock function (usually time.Now is enough - but we do DI for test sake)
-func NewTracker(getTime func() mbtime.Time) TimeTracker {
+func NewTracker(getTime func() time.Time) TimeTracker {
 	return TimeTracker{
 		getTime: getTime,
 	}

--- a/session/time_tracker_test.go
+++ b/session/time_tracker_test.go
@@ -21,21 +21,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mysteriumnetwork/node/session/mbtime"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_NotStartedTrackerElapsedReturnsZeroValue(t *testing.T) {
-	tt := NewTracker(func() mbtime.Time { return mbtime.New(10, 10) })
+	tt := NewTracker(func() time.Time { return time.Unix(10, 10) })
 
 	assert.Equal(t, 0*time.Second, tt.Elapsed())
 }
 
 func Test_ElapsedReturnsCorrectValue(t *testing.T) {
 	mockedClock := newMockedTime(
-		[]mbtime.Time{
-			mbtime.New(1, 0),
-			mbtime.New(4, 0),
+		[]time.Time{
+			time.Unix(1, 0),
+			time.Unix(4, 0),
 		},
 	)
 	tt := NewTracker(mockedClock)
@@ -46,10 +45,10 @@ func Test_ElapsedReturnsCorrectValue(t *testing.T) {
 	assert.Equal(t, 3*time.Second, elapsed)
 }
 
-func newMockedTime(timeValues []mbtime.Time) func() mbtime.Time {
+func newMockedTime(timeValues []time.Time) func() time.Time {
 	count := 0
 
-	return func() mbtime.Time {
+	return func() time.Time {
 		val := timeValues[count]
 		count = count + 1
 		return val


### PR DESCRIPTION
Compilation with xgo to build macOS doesn't work because it can't find needed syscall. Need to investigate xgo image. Also added TODO for windows since implementation need to be changed, but after Windows compilation is fixed (separate PR).