### PR TITLE
Override old policy rules

### DIFF
--- a/core/policy/repository.go
+++ b/core/policy/repository.go
@@ -44,7 +44,7 @@ func NewRepository() *Repository {
 	}
 }
 
-// SetPolicyRules set policy ant it's items to repository
+// SetPolicyRules set policy and it's items to repository
 func (r *Repository) SetPolicyRules(policy market.AccessPolicy, policyRules market.AccessPolicyRuleSet) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -182,9 +182,9 @@ func (r *Repository) IsHostAllowed(host string) bool {
 }
 
 func (r *Repository) findItemFor(policy market.AccessPolicy) (*listItem, error) {
-	for _, item := range r.items {
+	for i, item := range r.items {
 		if item.policy == policy {
-			return &item, nil
+			return &r.items[i], nil
 		}
 	}
 	return nil, fmt.Errorf("unknown policy: %s", policy)

--- a/core/policy/repository_test.go
+++ b/core/policy/repository_test.go
@@ -20,6 +20,7 @@ package policy
 import (
 	"testing"
 
+	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/stretchr/testify/assert"
 )
@@ -95,6 +96,33 @@ func Test_Repository_RulesForPolicies(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, []market.AccessPolicyRuleSet{policyOneRules, policyTwoRules}, policiesRules)
+}
+
+func Test_Repository_SetPolicyRules(t *testing.T) {
+	repo := NewRepository()
+	repo.SetPolicyRules(
+		policyOne,
+		market.AccessPolicyRuleSet{
+			ID:    "1",
+			Title: "One",
+			Allow: []market.AccessRule{
+				{Type: market.AccessPolicyTypeIdentity, Value: "0x1"},
+			},
+		},
+	)
+
+	repo.SetPolicyRules(
+		policyOne,
+		market.AccessPolicyRuleSet{
+			ID:    "1",
+			Title: "One",
+			Allow: []market.AccessRule{
+				{Type: market.AccessPolicyTypeIdentity, Value: "0x2"},
+			},
+		},
+	)
+
+	assert.True(t, repo.IsIdentityAllowed(identity.FromAddress("0x2")))
 }
 
 func Test_Repository_Rules(t *testing.T) {


### PR DESCRIPTION
Newly released policy updates where not being activated and were requiring a restart. 

fixes: #1882 