### PR TITLE
Check for no previous promise when revealing R

### DIFF
--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -551,6 +551,9 @@ func (it *InvoiceTracker) handleAccountantError(err error) error {
 			return errors.New("could not cast errNeedsRecovery to accountantError")
 		}
 		return it.recoverR(aer)
+	case stdErr.Is(err, ErrAccountantNoPreviousPromise):
+		log.Info().Msg("no previous promise on accountant, will mark R as revealed")
+		return nil
 	case stdErr.Is(err, ErrAccountantHashlockMissmatch), stdErr.Is(err, ErrAccountantPreviousRNotRevealed):
 		// These should basicly be obsolete with the introduction of R recovery. Will remove in the future.
 		// For now though, handle as ignorable.
@@ -558,7 +561,6 @@ func (it *InvoiceTracker) handleAccountantError(err error) error {
 	case
 		stdErr.Is(err, ErrAccountantInternal),
 		stdErr.Is(err, ErrAccountantNotFound),
-		stdErr.Is(err, ErrAccountantNoPreviousPromise),
 		stdErr.Is(err, ErrAccountantMalformedJSON):
 		// these are ignorable, we'll eventually fail
 		if it.incrementAccountantFailureCount() > it.deps.MaxAccountantFailureCount {


### PR DESCRIPTION
Will now check for appropriate error and mark R as revealed if needed.

Fixes #1976