### PR TITLE
Fix mbtime overflow on 32 bit systems

### DIFF
--- a/session/mbtime/mbtime_darwin.go
+++ b/session/mbtime/mbtime_darwin.go
@@ -30,5 +30,8 @@ func nanotime() (uint64, error) {
 			}
 		}
 	}
-	return uint64(ts.Sec*1e9 + ts.Nsec), nil
+	// explicit cast prevents overflow on 32 bit systems
+	castedSec := uint64(ts.Sec)
+	castedNsec := uint64(ts.Nsec)
+	return castedSec*1e9 + castedNsec, nil
 }

--- a/session/mbtime/mbtime_linux.go
+++ b/session/mbtime/mbtime_linux.go
@@ -17,7 +17,9 @@
 
 package mbtime
 
-import "golang.org/x/sys/unix"
+import (
+	"golang.org/x/sys/unix"
+)
 
 func nanotime() (uint64, error) {
 	var ts unix.Timespec
@@ -28,5 +30,9 @@ func nanotime() (uint64, error) {
 			}
 		}
 	}
-	return uint64(ts.Sec*1e9 + ts.Nsec), nil
+
+	// explicit cast prevents overflow on 32 bit systems
+	castedSec := uint64(ts.Sec)
+	castedNsec := uint64(ts.Nsec)
+	return castedSec*1e9 + castedNsec, nil
 }


### PR DESCRIPTION
The calculations would overflow on 32 bit systems, due to the way CGO works.

Explicit cast to a uint64 before making calculations forces each variable to be casted to 64bits.

Fixes #1942


BEFORE:
```
{"level":"info","time":"2020-04-01T10:08:37+03:00","message":"Getting nanotime"}
{"level":"info","time":"2020-04-01T10:08:37+03:00","message":"nanotimeRes ts.Sec*1e9=-1269021696, ts.Nsec=%!(EXTRA int32=335610159)"}
now  -933.411537ms
{"level":"info","time":"2020-04-01T10:08:37+03:00","message":"Getting nanotime"}
{"level":"info","time":"2020-04-01T10:08:37+03:00","message":"nanotimeRes ts.Sec*1e9=-1269021696, ts.Nsec=%!(EXTRA int32=335810053)"}
later  -933.211643ms
{"level":"info","time":"2020-04-01T10:08:37+03:00","message":"Subbing: u.ns -933.411537ms"}
{"level":"info","time":"2020-04-01T10:08:37+03:00","message":"Subbing: t.s -933.211643ms"}
{"level":"info","time":"2020-04-01T10:08:37+03:00","message":"Subbing: d 199.894µs"}
sub1  199.894µs
```

AFTER:
```
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"Getting nanotime"}
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"ts.Sec 1990319 ts.Nsec 894832190"}
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"nanotimeRes ts.Sec*1e9=1090262528, ts.Nsec=%!(EXTRA int32=894832190)"}
now  552h51m59.89483219s
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"Getting nanotime"}
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"ts.Sec 1990319 ts.Nsec 895114689"}
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"nanotimeRes ts.Sec*1e9=1090262528, ts.Nsec=%!(EXTRA int32=895114689)"}
later  552h51m59.895114689s
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"Subbing: u.ns 552h51m59.89483219s"}
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"Subbing: t.s 552h51m59.895114689s"}
{"level":"info","time":"2020-04-01T10:18:02+03:00","message":"Subbing: d 282.499µs"}
sub1  282.499µs
```