### PR TITLE
Send traversal event on router IP detection fail

### DIFF
--- a/eventbus/event_bus.go
+++ b/eventbus/event_bus.go
@@ -58,12 +58,14 @@ func (simplifiedBus simplifiedEventBus) SubscribeAsync(topic string, fn interfac
 }
 
 var logLevelsByTopic = map[string]zerolog.Level{
-	"ProposalAdded":   zerolog.Disabled,
-	"ProposalUpdated": zerolog.Disabled,
-	"ProposalRemoved": zerolog.Disabled,
-	"proposalEvent":   zerolog.Disabled,
-	"Statistics":      zerolog.Disabled,
-	"State change":    zerolog.TraceLevel,
+	"ProposalAdded":            zerolog.Disabled,
+	"ProposalUpdated":          zerolog.Disabled,
+	"ProposalRemoved":          zerolog.Disabled,
+	"proposalEvent":            zerolog.Disabled,
+	"Statistics":               zerolog.Disabled,
+	"State change":             zerolog.TraceLevel,
+	"Session data transferred": zerolog.TraceLevel,
+	"Session change":           zerolog.TraceLevel,
 }
 
 func levelFor(topic string) zerolog.Level {

--- a/nat/mapping/port_mapping.go
+++ b/nat/mapping/port_mapping.go
@@ -18,6 +18,7 @@
 package mapping
 
 import (
+	"errors"
 	"net"
 	"time"
 
@@ -69,7 +70,10 @@ type portMapper struct {
 
 func (p *portMapper) Map(protocol string, port int, name string) (release func(), ok bool) {
 	if !p.routerIPPublic() {
-		log.Info().Msg("Router located in the private network. Port mapping is useless, skipping it.")
+		err := errors.New("failed to find router public IP")
+		log.Info().Err(err).Msg("Port mapping is useless, skipping it.")
+		p.notify(err)
+
 		return nil, false
 	}
 


### PR DESCRIPTION
Port mapping was assumed as successful(not failed) if we failed to detect router public IP. 
It was breaking NAT hole punching in docker. 