### PR TITLE
Ping via localhost when both consumer and provider uses the same IP

### DIFF
--- a/ci/test/test.go
+++ b/ci/test/test.go
@@ -29,7 +29,7 @@ func TestWithCoverage() error {
 	if err != nil {
 		return err
 	}
-	args := append([]string{"test", "-v", "-race", "-timeout", "5m", "-cover", "-coverprofile", "coverage.txt", "-covermode", "atomic"}, packages...)
+	args := append([]string{"test", "-race", "-timeout", "5m", "-cover", "-coverprofile", "coverage.txt", "-covermode", "atomic"}, packages...)
 	return sh.RunV("go", args...)
 }
 

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -77,8 +77,8 @@ func (m *dialer) Dial(consumerID, providerID identity.Identity, serviceType stri
 		localPort = config.localPorts[0]
 		remotePort = config.peerPorts[0]
 	} else {
-		log.Debug().Msgf("Pinging provider %s with public IP %s using ports %v:%v", providerID.Address, config.peerPublicIP, config.localPorts, config.peerPorts)
-		conns, err := m.consumerPinger.PingProviderPeer(config.peerPublicIP, config.localPorts, config.peerPorts, consumerInitialTTL, requiredConnAmount)
+		log.Debug().Msgf("Pinging provider %s with IP %s using ports %v:%v", providerID.Address, config.pingIP(), config.localPorts, config.peerPorts)
+		conns, err := m.consumerPinger.PingProviderPeer(config.pingIP(), config.localPorts, config.peerPorts, consumerInitialTTL, requiredConnAmount)
 		if err != nil {
 			return nil, fmt.Errorf("could not ping peer: %w", err)
 		}
@@ -175,6 +175,7 @@ func (m *dialer) exchangeConfig(consumerID, providerID identity.Identity, servic
 	}
 
 	return &p2pConnectConfig{
+		publicIP:     publicIP,
 		privateKey:   privateKey,
 		localPorts:   localPorts,
 		peerPubKey:   peerPubKey,


### PR DESCRIPTION
Mostly this is needed when using noop service and running both provider and consumer locally.