### PR TITLE
Extract validation phase to a separate component in connection manager

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -514,7 +514,10 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		di.IPResolver,
 		connection.DefaultIPCheckParams(),
 		connection.DefaultStatsReportInterval,
-		di.ConsumerBalanceTracker.GetBalance,
+		connection.NewValidator(
+			di.ConsumerBalanceTracker,
+			di.IdentityManager,
+		),
 		di.P2PDialer,
 	)
 

--- a/core/connection/connection_validator.go
+++ b/core/connection/connection_validator.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connection
+
+import (
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/market"
+)
+
+type consumerBalanceGetter interface {
+	GetBalance(ID identity.Identity) uint64
+}
+
+type unlockChecker interface {
+	IsUnlocked(ID string) bool
+}
+
+// Validator validates pre connection conditions.
+type Validator struct {
+	consumerBalanceGetter consumerBalanceGetter
+	unlockChecker         unlockChecker
+}
+
+// NewValidator returns a new instance of connection validator.
+func NewValidator(consumerBalanceGetter consumerBalanceGetter, unlockChecker unlockChecker) *Validator {
+	return &Validator{
+		consumerBalanceGetter: consumerBalanceGetter,
+		unlockChecker:         unlockChecker,
+	}
+}
+
+// validateBalance checks if consumer has enough money for given proposal.
+func (v *Validator) validateBalance(consumerID identity.Identity, proposal market.ServiceProposal) bool {
+	if proposal.PaymentMethodType == "" || proposal.PaymentMethod == nil {
+		return true
+	}
+
+	proposalPrice := proposal.PaymentMethod.GetPrice()
+	balance := v.consumerBalanceGetter.GetBalance(consumerID)
+	return balance >= proposalPrice.Amount
+}
+
+// isUnlocked checks if the identity is unlocked or not.
+func (v *Validator) isUnlocked(consumerID identity.Identity) bool {
+	return v.unlockChecker.IsUnlocked(consumerID.Address)
+}
+
+// Validate checks whether the pre-connection conditions are fulfilled.
+func (v *Validator) Validate(consumerID identity.Identity, proposal market.ServiceProposal) error {
+	if !v.isUnlocked(consumerID) {
+		return ErrUnlockRequired
+	}
+
+	if !v.validateBalance(consumerID, proposal) {
+		return ErrInsufficientBalance
+	}
+
+	return nil
+}

--- a/core/connection/connection_validator_test.go
+++ b/core/connection/connection_validator_test.go
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/money"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidator_Validate(t *testing.T) {
+	type fields struct {
+		consumerBalanceGetter consumerBalanceGetter
+		unlockChecker         unlockChecker
+	}
+	type args struct {
+		consumerID identity.Identity
+		proposal   market.ServiceProposal
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr error
+	}{
+		{
+			name:    "returns insufficient balance",
+			wantErr: ErrInsufficientBalance,
+			fields: fields{
+				unlockChecker: &mockUnlockChecker{
+					toReturn: true,
+				},
+				consumerBalanceGetter: &mockConsumerBalanceGetter{
+					toReturn: 99,
+				},
+			},
+			args: args{
+				consumerID: identity.FromAddress("whatever"),
+				proposal: market.ServiceProposal{
+					ProviderID:        activeProviderID.Address,
+					ProviderContacts:  []market.Contact{activeProviderContact},
+					ServiceType:       activeServiceType,
+					ServiceDefinition: &fakeServiceDefinition{},
+					PaymentMethod: &mockPaymentMethod{price: money.Money{
+						Amount:   100,
+						Currency: "MYSTT",
+					}},
+					PaymentMethodType: "PER_MINUTE",
+				},
+			},
+		},
+		{
+			name:    "returns unlock required",
+			wantErr: ErrUnlockRequired,
+			fields: fields{
+				unlockChecker: &mockUnlockChecker{
+					toReturn: false,
+				},
+			},
+			args: args{
+				consumerID: identity.FromAddress("whatever"),
+			},
+		},
+		{
+			name:    "returns no error if conditions are satisfied",
+			wantErr: nil,
+			fields: fields{
+				unlockChecker: &mockUnlockChecker{
+					toReturn: true,
+				},
+				consumerBalanceGetter: &mockConsumerBalanceGetter{
+					toReturn: 101,
+				},
+			},
+			args: args{
+				consumerID: identity.FromAddress("whatever"),
+				proposal: market.ServiceProposal{
+					ProviderID:        activeProviderID.Address,
+					ProviderContacts:  []market.Contact{activeProviderContact},
+					ServiceType:       activeServiceType,
+					ServiceDefinition: &fakeServiceDefinition{},
+					PaymentMethod: &mockPaymentMethod{price: money.Money{
+						Amount:   100,
+						Currency: "MYSTT",
+					}},
+					PaymentMethodType: "PER_MINUTE",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Validator{
+				consumerBalanceGetter: tt.fields.consumerBalanceGetter,
+				unlockChecker:         tt.fields.unlockChecker,
+			}
+			err := v.Validate(tt.args.consumerID, tt.args.proposal)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error(), tt.name)
+			} else {
+				assert.NoError(t, err, tt.name)
+			}
+		})
+	}
+}
+
+type mockUnlockChecker struct {
+	toReturn bool
+}
+
+func (muc *mockUnlockChecker) IsUnlocked(id string) bool {
+	return muc.toReturn
+}
+
+type mockConsumerBalanceGetter struct {
+	toReturn uint64
+}
+
+func (mcbg *mockConsumerBalanceGetter) GetBalance(id identity.Identity) uint64 {
+	return mcbg.toReturn
+}

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -62,6 +62,14 @@ func NewIdentityManager(keystore keystore, eventBus eventbus.EventBus) *identity
 	}
 }
 
+// IsUnlocked checks if the given identity is unlocked or not
+func (idm *identityManager) IsUnlocked(identity string) bool {
+	idm.unlockedMu.Lock()
+	defer idm.unlockedMu.Unlock()
+	_, ok := idm.unlocked[identity]
+	return ok
+}
+
 func accountToIdentity(account accounts.Account) Identity {
 	identity := FromAddress(account.Address.Hex())
 	return identity

--- a/identity/manager_fake.go
+++ b/identity/manager_fake.go
@@ -25,12 +25,17 @@ type idmFake struct {
 	existingIdentities   []Identity
 	newIdentity          Identity
 	unlockFails          bool
+	isUnlocked           bool
 }
 
 // NewIdentityManagerFake creates fake identity manager for testing purposes
 // TODO each caller should use it's own mocked manager part instead of global one
 func NewIdentityManagerFake(existingIdentities []Identity, newIdentity Identity) *idmFake {
-	return &idmFake{"", "", existingIdentities, newIdentity, false}
+	return &idmFake{"", "", existingIdentities, newIdentity, false, true}
+}
+
+func (fakeIdm *idmFake) IsUnlocked(id string) bool {
+	return fakeIdm.isUnlocked
 }
 
 func (fakeIdm *idmFake) MarkUnlockToFail() {

--- a/identity/manager_interface.go
+++ b/identity/manager_interface.go
@@ -25,4 +25,5 @@ type Manager interface {
 	GetIdentity(address string) (Identity, error)
 	HasIdentity(address string) bool
 	Unlock(address string, passphrase string) error
+	IsUnlocked(address string) bool
 }


### PR DESCRIPTION
Connection manager now has a separate component responsible for pre-flight checks.

Fixes #1945