### PR TITLE
Proxy consumer OpenVPN for mobile

### DIFF
--- a/nat/traversal/nat_proxy.go
+++ b/nat/traversal/nat_proxy.go
@@ -35,13 +35,13 @@ type natProxy struct {
 }
 
 // NewNATProxy constructs an instance of natProxy
-func newNATProxy() *natProxy {
+func NewNATProxy() *natProxy {
 	return &natProxy{
 		servicePorts: make(map[string]int),
 	}
 }
 
-func (np *natProxy) consumerHandOff(consumerAddr string, remoteConn *net.UDPConn) chan struct{} {
+func (np *natProxy) ConsumerHandOff(consumerAddr string, remoteConn *net.UDPConn) chan struct{} {
 	stop := make(chan struct{})
 	if np.socketProtect == nil {
 		// shutdown pinger session since openvpn client will connect directly (without natProxy)
@@ -204,6 +204,6 @@ func (np *natProxy) isAvailable(key string) bool {
 	return np.servicePorts[key] > 0
 }
 
-func (np *natProxy) setProtectSocketCallback(socketProtect func(socket int) bool) {
+func (np *natProxy) SetProtectSocketCallback(socketProtect func(socket int) bool) {
 	np.socketProtect = socketProtect
 }

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -100,7 +100,7 @@ func NewPinger(pingConfig *PingConfig, publisher eventbus.Publisher) NATPinger {
 		pingConfig:     pingConfig,
 		stop:           make(chan struct{}),
 		stopNATProxy:   make(chan struct{}),
-		natProxy:       newNATProxy(),
+		natProxy:       NewNATProxy(),
 		eventPublisher: publisher,
 	}
 }
@@ -141,7 +141,7 @@ func (p *Pinger) PingProvider(ip string, localPorts, remotePorts []int, proxyPor
 		consumerAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
 		log.Info().Msg("Handing connection to consumer NATProxy: " + consumerAddr)
 
-		p.stopNATProxy = p.natProxy.consumerHandOff(consumerAddr, conn)
+		p.stopNATProxy = p.natProxy.ConsumerHandOff(consumerAddr, conn)
 	} else {
 		conn.Close()
 	}
@@ -434,7 +434,7 @@ func (p *Pinger) pingReceiver(conn *net.UDPConn, stop <-chan struct{}) (*net.UDP
 
 // SetProtectSocketCallback sets socket protection callback to be called when new socket is created in consumer NATProxy
 func (p *Pinger) SetProtectSocketCallback(socketProtect func(socket int) bool) {
-	p.natProxy.setProtectSocketCallback(socketProtect)
+	p.natProxy.SetProtectSocketCallback(socketProtect)
 }
 
 // Valid returns that this pinger is a valid pinger

--- a/services/openvpn/client_config.go
+++ b/services/openvpn/client_config.go
@@ -100,11 +100,11 @@ func NewClientConfigFromSession(vpnConfig VPNConfig, configDir string, runtimeDi
 	}
 
 	var remotePort, localPort int
-	if options.ProviderNATConn != nil {
+	if options.ProviderNATConn != nil && vpnConfig.RemoteIP != "127.0.0.1" {
 		options.ProviderNATConn.Close()
 		remotePort = options.ProviderNATConn.RemoteAddr().(*net.UDPAddr).Port
 		localPort = options.ProviderNATConn.LocalAddr().(*net.UDPAddr).Port
-	} else { // TODO this block needs to be removed once most of the nodes will be using p2p communication.
+	} else {
 		remotePort = vpnConfig.RemotePort
 		localPort = vpnConfig.LocalPort
 	}

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -121,7 +121,6 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 	c.stateCh <- connection.Connecting
 
 	if options.ProviderNATConn != nil {
-
 		options.ProviderNATConn.Close()
 		config.LocalPort = options.ProviderNATConn.LocalAddr().(*net.UDPAddr).Port
 		config.Provider.Endpoint.Port = options.ProviderNATConn.RemoteAddr().(*net.UDPAddr).Port


### PR DESCRIPTION
Mobile OpenVPN requires to start proxy to be able to use the existing connections.