### PR TITLE
Move logging to trace

### DIFF
--- a/consumer/bandwidth/tracker.go
+++ b/consumer/bandwidth/tracker.go
@@ -87,8 +87,8 @@ func (t *Tracker) ConsumeStatisticsEvent(evt connection.SessionStatsEvent) {
 	}
 	t.previous = evt.Stats
 
-	log.Debug().Msgf("Download speed: %s", t.currentSpeed.Down)
-	log.Debug().Msgf("Upload speed: %s", t.currentSpeed.Up)
+	log.Trace().Msgf("Download speed: %s", t.currentSpeed.Down)
+	log.Trace().Msgf("Upload speed: %s", t.currentSpeed.Up)
 }
 
 // ConsumeSessionEvent handles the session state changes

--- a/consumer/statistics/tracker.go
+++ b/consumer/statistics/tracker.go
@@ -74,7 +74,7 @@ func (sst *SessionStatisticsTracker) markSessionEnd() {
 func (sst *SessionStatisticsTracker) ConsumeStatisticsEvent(e connection.SessionStatsEvent) {
 	sst.sessionStats = sst.sessionStats.Plus(sst.lastStats.Diff(e.Stats))
 	sst.lastStats = e.Stats
-	log.Debug().Msg(sst.sessionStats.String())
+	log.Trace().Msg(sst.sessionStats.String())
 }
 
 // ConsumeSessionEvent handles the session state changes


### PR DESCRIPTION
Move the session stats logging to trace level to reduce the flooding of logs.