### PR TITLE
Add p2p send timeouts using context

### DIFF
--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -583,7 +583,7 @@ func (m *mockP2PChannel) getSentMsg() connectivity.StatusMessage {
 	return m.status
 }
 
-func (m *mockP2PChannel) Send(topic string, msg *p2p.Message) (*p2p.Message, error) {
+func (m *mockP2PChannel) Send(_ context.Context, topic string, msg *p2p.Message) (*p2p.Message, error) {
 	switch topic {
 	case p2p.TopicSessionCreate:
 		res := &pb.SessionResponse{

--- a/p2p/channel_test.go
+++ b/p2p/channel_test.go
@@ -18,6 +18,7 @@
 package p2p
 
 import (
+	"context"
 	"errors"
 	"net"
 	"sync"
@@ -27,11 +28,12 @@ import (
 	"github.com/mysteriumnetwork/node/core/port"
 	"github.com/mysteriumnetwork/node/pb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChannelFullCommunicationFlow(t *testing.T) {
-	provider, consumer := createTestChannels(t)
-
+	provider, consumer, err := createTestChannels()
+	require.NoError(t, err)
 	defer provider.Close()
 	defer consumer.Close()
 
@@ -57,12 +59,12 @@ func TestChannelFullCommunicationFlow(t *testing.T) {
 
 		publishedConsumerMsg := &pb.PingPong{Value: "Consumer BigZ"}
 		msg := ProtoMessage(publishedConsumerMsg)
-		_, err := consumer.Send("ping.pong", msg)
+		_, err := consumer.Send(context.Background(), "ping.pong", msg)
 		assert.NoError(t, err)
 
 		publishedProviderMsg := &pb.PingPong{Value: "Provider SmallZ"}
 		msg = ProtoMessage(publishedProviderMsg)
-		_, err = provider.Send("ping.pong", msg)
+		_, err = provider.Send(context.Background(), "ping.pong", msg)
 		assert.NoError(t, err)
 
 		select {
@@ -92,7 +94,7 @@ func TestChannelFullCommunicationFlow(t *testing.T) {
 		})
 
 		msg := ProtoMessage(&pb.PingPong{Value: "ping"})
-		res, err := consumer.Send("testreq", msg)
+		res, err := consumer.Send(context.Background(), "testreq", msg)
 		assert.NoError(t, err)
 
 		var resMsg pb.PingPong
@@ -111,7 +113,7 @@ func TestChannelFullCommunicationFlow(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
-				_, err := consumer.Send("concurrent", &Message{Data: []byte{}})
+				_, err := consumer.Send(context.Background(), "concurrent", &Message{Data: []byte{}})
 				assert.NoError(t, err)
 			}()
 		}
@@ -132,13 +134,13 @@ func TestChannelFullCommunicationFlow(t *testing.T) {
 		slowStarted := make(chan struct{})
 		go func() {
 			slowStarted <- struct{}{}
-			consumer.Send("slow", &Message{})
+			consumer.Send(context.Background(), "slow", &Message{})
 		}()
 
 		fastFinished := make(chan struct{})
 		go func() {
 			<-slowStarted
-			consumer.Send("fast", &Message{})
+			consumer.Send(context.Background(), "fast", &Message{})
 			fastFinished <- struct{}{}
 		}()
 
@@ -154,7 +156,7 @@ func TestChannelFullCommunicationFlow(t *testing.T) {
 			return c.Error(errors.New("I don't like you"))
 		})
 
-		_, err := consumer.Send("get-error", &Message{Data: []byte("hello")})
+		_, err := consumer.Send(context.Background(), "get-error", &Message{Data: []byte("hello")})
 		assert.EqualError(t, err, "public peer error: I don't like you")
 	})
 
@@ -163,48 +165,152 @@ func TestChannelFullCommunicationFlow(t *testing.T) {
 			return errors.New("I don't like you")
 		})
 
-		_, err := consumer.Send("get-error", &Message{Data: []byte("hello")})
+		_, err := consumer.Send(context.Background(), "get-error", &Message{Data: []byte("hello")})
 		assert.EqualError(t, err, "internal peer error")
 	})
 
 	t.Run("Test peer returns handler not found error", func(t *testing.T) {
-		_, err := consumer.Send("ping", &Message{Data: []byte("hello")})
+		_, err := consumer.Send(context.Background(), "ping", &Message{Data: []byte("hello")})
 		assert.EqualError(t, err, "public peer error: handler \"ping\" is not registered")
 	})
 }
 
-func createTestChannels(t *testing.T) (Channel, Channel) {
-	ports := acquirePorts(t, 2)
+func TestChannel_Send_Timeout(t *testing.T) {
+	provider, consumer, err := createTestChannels()
+	require.NoError(t, err)
+	defer provider.Close()
+	defer consumer.Close()
+
+	t.Run("Test timeout for long not responding peer", func(t *testing.T) {
+		provider.Handle("timeout", func(c Context) error {
+			time.Sleep(time.Hour)
+			return c.OK()
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_, err = consumer.Send(ctx, "timeout", &Message{Data: []byte("ping")})
+		if !errors.Is(err, ErrSendTimeout) {
+			t.Fatalf("expect timeout err, got: %v", err)
+		}
+	})
+
+	t.Run("Test timeout when peer is closed", func(t *testing.T) {
+		provider.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_, err = consumer.Send(ctx, "timeout", &Message{Data: []byte("ping")})
+		if !errors.Is(err, ErrSendTimeout) {
+			t.Fatalf("expect timeout err, got: %v", err)
+		}
+	})
+}
+
+func TestChannel_Send_To_When_Peer_Starts_Later(t *testing.T) {
+	provider, consumer, err := createTestChannels()
+	require.NoError(t, err)
+	defer consumer.Close()
+	defer provider.Close()
+
+	// Close provider channel to simulate unstable network.
+	// Consumer will try to send messages and during first 50 ms
+	// they will not reach provider peer, but since kcp will try
+	// keep resending packets they will finally reach opened
+	// provider peer.
+	err = provider.Close()
+	require.NoError(t, err)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		provider, err := reopenChannel(provider.(*channel))
+		require.NoError(t, err)
+		provider.Handle("timeout", func(c Context) error {
+			return c.OK()
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err = consumer.Send(ctx, "timeout", &Message{Data: []byte("ping")})
+	require.NoError(t, err)
+}
+
+func BenchmarkChannel_Send(b *testing.B) {
+	provider, consumer, err := createTestChannels()
+	require.NoError(b, err)
+	defer provider.Close()
+	defer consumer.Close()
+
+	provider.Handle("bench", func(c Context) error {
+		return c.OkWithReply(&Message{Data: []byte("I'm still OK")})
+	})
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		res, err := consumer.Send(context.Background(), "bench", &Message{Data: []byte("Catch this!")})
+		require.NoError(b, err)
+		require.NotNil(b, res)
+	}
+}
+
+func reopenChannel(c *channel) (*channel, error) {
+	punchedConn, err := net.DialUDP("udp", c.localAddr, c.peerAddr)
+	if err != nil {
+		return nil, err
+	}
+	return newChannel(punchedConn, c.privateKey, c.peerPubKey)
+}
+
+func createTestChannels() (Channel, Channel, error) {
+	ports, err := acquirePorts(2)
+	if err != nil {
+		return nil, nil, err
+	}
 	providerPort := ports[0]
 	consumerPort := ports[1]
 
 	providerConn, err := net.DialUDP("udp", &net.UDPAddr{Port: providerPort}, &net.UDPAddr{Port: consumerPort})
-	assert.NoError(t, err)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	consumerConn, err := net.DialUDP("udp", &net.UDPAddr{Port: consumerPort}, &net.UDPAddr{Port: providerPort})
-	assert.NoError(t, err)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	providerPublicKey, providerPrivateKey, err := GenerateKey()
-	assert.NoError(t, err)
+	if err != nil {
+		return nil, nil, err
+	}
 	consumerPublicKey, consumerPrivateKey, err := GenerateKey()
-	assert.NoError(t, err)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	provider, err := newChannel(providerConn, providerPrivateKey, consumerPublicKey)
-	assert.NoError(t, err)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	consumer, err := newChannel(consumerConn, consumerPrivateKey, providerPublicKey)
-	assert.NoError(t, err)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return provider, consumer
+	return provider, consumer, nil
 }
 
-func acquirePorts(t *testing.T, n int) []int {
+func acquirePorts(n int) ([]int, error) {
 	portPool := port.NewPool()
 	ports, err := portPool.AcquireMultiple(n)
-	assert.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	var res []int
 	for _, v := range ports {
 		res = append(res, v.Num())
 	}
-	return res
+	return res, nil
 }

--- a/p2p/dialer_test.go
+++ b/p2p/dialer_test.go
@@ -67,7 +67,7 @@ func TestDialer_Exchange_And_Communication_When_Provider_With_PublicIP(t *testin
 		consumerChannel, err := channelDialer.Dial(ctx, consumerID, "wireguard", providerID)
 		require.NoError(t, err)
 
-		res, err := consumerChannel.Send("test", &Message{Data: []byte("ping")})
+		res, err := consumerChannel.Send(context.Background(), "test", &Message{Data: []byte("ping")})
 		require.NoError(t, err)
 		assert.Equal(t, "pong", string(res.Data))
 	})
@@ -87,7 +87,8 @@ func TestDialer_Exchange_And_Communication_When_Provider_Behind_NAT(t *testing.T
 	portPool := &mockPortPool{}
 
 	// Create mock NAT pinger.
-	ports := acquirePorts(t, 2)
+	ports, err := acquirePorts(2)
+	assert.NoError(t, err)
 	providerPort := ports[0]
 	consumerPort := ports[1]
 	providerConn, err := net.DialUDP("udp", &net.UDPAddr{Port: providerPort}, &net.UDPAddr{Port: consumerPort})
@@ -117,7 +118,7 @@ func TestDialer_Exchange_And_Communication_When_Provider_Behind_NAT(t *testing.T
 		consumerChannel, err := channelDialer.Dial(ctx, consumerID, "wireguard", providerID)
 		require.NoError(t, err)
 
-		res, err := consumerChannel.Send("test", &Message{Data: []byte("ping")})
+		res, err := consumerChannel.Send(context.Background(), "test", &Message{Data: []byte("ping")})
 		require.NoError(t, err)
 		assert.Equal(t, "pong", string(res.Data))
 	})

--- a/session/pingpong/exchange_messaging.go
+++ b/session/pingpong/exchange_messaging.go
@@ -18,6 +18,9 @@
 package pingpong
 
 import (
+	"context"
+	"time"
+
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/p2p"
 	"github.com/mysteriumnetwork/node/pb"
@@ -67,7 +70,10 @@ func (es *ExchangeSender) Send(em crypto.ExchangeMessage) error {
 		Signature:      em.Signature,
 	}
 	log.Debug().Msgf("Sending P2P message to %q: %s", p2p.TopicPaymentMessage, pMessage.String())
-	_, err := es.ch.Send(p2p.TopicPaymentMessage, p2p.ProtoMessage(pMessage))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err := es.ch.Send(ctx, p2p.TopicPaymentMessage, p2p.ProtoMessage(pMessage))
 	return err
 }
 

--- a/session/pingpong/invoice_messaging.go
+++ b/session/pingpong/invoice_messaging.go
@@ -18,6 +18,9 @@
 package pingpong
 
 import (
+	"context"
+	"time"
+
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/p2p"
 	"github.com/mysteriumnetwork/node/pb"
@@ -61,7 +64,9 @@ func (is *InvoiceSender) Send(invoice crypto.Invoice) error {
 		Provider:       invoice.Provider,
 	}
 	log.Debug().Msgf("Sending P2P message to %q: %s", p2p.TopicPaymentInvoice, pInvoice.String())
-	_, err := is.ch.Send(p2p.TopicPaymentInvoice, p2p.ProtoMessage(pInvoice))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err := is.ch.Send(ctx, p2p.TopicPaymentInvoice, p2p.ProtoMessage(pInvoice))
 	return err
 }
 


### PR DESCRIPTION
Each p2p send message will need to be handled individually.

Need to think about payments. Now I just set 20 seconds timeout, but if consumer is not available when payment invoice message is sent session will be destroyed. @vkuznecovas