### PR TITLE
Publish identities to SSE state

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -260,9 +260,17 @@ func (di *Dependencies) bootstrapStateKeeper(options node.Options) error {
 		lastStageName = mapping.StageName
 	}
 
-	tracker := nat.NewStatusTracker(lastStageName)
-
-	di.StateKeeper = state.NewKeeper(tracker, di.EventBus, di.ServicesManager, di.ServiceSessionStorage, state.DefaultDebounceDuration, di.StatisticsTracker)
+	deps := state.KeeperDeps{
+		NATStatusProvider:       nat.NewStatusTracker(lastStageName),
+		Publisher:               di.EventBus,
+		ServiceLister:           di.ServicesManager,
+		ServiceSessionStorage:   di.ServiceSessionStorage,
+		SessionDurationProvider: di.StatisticsTracker,
+		IdentityProvider:        di.IdentityManager,
+		IdentityRegistry:        di.IdentityRegistry,
+		BalanceProvider:         di.ConsumerBalanceTracker,
+	}
+	di.StateKeeper = state.NewKeeper(deps, state.DefaultDebounceDuration)
 	return di.StateKeeper.Subscribe(di.EventBus)
 }
 

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/core/port"
 	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/node/market"
@@ -267,7 +268,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options, ser
 	)
 
 	serviceCleaner := service.Cleaner{SessionStorage: di.ServiceSessionStorage}
-	if err := di.EventBus.Subscribe(service.AppTopicServiceStatus, serviceCleaner.HandleServiceStatus); err != nil {
+	if err := di.EventBus.Subscribe(servicestate.AppTopicServiceStatus, serviceCleaner.HandleServiceStatus); err != nil {
 		log.Error().Msg("Failed to subscribe service cleaner")
 	}
 

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -166,7 +166,7 @@ func (d *Discovery) stopLoop() {
 func (d *Discovery) handleRegistrationEvent(rep registry.AppEventIdentityRegistration) {
 	log.Debug().Msgf("Registration event received for %v", rep.ID.Address)
 	if rep.ID.Address != d.ownIdentity.Address {
-		log.Debug().Msgf("Identity missmatch for registration. Expected %v got %v", d.ownIdentity.Address, rep.ID.Address)
+		log.Debug().Msgf("Identity mismatch for registration. Expected %v got %v", d.ownIdentity.Address, rep.ID.Address)
 		return
 	}
 

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -163,7 +163,7 @@ func (d *Discovery) stopLoop() {
 	d.mu.RUnlock()
 }
 
-func (d *Discovery) handleRegistrationEvent(rep registry.RegistrationEventPayload) {
+func (d *Discovery) handleRegistrationEvent(rep registry.AppEventIdentityRegistration) {
 	log.Debug().Msgf("Registration event received for %v", rep.ID.Address)
 	if rep.ID.Address != d.ownIdentity.Address {
 		log.Debug().Msgf("Identity missmatch for registration. Expected %v got %v", d.ownIdentity.Address, rep.ID.Address)
@@ -184,7 +184,7 @@ func (d *Discovery) handleRegistrationEvent(rep registry.RegistrationEventPayloa
 
 func (d *Discovery) registerIdentity() {
 	log.Info().Msg("Waiting for registration success event")
-	d.eventBus.Subscribe(registry.AppTopicRegistration, d.handleRegistrationEvent)
+	d.eventBus.Subscribe(registry.AppTopicIdentityRegistration, d.handleRegistrationEvent)
 	d.changeStatus(WaitingForRegistration)
 }
 

--- a/core/discovery/discovery_test.go
+++ b/core/discovery/discovery_test.go
@@ -69,7 +69,7 @@ func TestStartRegistersIdentitySuccessfully(t *testing.T) {
 	actualStatus := observeStatus(d, WaitingForRegistration)
 	assert.Equal(t, WaitingForRegistration, actualStatus)
 
-	d.eventBus.Publish(identityregistry.AppTopicRegistration, identityregistry.RegistrationEventPayload{
+	d.eventBus.Publish(identityregistry.AppTopicIdentityRegistration, identityregistry.AppEventIdentityRegistration{
 		ID:     providerID,
 		Status: identityregistry.RegisteredProvider,
 	})
@@ -89,7 +89,7 @@ func TestStartRegisterIdentityCancelled(t *testing.T) {
 	actualStatus := observeStatus(d, WaitingForRegistration)
 	assert.Equal(t, WaitingForRegistration, actualStatus)
 
-	d.eventBus.Publish(identityregistry.AppTopicRegistration, identityregistry.RegistrationEventPayload{
+	d.eventBus.Publish(identityregistry.AppTopicIdentityRegistration, identityregistry.AppEventIdentityRegistration{
 		ID:     providerID,
 		Status: identityregistry.RegistrationError,
 	})

--- a/core/service/cleaner.go
+++ b/core/service/cleaner.go
@@ -17,6 +17,8 @@
 
 package service
 
+import "github.com/mysteriumnetwork/node/core/service/servicestate"
+
 // Cleaner cleans up when service is stopped
 type Cleaner struct {
 	SessionStorage SessionStorage
@@ -28,8 +30,8 @@ type SessionStorage interface {
 }
 
 // HandleServiceStatus removes sessions of stopped service
-func (cleaner *Cleaner) HandleServiceStatus(event EventPayload) {
-	if event.Status == string(NotRunning) {
+func (cleaner *Cleaner) HandleServiceStatus(event servicestate.EventPayload) {
+	if event.Status == string(servicestate.NotRunning) {
 		cleaner.SessionStorage.RemoveForService(event.ID)
 	}
 }

--- a/core/service/cleaner.go
+++ b/core/service/cleaner.go
@@ -30,7 +30,7 @@ type SessionStorage interface {
 }
 
 // HandleServiceStatus removes sessions of stopped service
-func (cleaner *Cleaner) HandleServiceStatus(event servicestate.EventPayload) {
+func (cleaner *Cleaner) HandleServiceStatus(event servicestate.AppEventServiceStatus) {
 	if event.Status == string(servicestate.NotRunning) {
 		cleaner.SessionStorage.RemoveForService(event.ID)
 	}

--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/core/policy"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/session"
@@ -141,7 +142,7 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 
 	instance := &Instance{
 		id:             id,
-		state:          Starting,
+		state:          servicestate.Starting,
 		options:        options,
 		service:        service,
 		proposal:       proposal,
@@ -154,7 +155,7 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 	manager.servicePool.Add(instance)
 
 	go func() {
-		instance.setState(Running)
+		instance.setState(servicestate.Running)
 
 		serveErr := service.Serve(instance)
 		if serveErr != nil {

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/mysteriumnetwork/node/core/policy"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/mocks"
@@ -124,12 +125,12 @@ func TestManager_StopSendsEvent_SucceedsAndPublishesEvent(t *testing.T) {
 	eventBus.lock.Lock()
 	defer eventBus.lock.Unlock()
 
-	assert.Equal(t, AppTopicServiceStatus, eventBus.publishedTopic)
+	assert.Equal(t, servicestate.AppTopicServiceStatus, eventBus.publishedTopic)
 
 	var matchFound bool
-	expectedPayload := EventPayload{ID: string(serviceID), ProviderID: "", Type: "", Status: "NotRunning"}
+	expectedPayload := servicestate.EventPayload{ID: string(serviceID), ProviderID: "", Type: "", Status: "NotRunning"}
 	for i := range eventBus.publishedData {
-		e, ok := eventBus.publishedData[i].(EventPayload)
+		e, ok := eventBus.publishedData[i].(servicestate.EventPayload)
 		if !ok {
 			continue
 		}

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -128,9 +128,9 @@ func TestManager_StopSendsEvent_SucceedsAndPublishesEvent(t *testing.T) {
 	assert.Equal(t, servicestate.AppTopicServiceStatus, eventBus.publishedTopic)
 
 	var matchFound bool
-	expectedPayload := servicestate.EventPayload{ID: string(serviceID), ProviderID: "", Type: "", Status: "NotRunning"}
+	expectedPayload := servicestate.AppEventServiceStatus{ID: string(serviceID), ProviderID: "", Type: "", Status: "NotRunning"}
 	for i := range eventBus.publishedData {
-		e, ok := eventBus.publishedData[i].(servicestate.EventPayload)
+		e, ok := eventBus.publishedData[i].(servicestate.AppEventServiceStatus)
 		if !ok {
 			continue
 		}

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -202,8 +202,8 @@ func (i *Instance) setState(newState servicestate.State) {
 }
 
 // toEvent returns an event representation of the instance
-func (i *Instance) toEvent() servicestate.EventPayload {
-	return servicestate.EventPayload{
+func (i *Instance) toEvent() servicestate.AppEventServiceStatus {
+	return servicestate.AppEventServiceStatus{
 		ID:         string(i.id),
 		ProviderID: i.proposal.ProviderID,
 		Type:       i.proposal.ServiceType,

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/core/policy"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/utils"
 	"github.com/pkg/errors"
@@ -103,7 +104,7 @@ func (p *Pool) stop(id ID) error {
 
 	p.del(id)
 
-	instance.setState(NotRunning)
+	instance.setState(servicestate.NotRunning)
 
 	return errStop.Errorf("ErrorCollection(%s)", ", ")
 }
@@ -137,7 +138,7 @@ func (p *Pool) Instance(id ID) *Instance {
 // NewInstance creates new instance of the service.
 func NewInstance(
 	options Options,
-	state State,
+	state servicestate.State,
 	service RunnableService,
 	proposal market.ServiceProposal,
 	policies *policy.Repository,
@@ -158,7 +159,7 @@ func NewInstance(
 // Instance represents a run service
 type Instance struct {
 	id             ID
-	state          State
+	state          servicestate.State
 	options        Options
 	service        RunnableService
 	proposal       market.ServiceProposal
@@ -186,23 +187,23 @@ func (i *Instance) Policies() *policy.Repository {
 }
 
 // State returns the service instance state.
-func (i *Instance) State() State {
+func (i *Instance) State() servicestate.State {
 	i.stateLock.RLock()
 	defer i.stateLock.RUnlock()
 	return i.state
 }
 
-func (i *Instance) setState(newState State) {
+func (i *Instance) setState(newState servicestate.State) {
 	i.stateLock.Lock()
 	defer i.stateLock.Unlock()
 	i.state = newState
 
-	i.eventPublisher.Publish(AppTopicServiceStatus, i.toEvent())
+	i.eventPublisher.Publish(servicestate.AppTopicServiceStatus, i.toEvent())
 }
 
 // toEvent returns an event representation of the instance
-func (i *Instance) toEvent() EventPayload {
-	return EventPayload{
+func (i *Instance) toEvent() servicestate.EventPayload {
+	return servicestate.EventPayload{
 		ID:         string(i.id),
 		ProviderID: i.proposal.ProviderID,
 		Type:       i.proposal.ServiceType,

--- a/core/service/servicestate/status.go
+++ b/core/service/servicestate/status.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package service
+package servicestate
 
 // AppTopicServiceStatus is used in event bus to announce the service status
 const AppTopicServiceStatus = "Service status"

--- a/core/service/servicestate/status.go
+++ b/core/service/servicestate/status.go
@@ -20,8 +20,8 @@ package servicestate
 // AppTopicServiceStatus is used in event bus to announce the service status
 const AppTopicServiceStatus = "Service status"
 
-// EventPayload represents the service event related information
-type EventPayload struct {
+// AppEventServiceStatus represents the service event related information
+type AppEventServiceStatus struct {
 	ID         string `json:"id"`
 	ProviderID string `json:"providerId"`
 	Type       string `json:"type"`

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/mysteriumnetwork/node/core/connection"
+	"github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/node/market"
 )
 
@@ -29,10 +30,18 @@ const AppTopicState = "State change"
 
 // State represents the node state at the current moment. It's a read only object, used only to display data.
 type State struct {
-	NATStatus NATStatus        `json:"natStatus"`
-	Services  []ServiceInfo    `json:"serviceInfo"`
-	Sessions  []ServiceSession `json:"sessions"`
-	Consumer  ConsumerState    `json:"consumer"`
+	NATStatus  NATStatus        `json:"natStatus"`
+	Services   []ServiceInfo    `json:"serviceInfo"`
+	Sessions   []ServiceSession `json:"sessions"`
+	Consumer   ConsumerState    `json:"consumer"`
+	Identities []Identity       `json:"identities"`
+}
+
+// Identity represents identity and its status.
+type Identity struct {
+	Address            string                      `json:"id"`
+	RegistrationStatus registry.RegistrationStatus `json:"registrationStatus,omitempty"`
+	Balance            uint64                      `json:"balance,omitempty"`
 }
 
 // ConsumerState represents consumer state.

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/core/state/event"
 	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
 	"github.com/mysteriumnetwork/node/eventbus"
@@ -149,7 +150,7 @@ func (k *Keeper) fetchIdentities() []stateEvent.Identity {
 
 // Subscribe subscribes to the event bus.
 func (k *Keeper) Subscribe(bus eventbus.Subscriber) error {
-	if err := bus.SubscribeAsync(service.AppTopicServiceStatus, k.consumeServiceStateEvent); err != nil {
+	if err := bus.SubscribeAsync(servicestate.AppTopicServiceStatus, k.consumeServiceStateEvent); err != nil {
 		return err
 	}
 	if err := bus.SubscribeAsync(sevent.AppTopicSession, k.consumeSessionStateEvent); err != nil {

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -347,7 +347,7 @@ func (k *Keeper) updateConnectionStatistics(e interface{}) {
 func (k *Keeper) consumeBalanceChangedEvent(e interface{}) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	evt, ok := e.(pingpong.BalanceChangedEvent)
+	evt, ok := e.(pingpong.AppEventBalanceChanged)
 	if !ok {
 		log.Warn().Msg("Received a wrong kind of event for balance change")
 	}

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -165,6 +165,9 @@ func (k *Keeper) Subscribe(bus eventbus.Subscriber) error {
 	if err := bus.SubscribeAsync(connection.AppTopicConsumerStatistics, k.consumeConnectionStatisticsEvent); err != nil {
 		return err
 	}
+	if err := bus.SubscribeAsync(identity.AppTopicIdentityCreated, k.consumeIdentityCreatedEvent); err != nil {
+		return err
+	}
 	if err := bus.SubscribeAsync(registry.AppTopicIdentityRegistration, k.consumeIdentityRegistrationEvent); err != nil {
 		return err
 	}
@@ -363,6 +366,13 @@ func (k *Keeper) consumeBalanceChangedEvent(e interface{}) {
 		return
 	}
 	id.Balance = evt.Current
+	go k.announceStateChanges(nil)
+}
+
+func (k *Keeper) consumeIdentityCreatedEvent(_ interface{}) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	k.state.Identities = k.fetchIdentities()
 	go k.announceStateChanges(nil)
 }
 

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -295,7 +295,7 @@ func Test_ConsumesServiceEvents(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		// shoot a few events to see if we'll debounce
-		keeper.consumeServiceStateEvent(servicestate.EventPayload{})
+		keeper.consumeServiceStateEvent(servicestate.AppEventServiceStatus{})
 	}
 
 	assert.Eventually(t, interacted(sl, 1), 2*time.Second, 10*time.Millisecond)
@@ -395,7 +395,7 @@ func Test_ConsumesBalanceChangeEvent(t *testing.T) {
 	assert.Zero(t, keeper.GetState().Identities[0].Balance)
 
 	// when
-	eventBus.Publish(pingpong.AppTopicBalanceChanged, pingpong.BalanceChangedEvent{
+	eventBus.Publish(pingpong.AppTopicBalanceChanged, pingpong.AppEventBalanceChanged{
 		Identity: identity.Identity{Address: "0x000000000000000000000000000000000000000a"},
 		Previous: 0,
 		Current:  999,

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/core/state/event"
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/eventbus"
@@ -294,7 +295,7 @@ func Test_ConsumesServiceEvents(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		// shoot a few events to see if we'll debounce
-		keeper.consumeServiceStateEvent(service.EventPayload{})
+		keeper.consumeServiceStateEvent(servicestate.EventPayload{})
 	}
 
 	assert.Eventually(t, interacted(sl, 1), 2*time.Second, 10*time.Millisecond)

--- a/eventbus/event_bus.go
+++ b/eventbus/event_bus.go
@@ -19,6 +19,7 @@ package eventbus
 
 import (
 	asaskevichEventBus "github.com/asaskevich/EventBus"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -56,8 +57,24 @@ func (simplifiedBus simplifiedEventBus) SubscribeAsync(topic string, fn interfac
 	return simplifiedBus.bus.SubscribeAsync(topic, fn, false)
 }
 
+var logLevelsByTopic = map[string]zerolog.Level{
+	"ProposalAdded":   zerolog.Disabled,
+	"ProposalUpdated": zerolog.Disabled,
+	"ProposalRemoved": zerolog.Disabled,
+	"proposalEvent":   zerolog.Disabled,
+	"Statistics":      zerolog.Disabled,
+	"State change":    zerolog.TraceLevel,
+}
+
+func levelFor(topic string) zerolog.Level {
+	if level, exist := logLevelsByTopic[topic]; exist {
+		return level
+	}
+	return zerolog.DebugLevel
+}
+
 func (simplifiedBus simplifiedEventBus) Publish(topic string, data interface{}) {
-	log.Trace().Msgf("Published topic=%q event=%+v", topic, data)
+	log.WithLevel(levelFor(topic)).Msgf("Published topic=%q event=%+v", topic, data)
 	simplifiedBus.bus.Publish(topic, data)
 }
 

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -31,8 +31,11 @@ import (
 	"github.com/mysteriumnetwork/node/eventbus"
 )
 
-// AppTopicIdentityUnlock is the channel name for identity unlock event
-const AppTopicIdentityUnlock = "identity-unlocked"
+// Identity events
+const (
+	AppTopicIdentityUnlock  = "identity-unlocked"
+	AppTopicIdentityCreated = "identity-created"
+)
 
 type identityManager struct {
 	keystoreManager keystore
@@ -80,7 +83,9 @@ func (idm *identityManager) CreateNewIdentity(passphrase string) (identity Ident
 		return identity, err
 	}
 
-	return accountToIdentity(account), nil
+	identity = accountToIdentity(account)
+	idm.eventBus.Publish(AppTopicIdentityCreated, identity.Address)
+	return identity, nil
 }
 
 func (idm *identityManager) GetIdentities() []Identity {

--- a/identity/registry/provider_registrar.go
+++ b/identity/registry/provider_registrar.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/core/node/event"
-	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/pkg/errors"
@@ -52,7 +52,7 @@ type ProviderRegistrar struct {
 }
 
 type queuedEvent struct {
-	event   service.EventPayload
+	event   servicestate.EventPayload
 	retries int
 }
 
@@ -83,7 +83,7 @@ func (pr *ProviderRegistrar) Subscribe(eb eventbus.EventBus) error {
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to node events")
 	}
-	return eb.SubscribeAsync(service.AppTopicServiceStatus, pr.consumeServiceEvent)
+	return eb.SubscribeAsync(servicestate.AppTopicServiceStatus, pr.consumeServiceEvent)
 }
 
 func (pr *ProviderRegistrar) handleNodeStartupEvents(e event.Payload) {
@@ -100,7 +100,7 @@ func (pr *ProviderRegistrar) handleNodeStartupEvents(e event.Payload) {
 	}
 }
 
-func (pr *ProviderRegistrar) consumeServiceEvent(event service.EventPayload) {
+func (pr *ProviderRegistrar) consumeServiceEvent(event servicestate.EventPayload) {
 	pr.queue <- queuedEvent{
 		event:   event,
 		retries: 0,
@@ -108,7 +108,7 @@ func (pr *ProviderRegistrar) consumeServiceEvent(event service.EventPayload) {
 }
 
 func (pr *ProviderRegistrar) needsHandling(qe queuedEvent) bool {
-	if qe.event.Status != string(service.Running) {
+	if qe.event.Status != string(servicestate.Running) {
 		log.Debug().Msgf("Received %q service event, ignoring", qe.event.Status)
 		return false
 	}

--- a/identity/registry/provider_registrar.go
+++ b/identity/registry/provider_registrar.go
@@ -52,7 +52,7 @@ type ProviderRegistrar struct {
 }
 
 type queuedEvent struct {
-	event   servicestate.EventPayload
+	event   servicestate.AppEventServiceStatus
 	retries int
 }
 
@@ -100,7 +100,7 @@ func (pr *ProviderRegistrar) handleNodeStartupEvents(e event.Payload) {
 	}
 }
 
-func (pr *ProviderRegistrar) consumeServiceEvent(event servicestate.EventPayload) {
+func (pr *ProviderRegistrar) consumeServiceEvent(event servicestate.AppEventServiceStatus) {
 	pr.queue <- queuedEvent{
 		event:   event,
 		retries: 0,

--- a/identity/registry/provider_registrar_test.go
+++ b/identity/registry/provider_registrar_test.go
@@ -50,7 +50,7 @@ func Test_Provider_Registrar_needsHandling(t *testing.T) {
 	registrar := NewProviderRegistrar(&mt, &mrsp, cfg)
 
 	mockEvent := queuedEvent{
-		event:   servicestate.EventPayload{},
+		event:   servicestate.AppEventServiceStatus{},
 		retries: 0,
 	}
 
@@ -71,7 +71,7 @@ func Test_Provider_Registrar_RegistersProvider(t *testing.T) {
 	registrar := NewProviderRegistrar(&mt, &mrsp, cfg)
 
 	mockEvent := queuedEvent{
-		event: servicestate.EventPayload{
+		event: servicestate.AppEventServiceStatus{
 			Status:     "Running",
 			ProviderID: "0xsuchIDManyWow",
 		},
@@ -105,7 +105,7 @@ func Test_Provider_Registrar_FailsAfterRetries(t *testing.T) {
 	registrar := NewProviderRegistrar(&mt, &mrsp, cfg)
 
 	mockEvent := queuedEvent{
-		event: servicestate.EventPayload{
+		event: servicestate.AppEventServiceStatus{
 			Status:     "Running",
 			ProviderID: "0xsuchIDManyWow",
 		},

--- a/identity/registry/provider_registrar_test.go
+++ b/identity/registry/provider_registrar_test.go
@@ -20,7 +20,7 @@ package registry
 import (
 	"testing"
 
-	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +50,7 @@ func Test_Provider_Registrar_needsHandling(t *testing.T) {
 	registrar := NewProviderRegistrar(&mt, &mrsp, cfg)
 
 	mockEvent := queuedEvent{
-		event:   service.EventPayload{},
+		event:   servicestate.EventPayload{},
 		retries: 0,
 	}
 
@@ -71,7 +71,7 @@ func Test_Provider_Registrar_RegistersProvider(t *testing.T) {
 	registrar := NewProviderRegistrar(&mt, &mrsp, cfg)
 
 	mockEvent := queuedEvent{
-		event: service.EventPayload{
+		event: servicestate.EventPayload{
 			Status:     "Running",
 			ProviderID: "0xsuchIDManyWow",
 		},
@@ -105,7 +105,7 @@ func Test_Provider_Registrar_FailsAfterRetries(t *testing.T) {
 	registrar := NewProviderRegistrar(&mt, &mrsp, cfg)
 
 	mockEvent := queuedEvent{
-		event: service.EventPayload{
+		event: servicestate.EventPayload{
 			Status:     "Running",
 			ProviderID: "0xsuchIDManyWow",
 		},

--- a/identity/registry/registry_contract.go
+++ b/identity/registry/registry_contract.go
@@ -170,6 +170,10 @@ func (registry *contractRegistry) handleRegistrationEvent(ev IdentityRegistratio
 
 	ID := identity.FromAddress(ev.Identity)
 
+	go registry.publisher.Publish(AppTopicIdentityRegistration, AppEventIdentityRegistration{
+		ID:     ID,
+		Status: s,
+	})
 	err = registry.storage.Store(StoredRegistrationStatus{
 		Identity:           ID,
 		RegistrationStatus: s,

--- a/identity/registry/registry_contract.go
+++ b/identity/registry/registry_contract.go
@@ -199,7 +199,7 @@ func (registry *contractRegistry) subscribeToRegistrationEvent(identity identity
 		sink := make(chan *bindings.RegistryRegisteredIdentity)
 		subscription, err := registry.filterer.WatchRegisteredIdentity(filterOps, sink, userIdentities, accountantIdentities)
 		if err != nil {
-			registry.publisher.Publish(AppTopicRegistration, RegistrationEventPayload{
+			registry.publisher.Publish(AppTopicIdentityRegistration, AppEventIdentityRegistration{
 				ID:     identity,
 				Status: RegistrationError,
 			})
@@ -231,7 +231,7 @@ func (registry *contractRegistry) subscribeToRegistrationEvent(identity identity
 			}
 
 			log.Debug().Msgf("Sending registration success event for %v", identity)
-			registry.publisher.Publish(AppTopicRegistration, RegistrationEventPayload{
+			registry.publisher.Publish(AppTopicIdentityRegistration, AppEventIdentityRegistration{
 				ID:     identity,
 				Status: status,
 			})
@@ -244,7 +244,7 @@ func (registry *contractRegistry) subscribeToRegistrationEvent(identity identity
 				log.Error().Err(err).Msg("Could not store registration status")
 			}
 		case err := <-subscription.Err():
-			registry.publisher.Publish(AppTopicRegistration, RegistrationEventPayload{
+			registry.publisher.Publish(AppTopicIdentityRegistration, AppEventIdentityRegistration{
 				ID:     identity,
 				Status: RegistrationError,
 			})

--- a/identity/registry/status.go
+++ b/identity/registry/status.go
@@ -80,11 +80,11 @@ func (srs StoredRegistrationStatus) FromEvent(status RegistrationStatus, ev Iden
 	}
 }
 
-// AppTopicRegistration represents the registration event topic
-const AppTopicRegistration = "registration_event_topic"
+// AppTopicIdentityRegistration represents the registration event topic.
+const AppTopicIdentityRegistration = "registration_event_topic"
 
-// RegistrationEventPayload represents the registration event payload
-type RegistrationEventPayload struct {
+// AppEventIdentityRegistration represents the registration event payload.
+type AppEventIdentityRegistration struct {
 	ID     identity.Identity
 	Status RegistrationStatus
 }

--- a/mmn/mmn.go
+++ b/mmn/mmn.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/mysteriumnetwork/node/core/connection"
-	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
 
@@ -51,7 +51,7 @@ func (m *MMN) Subscribe(eventBus eventbus.EventBus) error {
 	}
 
 	err = eventBus.SubscribeAsync(
-		service.AppTopicServiceStatus,
+		servicestate.AppTopicServiceStatus,
 		m.handleProvider,
 	)
 	if err != nil {

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -321,7 +321,7 @@ type BalanceChangeCallback interface {
 
 // RegisterBalanceChangeCallback registers callback which is called on identity balance change.
 func (mb *MobileNode) RegisterBalanceChangeCallback(cb BalanceChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(pingpong.AppTopicBalanceChanged, func(e pingpong.BalanceChangedEvent) {
+	_ = mb.eventBus.SubscribeAsync(pingpong.AppTopicBalanceChanged, func(e pingpong.AppEventBalanceChanged) {
 		cb.OnChange(e.Identity.Address, int64(e.Current))
 	})
 }

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -333,7 +333,7 @@ type IdentityRegistrationChangeCallback interface {
 
 // RegisterIdentityRegistrationChangeCallback registers callback which is called on identity registration status change.
 func (mb *MobileNode) RegisterIdentityRegistrationChangeCallback(cb IdentityRegistrationChangeCallback) {
-	_ = mb.eventBus.SubscribeAsync(registry.AppTopicRegistration, func(e registry.RegistrationEventPayload) {
+	_ = mb.eventBus.SubscribeAsync(registry.AppTopicIdentityRegistration, func(e registry.AppEventIdentityRegistration) {
 		cb.OnChange(e.ID.Address, e.Status.String())
 	})
 }

--- a/mocks/mock_consumer_balance_tracker.go
+++ b/mocks/mock_consumer_balance_tracker.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import "github.com/mysteriumnetwork/node/identity"
+
+// BalanceProvider is a fixed balance provider.
+type BalanceProvider struct {
+	Balance uint64
+}
+
+// GetBalance returns a pre-defined balance.
+func (b *BalanceProvider) GetBalance(identity.Identity) uint64 {
+	return b.Balance
+}

--- a/mocks/mock_identity_manager.go
+++ b/mocks/mock_identity_manager.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import (
+	"sync"
+
+	"github.com/mysteriumnetwork/node/identity"
+)
+
+// IdentityProvider is a fake identity provider.
+type IdentityProvider struct {
+	Identities []identity.Identity
+	lock       sync.Mutex
+}
+
+// GetIdentities returns a predefined set of identities.
+func (ip *IdentityProvider) GetIdentities() []identity.Identity {
+	ip.lock.Lock()
+	defer ip.lock.Unlock()
+	return ip.Identities
+}

--- a/mocks/mock_identity_registry.go
+++ b/mocks/mock_identity_registry.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import (
+	"github.com/mysteriumnetwork/node/eventbus"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/identity/registry"
+)
+
+// IdentityRegistry is a fake identity registry.
+type IdentityRegistry struct {
+	Status registry.RegistrationStatus
+}
+
+// Subscribe does nothing.
+func (i IdentityRegistry) Subscribe(_ eventbus.Subscriber) error {
+	return nil
+}
+
+// GetRegistrationStatus returns a pre-defined RegistrationStatus.
+func (i IdentityRegistry) GetRegistrationStatus(identity.Identity) (registry.RegistrationStatus, error) {
+	return i.Status, nil
+}

--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -62,7 +62,7 @@ func NewManager(nodeOptions node.Options,
 	callback := func(sbc bytecount.SessionByteCount) {
 		sessions := clientMap.GetClientSessions(sbc.ClientID)
 		if len(sessions) == 1 {
-			bus.Publish(event.AppTopicDataTransferred, event.DataTransferEventPayload{
+			bus.Publish(event.AppTopicDataTransferred, event.AppEventDataTransferred{
 				ID:   string(sessions[0]),
 				Up:   sbc.BytesOut,
 				Down: sbc.BytesIn,

--- a/services/wireguard/service/service_test.go
+++ b/services/wireguard/service/service_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/nat"
@@ -63,7 +64,7 @@ func Test_Manager_Stop(t *testing.T) {
 	manager := newManagerStub(pubIP, outIP, country)
 	service := service.NewInstance(
 		"",
-		service.Running,
+		servicestate.Running,
 		nil,
 		market.ServiceProposal{},
 		policy.NewRepository(),

--- a/services/wireguard/service/stats_publisher.go
+++ b/services/wireguard/service/stats_publisher.go
@@ -53,7 +53,7 @@ func (s statsPublisher) start(sessionID string, supplier statsSupplier) {
 				log.Warn().Err(err).Msg("Could not get peer statistics")
 				continue
 			}
-			s.bus.Publish(event.AppTopicDataTransferred, event.DataTransferEventPayload{
+			s.bus.Publish(event.AppTopicDataTransferred, event.AppEventDataTransferred{
 				ID:   sessionID,
 				Up:   stats.BytesSent,
 				Down: stats.BytesReceived,

--- a/services/wireguard/service/stats_publisher_test.go
+++ b/services/wireguard/service/stats_publisher_test.go
@@ -49,7 +49,7 @@ func Test_statsPublisher_start(t *testing.T) {
 		if lastEvt == nil {
 			return false
 		}
-		evt, ok := lastEvt.(event.DataTransferEventPayload)
+		evt, ok := lastEvt.(event.AppEventDataTransferred)
 		assert.True(t, ok)
 		return evt.ID == "kappa" && evt.Down == 52 && evt.Up == 25
 	}, 1*time.Second, 5*time.Millisecond)

--- a/session/event/event.go
+++ b/session/event/event.go
@@ -28,8 +28,8 @@ const (
 	AppTopicSessionTokensEarned = "SessionTokensEarned"
 )
 
-// DataTransferEventPayload represents the data transfer event
-type DataTransferEventPayload struct {
+// AppEventDataTransferred represents the data transfer event
+type AppEventDataTransferred struct {
 	ID       string
 	Up, Down uint64
 }

--- a/session/event_based_storage.go
+++ b/session/event_based_storage.go
@@ -66,7 +66,7 @@ func (ebs *EventBasedStorage) GetAll() []Session {
 	return ebs.storage.GetAll()
 }
 
-func (ebs *EventBasedStorage) consumeDataTransferredEvent(e event.DataTransferEventPayload) {
+func (ebs *EventBasedStorage) consumeDataTransferredEvent(e event.AppEventDataTransferred) {
 	// From a server perspective, bytes up are the actual bytes the client downloaded(aka the bytes we pushed to the consumer)
 	// To lessen the confusion, I suggest having the bytes reversed on the session instance.
 	// This way, the session will show that it downloaded the bytes in a manner that is easier to comprehend.

--- a/session/pingpong/accountant_promise_settler.go
+++ b/session/pingpong/accountant_promise_settler.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	nodevent "github.com/mysteriumnetwork/node/core/node/event"
-	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/identity/registry"
@@ -153,7 +153,7 @@ func (aps *AccountantPromiseSettler) Subscribe(sub eventbus.Subscriber) error {
 		return errors.Wrap(err, "could not subscribe to registration event")
 	}
 
-	err = sub.SubscribeAsync(service.AppTopicServiceStatus, aps.handleServiceEvent)
+	err = sub.SubscribeAsync(servicestate.AppTopicServiceStatus, aps.handleServiceEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to service status event")
 	}
@@ -162,9 +162,9 @@ func (aps *AccountantPromiseSettler) Subscribe(sub eventbus.Subscriber) error {
 	return errors.Wrap(err, "could not subscribe to accountant promise event")
 }
 
-func (aps *AccountantPromiseSettler) handleServiceEvent(event service.EventPayload) {
+func (aps *AccountantPromiseSettler) handleServiceEvent(event servicestate.EventPayload) {
 	switch event.Status {
-	case string(service.Running):
+	case string(servicestate.Running):
 		err := aps.loadInitialState(identity.FromAddress(event.ProviderID))
 		// TODO: should we retry? should we signal that we need to cancel and abort?
 		// In any case, if we start exceeding our balances, the accountant will let us know.

--- a/session/pingpong/accountant_promise_settler.go
+++ b/session/pingpong/accountant_promise_settler.go
@@ -162,7 +162,7 @@ func (aps *AccountantPromiseSettler) Subscribe(sub eventbus.Subscriber) error {
 	return errors.Wrap(err, "could not subscribe to accountant promise event")
 }
 
-func (aps *AccountantPromiseSettler) handleServiceEvent(event servicestate.EventPayload) {
+func (aps *AccountantPromiseSettler) handleServiceEvent(event servicestate.AppEventServiceStatus) {
 	switch event.Status {
 	case string(servicestate.Running):
 		err := aps.loadInitialState(identity.FromAddress(event.ProviderID))
@@ -215,7 +215,7 @@ func (aps *AccountantPromiseSettler) handleRegistrationEvent(payload registry.Ap
 	log.Info().Msgf("Identity registration event handled for provider %q", payload.ID)
 }
 
-func (aps *AccountantPromiseSettler) handleAccountantPromiseReceived(apep AccountantPromiseEventPayload) {
+func (aps *AccountantPromiseSettler) handleAccountantPromiseReceived(apep AppEventAccountantPromise) {
 	aps.lock.Lock()
 	defer aps.lock.Unlock()
 

--- a/session/pingpong/accountant_promise_settler.go
+++ b/session/pingpong/accountant_promise_settler.go
@@ -148,7 +148,7 @@ func (aps *AccountantPromiseSettler) Subscribe(sub eventbus.Subscriber) error {
 		return errors.Wrap(err, "could not subscribe to node status event")
 	}
 
-	err = sub.SubscribeAsync(registry.AppTopicRegistration, aps.handleRegistrationEvent)
+	err = sub.SubscribeAsync(registry.AppTopicIdentityRegistration, aps.handleRegistrationEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to registration event")
 	}
@@ -191,7 +191,7 @@ func (aps *AccountantPromiseSettler) handleNodeEvent(payload nodevent.Payload) {
 	}
 }
 
-func (aps *AccountantPromiseSettler) handleRegistrationEvent(payload registry.RegistrationEventPayload) {
+func (aps *AccountantPromiseSettler) handleRegistrationEvent(payload registry.AppEventIdentityRegistration) {
 	aps.lock.Lock()
 	defer aps.lock.Unlock()
 

--- a/session/pingpong/accountant_promise_settler_test.go
+++ b/session/pingpong/accountant_promise_settler_test.go
@@ -246,7 +246,7 @@ func TestPromiseSettler_handleRegistrationEvent(t *testing.T) {
 
 	statusesWithNoChangeExpected := []registry.RegistrationStatus{registry.RegisteredConsumer, registry.Unregistered, registry.InProgress, registry.Promoting, registry.RegistrationError}
 	for _, v := range statusesWithNoChangeExpected {
-		settler.handleRegistrationEvent(registry.RegistrationEventPayload{
+		settler.handleRegistrationEvent(registry.AppEventIdentityRegistration{
 			ID:     mockID,
 			Status: v,
 		})
@@ -256,7 +256,7 @@ func TestPromiseSettler_handleRegistrationEvent(t *testing.T) {
 		assert.False(t, ok)
 	}
 
-	settler.handleRegistrationEvent(registry.RegistrationEventPayload{
+	settler.handleRegistrationEvent(registry.AppEventIdentityRegistration{
 		ID:     mockID,
 		Status: registry.RegisteredProvider,
 	})

--- a/session/pingpong/accountant_promise_settler_test.go
+++ b/session/pingpong/accountant_promise_settler_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/payments/bindings"
@@ -202,10 +202,10 @@ func TestPromiseSettler_handleServiceEvent(t *testing.T) {
 
 	settler := NewAccountantPromiseSettler(&mockTransactor{}, nil, channelStatusProvider, mrsp, ks, mapg, cfg)
 
-	statusesWithNoChangeExpected := []string{string(service.Starting), string(service.NotRunning)}
+	statusesWithNoChangeExpected := []string{string(servicestate.Starting), string(servicestate.NotRunning)}
 
 	for _, v := range statusesWithNoChangeExpected {
-		settler.handleServiceEvent(service.EventPayload{
+		settler.handleServiceEvent(servicestate.EventPayload{
 			ProviderID: mockID.Address,
 			Status:     v,
 		})
@@ -215,9 +215,9 @@ func TestPromiseSettler_handleServiceEvent(t *testing.T) {
 		assert.False(t, ok)
 	}
 
-	settler.handleServiceEvent(service.EventPayload{
+	settler.handleServiceEvent(servicestate.EventPayload{
 		ProviderID: mockID.Address,
-		Status:     string(service.Running),
+		Status:     string(servicestate.Running),
 	})
 
 	_, ok := settler.currentState[mockID]

--- a/session/pingpong/accountant_promise_settler_test.go
+++ b/session/pingpong/accountant_promise_settler_test.go
@@ -205,7 +205,7 @@ func TestPromiseSettler_handleServiceEvent(t *testing.T) {
 	statusesWithNoChangeExpected := []string{string(servicestate.Starting), string(servicestate.NotRunning)}
 
 	for _, v := range statusesWithNoChangeExpected {
-		settler.handleServiceEvent(servicestate.EventPayload{
+		settler.handleServiceEvent(servicestate.AppEventServiceStatus{
 			ProviderID: mockID.Address,
 			Status:     v,
 		})
@@ -215,7 +215,7 @@ func TestPromiseSettler_handleServiceEvent(t *testing.T) {
 		assert.False(t, ok)
 	}
 
-	settler.handleServiceEvent(servicestate.EventPayload{
+	settler.handleServiceEvent(servicestate.AppEventServiceStatus{
 		ProviderID: mockID.Address,
 		Status:     string(servicestate.Running),
 	})
@@ -285,7 +285,7 @@ func TestPromiseSettler_handleAccountantPromiseReceived(t *testing.T) {
 
 	// no receive on unknown provider
 	settler := NewAccountantPromiseSettler(&mockTransactor{}, nil, channelStatusProvider, mrsp, ks, mapg, cfg)
-	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+	settler.handleAccountantPromiseReceived(AppEventAccountantPromise{
 		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
 		ProviderID:   mockID,
 	})
@@ -293,7 +293,7 @@ func TestPromiseSettler_handleAccountantPromiseReceived(t *testing.T) {
 
 	// no receive should be gotten on a non registered provider
 	settler.currentState[mockID] = state{registered: false}
-	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+	settler.handleAccountantPromiseReceived(AppEventAccountantPromise{
 		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
 		ProviderID:   mockID,
 	})
@@ -309,7 +309,7 @@ func TestPromiseSettler_handleAccountantPromiseReceived(t *testing.T) {
 		},
 	}
 
-	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+	settler.handleAccountantPromiseReceived(AppEventAccountantPromise{
 		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
 		ProviderID:   mockID,
 		Promise: crypto.Promise{
@@ -333,7 +333,7 @@ func TestPromiseSettler_handleAccountantPromiseReceived(t *testing.T) {
 		},
 	}
 
-	settler.handleAccountantPromiseReceived(AccountantPromiseEventPayload{
+	settler.handleAccountantPromiseReceived(AppEventAccountantPromise{
 		AccountantID: identity.FromAddress(cfg.AccountantAddress.Hex()),
 		ProviderID:   mockID,
 		Promise: crypto.Promise{

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -104,12 +104,12 @@ func (cbt *ConsumerBalanceTracker) GetBalance(ID identity.Identity) uint64 {
 	return 0
 }
 
-func (cbt *ConsumerBalanceTracker) handleExchangeMessageEvent(event ExchangeMessageEventPayload) {
+func (cbt *ConsumerBalanceTracker) handleExchangeMessageEvent(event AppEventExchangeMessage) {
 	cbt.decreaseBalance(event.Identity, event.AmountPromised)
 }
 
 func (cbt *ConsumerBalanceTracker) publishChangeEvent(id identity.Identity, before, after uint64) {
-	cbt.publisher.Publish(AppTopicBalanceChanged, BalanceChangedEvent{
+	cbt.publisher.Publish(AppTopicBalanceChanged, AppEventBalanceChanged{
 		Identity: id,
 		Previous: before,
 		Current:  after,

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -75,7 +75,7 @@ type Balance struct {
 
 // Subscribe subscribes the consumer balance tracker to relevant events
 func (cbt *ConsumerBalanceTracker) Subscribe(bus eventbus.Subscriber) error {
-	err := bus.SubscribeAsync(registry.AppTopicRegistration, cbt.handleRegistrationEvent)
+	err := bus.SubscribeAsync(registry.AppTopicIdentityRegistration, cbt.handleRegistrationEvent)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (cbt *ConsumerBalanceTracker) handleTopUpEvent(id string) {
 	}
 }
 
-func (cbt *ConsumerBalanceTracker) handleRegistrationEvent(event registry.RegistrationEventPayload) {
+func (cbt *ConsumerBalanceTracker) handleRegistrationEvent(event registry.AppEventIdentityRegistration) {
 	switch event.Status {
 	case registry.RegisteredConsumer, registry.RegisteredProvider:
 		var boff backoff.BackOff

--- a/session/pingpong/consumer_balance_tracker_test.go
+++ b/session/pingpong/consumer_balance_tracker_test.go
@@ -56,11 +56,11 @@ func TestConsumerBalanceTracker(t *testing.T) {
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
 
-	bus.Publish(registry.AppTopicRegistration, registry.RegistrationEventPayload{
+	bus.Publish(registry.AppTopicIdentityRegistration, registry.AppEventIdentityRegistration{
 		ID:     id1,
 		Status: registry.RegisteredProvider,
 	})
-	bus.Publish(registry.AppTopicRegistration, registry.RegistrationEventPayload{
+	bus.Publish(registry.AppTopicIdentityRegistration, registry.AppEventIdentityRegistration{
 		ID:     id2,
 		Status: registry.RegistrationError,
 	})

--- a/session/pingpong/consumer_balance_tracker_test.go
+++ b/session/pingpong/consumer_balance_tracker_test.go
@@ -77,7 +77,7 @@ func TestConsumerBalanceTracker(t *testing.T) {
 	assert.Nil(t, err)
 
 	var promised uint64 = 100
-	bus.Publish(AppTopicExchangeMessage, ExchangeMessageEventPayload{
+	bus.Publish(AppTopicExchangeMessage, AppEventExchangeMessage{
 		Identity:       id1,
 		AmountPromised: promised,
 	})

--- a/session/pingpong/event.go
+++ b/session/pingpong/event.go
@@ -25,8 +25,8 @@ import (
 // AppTopicAccountantPromise represents a topic to which we send accountant promise events.
 const AppTopicAccountantPromise = "accountant_promise_received"
 
-// AccountantPromiseEventPayload represents the payload that is sent on the AppTopicAccountantPromise.
-type AccountantPromiseEventPayload struct {
+// AppEventAccountantPromise represents the payload that is sent on the AppTopicAccountantPromise.
+type AppEventAccountantPromise struct {
 	Promise      crypto.Promise
 	AccountantID identity.Identity
 	ProviderID   identity.Identity
@@ -35,8 +35,8 @@ type AccountantPromiseEventPayload struct {
 // AppTopicExchangeMessage represents a topic where exchange messages are sent.
 const AppTopicExchangeMessage = "exchange_message_topic"
 
-// ExchangeMessageEventPayload represents the messages that are sent on the AppTopicExchangeMessage.
-type ExchangeMessageEventPayload struct {
+// AppEventExchangeMessage represents the messages that are sent on the AppTopicExchangeMessage.
+type AppEventExchangeMessage struct {
 	Identity       identity.Identity
 	AmountPromised uint64
 }
@@ -44,8 +44,8 @@ type ExchangeMessageEventPayload struct {
 // AppTopicBalanceChanged represents the balance change topic
 const AppTopicBalanceChanged = "balance_change"
 
-// BalanceChangedEvent represents a balance change event
-type BalanceChangedEvent struct {
+// AppEventBalanceChanged represents a balance change event
+type AppEventBalanceChanged struct {
 	Identity identity.Identity
 	Previous uint64
 	Current  uint64

--- a/session/pingpong/invoice_payer.go
+++ b/session/pingpong/invoice_payer.go
@@ -297,7 +297,7 @@ func (ip *InvoicePayer) issueExchangeMessage(invoice crypto.Invoice) error {
 		log.Warn().Err(err).Msg("Failed to send exchange message")
 	}
 
-	defer ip.deps.EventBus.Publish(AppTopicExchangeMessage, ExchangeMessageEventPayload{
+	defer ip.deps.EventBus.Publish(AppTopicExchangeMessage, AppEventExchangeMessage{
 		Identity:       ip.deps.Identity,
 		AmountPromised: diff,
 	})

--- a/session/pingpong/invoice_payer_test.go
+++ b/session/pingpong/invoice_payer_test.go
@@ -570,7 +570,7 @@ func TestInvoicePayer_issueExchangeMessage_publishesEvents(t *testing.T) {
 	assert.NoError(t, err)
 	ev := <-mp.publicationChan
 	assert.Equal(t, AppTopicExchangeMessage, ev.name)
-	assert.EqualValues(t, ExchangeMessageEventPayload{
+	assert.EqualValues(t, AppEventExchangeMessage{
 		Identity:       emt.deps.Identity,
 		AmountPromised: 5,
 	}, ev.value)

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -296,7 +296,7 @@ func (it *InvoiceTracker) requestPromise(r []byte, pm crypto.ExchangeMessage) er
 	}
 
 	promise.R = r
-	it.deps.EventBus.Publish(AppTopicAccountantPromise, AccountantPromiseEventPayload{
+	it.deps.EventBus.Publish(AppTopicAccountantPromise, AppEventAccountantPromise{
 		Promise:      promise,
 		AccountantID: it.deps.AccountantID,
 		ProviderID:   it.deps.ProviderID,
@@ -594,7 +594,7 @@ func (it *InvoiceTracker) Stop() {
 	})
 }
 
-func (it *InvoiceTracker) consumeDataTransferredEvent(e event.DataTransferEventPayload) {
+func (it *InvoiceTracker) consumeDataTransferredEvent(e event.AppEventDataTransferred) {
 	// skip irrelevant sessions
 	if !strings.EqualFold(e.ID, it.deps.SessionID) {
 		return

--- a/tequilapi/endpoints/identities.go
+++ b/tequilapi/endpoints/identities.go
@@ -55,13 +55,13 @@ func NewIdentitiesEndpoint(
 	fetchBalance balanceFetcher,
 ) *identitiesAPI {
 	return &identitiesAPI{
-		idm,
-		selector,
-		registry,
-		registryAddress,
-		channelImplementationAddress,
-		getBalance,
-		fetchBalance,
+		idm:                          idm,
+		selector:                     selector,
+		registry:                     registry,
+		registryAddress:              registryAddress,
+		channelImplementationAddress: channelImplementationAddress,
+		getBalance:                   getBalance,
+		fetchBalance:                 fetchBalance,
 	}
 }
 

--- a/tequilapi/endpoints/service_test.go
+++ b/tequilapi/endpoints/service_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/mysteriumnetwork/node/core/service"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/mocks"
@@ -77,9 +78,9 @@ var (
 		PaymentMethodType: mocks.DefaultPaymentMethodType,
 		PaymentMethod:     mocks.DefaultPaymentMethod(),
 	}
-	mockServiceRunning                 = service.NewInstance(mockServiceOptions, service.Running, nil, mockProposal, nil, nil, nil)
-	mockServiceStopped                 = service.NewInstance(mockServiceOptions, service.NotRunning, nil, mockProposal, nil, nil, nil)
-	mockServiceRunningWithAccessPolicy = service.NewInstance(mockServiceOptions, service.Running, nil, mockProposalWithAccessPolicy, nil, nil, nil)
+	mockServiceRunning                 = service.NewInstance(mockServiceOptions, servicestate.Running, nil, mockProposal, nil, nil, nil)
+	mockServiceStopped                 = service.NewInstance(mockServiceOptions, servicestate.NotRunning, nil, mockProposal, nil, nil, nil)
+	mockServiceRunningWithAccessPolicy = service.NewInstance(mockServiceOptions, servicestate.Running, nil, mockProposalWithAccessPolicy, nil, nil, nil)
 )
 
 type fancyServiceOptions struct {


### PR DESCRIPTION
Ref #1844

Identity list is fetched on the initial state construction and then updated on:

- AppTopicIdentityCreated (re-fetches the whole list, to ensure the same order as the identity manager)
- AppTopicIdentityRegistration
- AppTopicBalanceChanged (Which is also triggered by AppTopicIdentityUnlock)
