### PR TITLE
Use noop promise settle for mobile

### DIFF
--- a/cmd/di_mobile.go
+++ b/cmd/di_mobile.go
@@ -22,6 +22,7 @@ package cmd
 import (
 	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/node"
+	pingpong_noop "github.com/mysteriumnetwork/node/session/pingpong/noop"
 	"github.com/mysteriumnetwork/node/ui/noop"
 )
 
@@ -47,5 +48,5 @@ func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) err
 }
 
 func (di *Dependencies) bootstrapAccountantPromiseSettler(nodeOptions node.Options) error {
-	return nil
+	return pingpong_noop.NoopAccountantPromiseSettler{}
 }

--- a/session/pingpong/noop/accountant_promise_settler.go
+++ b/session/pingpong/noop/accountant_promise_settler.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package noop
+
+import (
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/session/pingpong"
+	"github.com/mysteriumnetwork/payments/client"
+	"github.com/mysteriumnetwork/payments/crypto"
+)
+
+// NoopAccountantPromiseSettler doesn't do much.
+type NoopAccountantPromiseSettler struct {
+}
+
+// SettlementState returns an empty state.
+func (n *NoopAccountantPromiseSettler) SettlementState(id identity.Identity) pingpong.SettlementState {
+	return pingpong.SettlementState{
+		Channel:     client.ProviderChannel{},
+		LastPromise: crypto.Promise{},
+	}
+}
+
+// ForceSettle does nothing.
+func (n *NoopAccountantPromiseSettler) ForceSettle(_, _ identity.Identity) error {
+	return nil
+}


### PR DESCRIPTION
To avoid state keeper crash on nil settler.
Accountant promise settler is only for provider.
This noop should return zeros in SettlementState that is needed for state to fill in the Earnings.

Fixes: #1952 

cc @anjmao 