### PR TITLE
Order pinger connections for each peer

### DIFF
--- a/nat/traversal/noop.go
+++ b/nat/traversal/noop.go
@@ -27,6 +27,16 @@ func NewNoopPinger() NATPinger {
 	return &NoopPinger{}
 }
 
+// PingProviderPeer does nothing.
+func (np *NoopPinger) PingProviderPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
+	return []*net.UDPConn{}, nil
+}
+
+// PingConsumerPeer does nothing.
+func (np *NoopPinger) PingConsumerPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
+	return []*net.UDPConn{}, nil
+}
+
 // Valid returns that noop pinger is not a valid pinger
 func (np *NoopPinger) Valid() bool {
 	return false

--- a/nat/traversal/pinger_test.go
+++ b/nat/traversal/pinger_test.go
@@ -40,13 +40,15 @@ func TestPinger_Multiple_Stop(t *testing.T) {
 }
 
 func TestPinger_Provider_Consumer_Ping_Flow(t *testing.T) {
-	providerProxyPort := 51199
-	providerPort := 51200
-	consumerPort := 51201
+	ports, err := port.NewPool().AcquireMultiple(3)
+	assert.NoError(t, err)
+	providerProxyPort := ports[0].Num()
+	providerPort := ports[1].Num()
+	consumerPort := ports[2].Num()
 
 	pingConfig := &PingConfig{
 		Interval: 10 * time.Millisecond,
-		Timeout:  100 * time.Millisecond,
+		Timeout:  1 * time.Second,
 	}
 
 	pinger := newPinger(pingConfig)
@@ -59,9 +61,7 @@ func TestPinger_Provider_Consumer_Ping_Flow(t *testing.T) {
 		addr, _ := net.ResolveUDPAddr("udp4", fmt.Sprintf("127.0.0.1:%d", providerProxyPort))
 		conn, err := net.ListenUDP("udp4", addr)
 		assert.NoError(t, err)
-
 		proxyBuf := make([]byte, 1024)
-
 		for {
 			n, err := conn.Read(proxyBuf)
 			assert.NoError(t, err)
@@ -78,7 +78,7 @@ func TestPinger_Provider_Consumer_Ping_Flow(t *testing.T) {
 	// Wait some time to simulate real network delay conditions.
 	time.Sleep(5 * pingConfig.Interval)
 
-	_, _, err := pinger.PingProvider("127.0.0.1", []int{consumerPort}, []int{providerPort}, consumerPort+1)
+	_, _, err = pinger.PingProvider("127.0.0.1", []int{consumerPort}, []int{providerPort}, consumerPort+1)
 	assert.NoError(t, err)
 
 	laddr, _ := net.ResolveUDPAddr("udp4", fmt.Sprintf("127.0.0.1:%d", consumerPort))
@@ -86,7 +86,6 @@ func TestPinger_Provider_Consumer_Ping_Flow(t *testing.T) {
 
 	conn, err := net.DialUDP("udp4", laddr, raddr)
 	assert.NoError(t, err)
-
 	defer conn.Close()
 
 	assert.Eventually(t, func() bool {
@@ -105,32 +104,45 @@ func TestPinger_Provider_Consumer_Ping_Flow(t *testing.T) {
 func TestPinger_PingPeer_N_Connections(t *testing.T) {
 	pingConfig := &PingConfig{
 		Interval: 10 * time.Millisecond,
-		Timeout:  1000 * time.Millisecond,
+		Timeout:  1 * time.Second,
 	}
-
 	provider := newPinger(pingConfig)
 	consumer := newPinger(pingConfig)
-
 	var pPorts, cPorts []int
 	ports, err := port.NewPool().AcquireMultiple(10)
 	assert.NoError(t, err)
-
 	for i := 0; i < 5; i++ {
 		pPorts = append(pPorts, ports[i].Num())
 		cPorts = append(cPorts, ports[5+i].Num())
 	}
-
-	go consumer.PingPeer("127.0.0.1", cPorts, pPorts, 2, 3)
-	conns, err := provider.PingPeer("127.0.0.1", pPorts, cPorts, 2, 3)
+	peerConns := make(chan *net.UDPConn, 3)
+	go func() {
+		conns, err := consumer.PingProviderPeer("127.0.0.1", cPorts, pPorts, 2, 3)
+		assert.NoError(t, err)
+		assert.Len(t, conns, 3)
+		peerConns <- conns[0]
+		peerConns <- conns[1]
+		peerConns <- conns[2]
+	}()
+	conns, err := provider.PingConsumerPeer("127.0.0.1", pPorts, cPorts, 2, 3)
 	assert.NoError(t, err)
 
 	assert.Len(t, conns, 3)
+	conn1 := conns[0]
+	conn2 := conns[1]
+	conn3 := conns[2]
+	peerConn1 := <-peerConns
+	peerConn2 := <-peerConns
+	peerConn3 := <-peerConns
+	assert.Equal(t, conn1.RemoteAddr().(*net.UDPAddr).Port, peerConn1.LocalAddr().(*net.UDPAddr).Port)
+	assert.Equal(t, conn2.RemoteAddr().(*net.UDPAddr).Port, peerConn2.LocalAddr().(*net.UDPAddr).Port)
+	assert.Equal(t, conn3.RemoteAddr().(*net.UDPAddr).Port, peerConn3.LocalAddr().(*net.UDPAddr).Port)
 }
 
-func TestPinger_PingPeer_Not_Enough_Connections(t *testing.T) {
+func TestPinger_PingPeer_Not_Enough_Connections_Timeout(t *testing.T) {
 	pingConfig := &PingConfig{
 		Interval: 10 * time.Millisecond,
-		Timeout:  1000 * time.Millisecond,
+		Timeout:  300 * time.Millisecond,
 	}
 
 	provider := newPinger(pingConfig)
@@ -145,11 +157,17 @@ func TestPinger_PingPeer_Not_Enough_Connections(t *testing.T) {
 		cPorts = append(cPorts, ports[5+i].Num())
 	}
 
-	go consumer.PingPeer("127.0.0.1", cPorts, pPorts, 2, 30)
-	conns, err := provider.PingPeer("127.0.0.1", pPorts, cPorts, 2, 30)
+	consumerPingErr := make(chan error)
+	go func() {
+		_, err := consumer.PingProviderPeer("127.0.0.1", cPorts, pPorts, 2, 30)
+		consumerPingErr <- err
+	}()
+	conns, err := provider.PingConsumerPeer("127.0.0.1", pPorts, cPorts, 2, 30)
 	assert.EqualError(t, err, "not enough connections")
+	assert.Len(t, conns, 0)
 
-	assert.Len(t, conns, 5)
+	consumerErr := <-consumerPingErr
+	assert.EqualError(t, consumerErr, "NAT punch attempt timed out")
 }
 
 func TestPinger_PingProvider_Timeout(t *testing.T) {
@@ -171,6 +189,31 @@ func TestPinger_PingProvider_Timeout(t *testing.T) {
 	}()
 
 	_, _, err := pinger.PingProvider("127.0.0.1", []int{consumerPort}, []int{providerPort}, 0)
+
+	assert.Error(t, errNATPunchAttemptTimedOut, err)
+}
+
+func TestPinger_PingConsumerPeer_Timeout(t *testing.T) {
+	pinger := newPinger(&PingConfig{
+		Interval: 1 * time.Millisecond,
+		Timeout:  5 * time.Millisecond,
+	})
+	ports, err := port.NewPool().AcquireMultiple(10)
+	assert.NoError(t, err)
+
+	providerPort := ports[0].Num()
+	consumerPort := ports[1].Num()
+
+	go func() {
+		addr, _ := net.ResolveUDPAddr("udp4", fmt.Sprintf("127.0.0.1:%d", providerPort))
+		conn, err := net.ListenUDP("udp4", addr)
+		assert.NoError(t, err)
+		defer conn.Close()
+
+		select {}
+	}()
+
+	_, err = pinger.PingConsumerPeer("127.0.0.1", []int{consumerPort}, []int{providerPort}, 2, 2)
 
 	assert.Error(t, errNATPunchAttemptTimedOut, err)
 }


### PR DESCRIPTION
Currently nat pinger pings peer concurrently and returns **n**  connections from max 10 possible (10 ports currently). The problem is that consumer and provider can select connection orders like **[1,2]** and **[2,3]** etc.  For such cases connections will not match and we can't use them for later communication.

This PR splits PingPeer into PingConsumerPeer and PingProviderPeer and adds logic to notify consumer which connections should be used.