### PR TITLE
Send session failure through original device

### DIFF
--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -512,10 +512,11 @@ type mockStatusSender struct {
 	sync.Mutex
 }
 
-func (s *mockStatusSender) Send(dialog communication.Sender, msg *connectivity.StatusMessage) {
+func (s *mockStatusSender) Send(dialog communication.Sender, msg *connectivity.StatusMessage) error {
 	s.Lock()
 	defer s.Unlock()
 	s.sentMsg = msg
+	return nil
 }
 
 func (s *mockStatusSender) getSentMsg() connectivity.StatusMessage {

--- a/session/connectivity/status_sender.go
+++ b/session/connectivity/status_sender.go
@@ -19,12 +19,12 @@ package connectivity
 
 import (
 	"github.com/mysteriumnetwork/node/communication"
-	"github.com/rs/zerolog/log"
+	"github.com/pkg/errors"
 )
 
 // StatusSender is responsible for sending session connectivity status to other peer.
 type StatusSender interface {
-	Send(dialog communication.Sender, msg *StatusMessage)
+	Send(dialog communication.Sender, msg *StatusMessage) error
 }
 
 // NewStatusSender creates StatusSender instance.
@@ -35,11 +35,13 @@ func NewStatusSender() StatusSender {
 type statusSender struct{}
 
 // Send sends status message to other peer via broker.
-func (s *statusSender) Send(dialog communication.Sender, msg *StatusMessage) {
+func (s *statusSender) Send(dialog communication.Sender, msg *StatusMessage) error {
 	producer := &statusProducer{
 		message: msg,
 	}
-	if err := dialog.Send(producer); err != nil {
-		log.Error().Err(err).Msg("Could not send connectivity status")
+	err := dialog.Send(producer)
+	if err != nil {
+		return errors.Wrap(err, "could not send connectivity status")
 	}
+	return nil
 }


### PR DESCRIPTION
After connecting to provider which does not connectivity now sends status to provider gracefully:
```
Message "61849fb7-b7e5-4261-8710-43407cc17184.session-connectivity-status" sending: {"payload":{"sessionID":"4570e1ef-9e1e-4841-93cc-99ee4a26b7da","statusCode":2003,"message":"connection has failed"},"signature":"63hyDXGLfEMqbs8n01ITos19U3T8LmyVaLiyRhu1WIEPcDpG58UXccFsVIkaTk4wFhbgdWPCHDW3aliAMWBRnQE="}
```

```
2020-03-04T17:48:59.944 DBG logconfig/openvpnlog.go:63               > [openvpn-mgmt] Line received: >STATE:1583336939,EXITING,init_instance,,,,,
2020-03-04T17:48:59.944 DBG logconfig/openvpnlog.go:63               > [openvpn-mgmt] Line delivering: >STATE:1583336939,TCP_CONNECT,,,,,,
2020-03-04T17:48:59.944 WRN logconfig/openvpnlog.go:45               > [openvpn-mgmt] Connection failed to read: EOF
2020-03-04T17:48:59.944 DBG logconfig/openvpnlog.go:63               > [openvpn-mgmt] Line delivering: >STATE:1583336939,EXITING,init_instance,,,,,
2020-03-04T17:48:59.944 INF logconfig/openvpnlog.go:54               > [openvpn-mgmt] Event consumer is done
2020-03-04T17:48:59.944 DBG core/connection/manager.go:525           > onStateChanged called020-03-04T17:48:59.945 INF logconfig/openvpnlog.go:54               > [openvpn-proc] Stdout: stream ended
2020-03-04T17:48:59.945 WRN logconfig/openvpnlog.go:45               > [openvpn-mgmt] Middleware stop error: connection is gone
2020-03-04T17:48:59.945 INF logconfig/openvpnlog.go:54               > [openvpn-proc] Stderr: stream ended
2020-03-04T17:48:59.945 INF core/connection/manager.go:201           > Cancelling connection initiation:  error="connection has failed"
2020-03-04T17:48:59.945 WRN logconfig/openvpnlog.go:45               > [openvpn-mgmt] Middleware stop error: write tcp 127.0.0.1:53363->127.0.0.1:53364: write: broken pipe
2020-03-04T17:48:59.945 INF core/connection/manager.go:439           > Connection state: Connecting → Canceled
2020-03-04T17:48:59.945 DBG core/connection/manager.go:525           > onStateChanged called
2020-03-04T17:48:59.946 INF core/connection/manager.go:439           > Connection state: Canceled → Disconnecting
2020-03-04T17:48:59.946 INF firewall/outgoing_firewall_noop.go:42    > Outgoing traffic block removed
2020-03-04T17:48:59.946 ERR logconfig/openvpnlog.go:36               > [openvpn-proc] Error killing cw: os: process already finished
2020-03-04T17:48:59.946 INF logconfig/openvpnlog.go:54               > [openvpn-mgmt] Shutdown
2020-03-04T17:48:59.946 INF logconfig/openvpnlog.go:54               > [openvpn-mgmt] Shutdown finished
2020-03-04T17:48:59.946 INF firewall/outgoing_firewall_noop.go:50    > Rule for IP: 88.119.191.24 removed
2020-03-04T17:48:59.946 DBG session/pingpong/invoice_payer.go:294    > Stopping...
2020-03-04T17:48:59.946 INF core/connection/stats_publisher.go:62    > Stopped publishing statistics for session 4570e1ef-9e1e-4841-93cc-99ee4a26b7da
2020-03-04T17:48:59.947 DBG consumer/statistics/reporter.go:131      > Session statistics reporter stopping
2020-03-04T17:48:59.978 DBG consumer/session/session_storage.go:87   > Session 4570e1ef-9e1e-4841-93cc-99ee4a26b7da updated
2020-03-04T17:48:59.983 INF core/connection/manager.go:439           > Connection state: Disconnecting → NotConnected
2020-03-04T17:48:59.983 DBG core/connection/manager.go:301           > Connection cleaning up (after disconnect): (3/3)
2020-03-04T17:48:59.983 DBG core/location/oracle_resolver.go:41      > Detecting with oracle resolver
2020-03-04T17:48:59.984 DBG communication/nats/sender.go:56          > Message "61849fb7-b7e5-4261-8710-43407cc17184.session-connectivity-status" sending: {"payload":{"sessionID":"4570e1ef-9e1e-4841-93cc-99ee4a26b7da","statusCode":2003,"message":"connection has failed"},"signature":"63hyDXGLfEMqbs8n01ITos19U3T8LmyVaLiyRhu1WIEPcDpG58UXccFsVIkaTk4wFhbgdWPCHDW3aliAMWBRnQE="}
2020-03-04T17:48:59.984 DBG core/connection/manager.go:301           > Connection cleaning up (after disconnect): (2/3)
2020-03-04T17:48:59.985 DBG communication/nats/sender.go:76          > Request "61849fb7-b7e5-4261-8710-43407cc17184.session-destroy" sending: {"payload":{"session_id":"4570e1ef-9e1e-4841-93cc-99ee4a26b7da"},"signature":"um+DjXGq9/ZU07P4JQgzZjhXa5ySaVwfJdLP1Gj0RdNIFHszxatMs/BJy9vqxBgzLgHqvCFhH2EPtK8H6RXyegE="}
2020-03-04T17:49:00.035 DBG communication/nats/receiver.go:54        > Message "61849fb7-b7e5-4261-8710-43407cc17184.session-invoice" received: {"payload":{"invoice":{"AgreementID":9921645526088579994,"AgreementTotal":947,"TransactorFee":0,"Hashlock":"bc6727727077814a5ffb9beaad420dfab4f51d614b7787dbfa090b6392ae23c7","Provider":"0xbb10b94abb290742bd97afba5f4c6f84d89f103b"}},"signature":"mYU/zIukfVerf8s7GVWWMhfxfmBgfE/up8yNPIxdnkU4aT7FdzuoQGRm4OTvjdhGJF79IP8A1IyQohdWmGCTBQE="}
2020-03-04T17:49:00.080 DBG communication/nats/sender.go:83          > Received response for "61849fb7-b7e5-4261-8710-43407cc17184.session-destroy": {"payload":{"success":true,"message":""},"signature":"ygmS4KKEyBnWiS7nR+Smz82CZnDflCF7mqjE2u3bHGtY8qWofxBWAzxijonfIhivv8eG1Ue+XIMAzwn8hAfd5gA="}
2020-03-04T17:49:00.081 DBG core/connection/manager.go:301           > Connection cleaning up (after disconnect): (1/3)
2020-03-04T17:49:00.081 WRN communication/nats/connection_wrap.go:86 > NATS: disconnected
2020-03-04T17:49:00.081 INF communication/nats/connector.go:71       > Removing broker connection from the registry: d19f3384-cb6b-4073-ad39-f9dde098e5b7
2020-03-04T17:49:00.081 WRN communication/nats/connection_wrap.go:85 > NATS: connection closed
2020-03-04T17:49:00.081 INF firewall/outgoing_firewall_noop.go:61    > Rule for URL: nats://testnet-broker.mysterium.network:4222 removed
2020-03-04T17:49:00.081 INF core/connection/manager.go:439           > Connection state: NotConnected → NotConnected
2020-03-04T17:49:00.082 ERR tequilapi/endpoints/connection.go:258    >  error="connection has failed"
2020-03-04T17:49:00.088 INF market/mysterium/mysterium_api.go:306    > Session stats sent: 4570e1ef-9e1e-4841-93cc-99ee4a26b7da
2020-03-04T17:49:00.088 DBG consumer/statistics/reporter.go:101      > Final stats sent
2020-03-04T17:49:00.265 DBG core/location/cache.go:95                > Location update succeeded: {88.119.191.24 8764 Telia Lietuva EU LT Vilnius residential}
```