### PR TITLE
Skip p2p NAT pinging when provider is not behind NAT

### DIFF
--- a/p2p/channel.go
+++ b/p2p/channel.go
@@ -102,6 +102,10 @@ type channel struct {
 // newChannel creates new p2p channel with initialized crypto primitives for data encryption
 // and starts listening for connections.
 func newChannel(punchedConn *net.UDPConn, privateKey PrivateKey, peerPubKey PublicKey) (*channel, error) {
+	localPort := punchedConn.LocalAddr().(*net.UDPAddr).Port
+	remotePort := punchedConn.RemoteAddr().(*net.UDPAddr).Port
+	log.Debug().Msgf("Creating p2p channel with local port: %d, remote port: %d", localPort, remotePort)
+
 	blockCrypt, err := newBlockCrypt(privateKey, peerPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("could not create block crypt: %w", err)
@@ -334,6 +338,11 @@ func (c *channel) deleteStream(id uint64) {
 	defer c.mu.Unlock()
 
 	delete(c.streams, id)
+}
+
+func (c *channel) setServiceConn(conn *net.UDPConn) {
+	log.Debug().Msgf("Will use service conn with local port: %d, remote port: %d", conn.LocalAddr().(*net.UDPAddr).Port, conn.RemoteAddr().(*net.UDPAddr).Port)
+	c.serviceConn = conn
 }
 
 func newBlockCrypt(privateKey PrivateKey, peerPublicKey PublicKey) (kcp.BlockCrypt, error) {

--- a/p2p/common.go
+++ b/p2p/common.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	pingMaxPorts       = 20
-	requiredConnAmount = 2
+	requiredConnCount  = 2
 	consumerInitialTTL = 128
 	providerInitialTTL = 2
 )
@@ -61,8 +61,8 @@ func channelHandlersReadySubject(providerID identity.Identity, serviceType strin
 	return fmt.Sprintf("%s.%s.p2p-channel-handlers-ready", providerID.Address, serviceType)
 }
 
-func acquireLocalPorts(portPool port.ServicePortSupplier) ([]int, error) {
-	ports, err := portPool.AcquireMultiple(pingMaxPorts)
+func acquireLocalPorts(portPool port.ServicePortSupplier, n int) ([]int, error) {
+	ports, err := portPool.AcquireMultiple(n)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/dialer_test.go
+++ b/p2p/dialer_test.go
@@ -33,20 +33,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDialerExchangeAndCommunication(t *testing.T) {
-	dir, err := ioutil.TempDir("", "p2pDialerTest")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+func TestDialer_Exchange_And_Communication_When_Provider_With_PublicIP(t *testing.T) {
+	consumerID, providerID, ks, cleanup := createTestIdentities(t)
+	defer cleanup()
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
-	consumerAcc, err := ks.NewAccount("")
-	assert.NoError(t, err)
-	ks.Unlock(consumerAcc, "")
-	consumerID := identity.FromAddress(consumerAcc.Address.Hex())
-	providerAcc, err := ks.NewAccount("")
-	assert.NoError(t, err)
-	ks.Unlock(providerAcc, "")
-	providerID := identity.FromAddress(providerAcc.Address.Hex())
 	signerFactory := func(id identity.Identity) identity.Signer {
 		return identity.NewSigner(ks, identity.FromAddress(id.Address))
 	}
@@ -54,24 +44,14 @@ func TestDialerExchangeAndCommunication(t *testing.T) {
 	brokerConn := nats.StartConnectionMock()
 	defer brokerConn.Close()
 	mockBroker := &mockBroker{conn: brokerConn}
-
-	mockPortPool := &mockPortPool{}
-
-	ports := acquirePorts(t, 2)
-	providerPort := ports[0]
-	consumerPort := ports[1]
-	providerConn, err := net.DialUDP("udp", &net.UDPAddr{Port: providerPort}, &net.UDPAddr{Port: consumerPort})
-	assert.NoError(t, err)
-	consumerConn, err := net.DialUDP("udp", &net.UDPAddr{Port: consumerPort}, &net.UDPAddr{Port: providerPort})
-	assert.NoError(t, err)
-	providerPinger := &mockProviderNATPinger{conns: []*net.UDPConn{consumerConn, consumerConn}}
-	consumerPinger := &mockConsumerNATPinger{conns: []*net.UDPConn{providerConn, providerConn}}
-
+	portPool := port.NewPool()
+	providerPinger := &mockProviderNATPinger{}
+	consumerPinger := &mockConsumerNATPinger{}
 	ipResolver := ip.NewResolverMock("127.0.0.1")
 
 	t.Run("Test provider listens to peer", func(t *testing.T) {
-		channelListener := NewListener(mockBroker, "broker", signerFactory, verifier, ipResolver, providerPinger, mockPortPool)
-		err = channelListener.Listen(providerID, "wireguard", func(ch Channel) {
+		channelListener := NewListener(mockBroker, "broker", signerFactory, verifier, ipResolver, providerPinger, portPool)
+		err := channelListener.Listen(providerID, "wireguard", func(ch Channel) {
 			ch.Handle("test", func(c Context) error {
 				return c.OkWithReply(&Message{Data: []byte("pong")})
 			})
@@ -80,7 +60,7 @@ func TestDialerExchangeAndCommunication(t *testing.T) {
 	})
 
 	t.Run("Test consumer dialer creates new ready to use channel", func(t *testing.T) {
-		channelDialer := NewDialer(mockBroker, "broker", signerFactory, verifier, ipResolver, consumerPinger, mockPortPool)
+		channelDialer := NewDialer(mockBroker, "broker", signerFactory, verifier, ipResolver, consumerPinger, portPool)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -91,6 +71,73 @@ func TestDialerExchangeAndCommunication(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "pong", string(res.Data))
 	})
+}
+
+func TestDialer_Exchange_And_Communication_When_Provider_Behind_NAT(t *testing.T) {
+	consumerID, providerID, ks, cleanup := createTestIdentities(t)
+	defer cleanup()
+
+	signerFactory := func(id identity.Identity) identity.Signer {
+		return identity.NewSigner(ks, identity.FromAddress(id.Address))
+	}
+	verifier := identity.NewVerifierSigned()
+	brokerConn := nats.StartConnectionMock()
+	defer brokerConn.Close()
+	mockBroker := &mockBroker{conn: brokerConn}
+	portPool := &mockPortPool{}
+
+	// Create mock NAT pinger.
+	ports := acquirePorts(t, 2)
+	providerPort := ports[0]
+	consumerPort := ports[1]
+	providerConn, err := net.DialUDP("udp", &net.UDPAddr{Port: providerPort}, &net.UDPAddr{Port: consumerPort})
+	assert.NoError(t, err)
+	consumerConn, err := net.DialUDP("udp", &net.UDPAddr{Port: consumerPort}, &net.UDPAddr{Port: providerPort})
+	assert.NoError(t, err)
+	providerPinger := &mockProviderNATPinger{conns: []*net.UDPConn{consumerConn, consumerConn}}
+	consumerPinger := &mockConsumerNATPinger{conns: []*net.UDPConn{providerConn, providerConn}}
+	// Simulate behind NAT behaviour with different IP's.
+	ipResolver := ip.NewResolverMock("127.0.0.1", "1.1.1.1")
+
+	t.Run("Test provider listens to peer", func(t *testing.T) {
+		channelListener := NewListener(mockBroker, "broker", signerFactory, verifier, ipResolver, providerPinger, portPool)
+		err = channelListener.Listen(providerID, "wireguard", func(ch Channel) {
+			ch.Handle("test", func(c Context) error {
+				return c.OkWithReply(&Message{Data: []byte("pong")})
+			})
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("Test consumer dialer creates new ready to use channel", func(t *testing.T) {
+		channelDialer := NewDialer(mockBroker, "broker", signerFactory, verifier, ipResolver, consumerPinger, portPool)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		consumerChannel, err := channelDialer.Dial(ctx, consumerID, "wireguard", providerID)
+		require.NoError(t, err)
+
+		res, err := consumerChannel.Send("test", &Message{Data: []byte("ping")})
+		require.NoError(t, err)
+		assert.Equal(t, "pong", string(res.Data))
+	})
+}
+
+func createTestIdentities(t *testing.T) (consumerID identity.Identity, providerID identity.Identity, ks *identity.Keystore, cleanup func()) {
+	dir, err := ioutil.TempDir("", "p2pDialerTest")
+	assert.NoError(t, err)
+	cleanup = func() { os.RemoveAll(dir) }
+
+	ks = identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	consumerAcc, err := ks.NewAccount("")
+	assert.NoError(t, err)
+	ks.Unlock(consumerAcc, "")
+	consumerID = identity.FromAddress(consumerAcc.Address.Hex())
+	providerAcc, err := ks.NewAccount("")
+	assert.NoError(t, err)
+	ks.Unlock(providerAcc, "")
+	providerID = identity.FromAddress(providerAcc.Address.Hex())
+	return
 }
 
 type mockConsumerNATPinger struct {


### PR DESCRIPTION
There is no need to ping provider which is not behind NAT. Is such case provider will send the amount of ports equal the amount of needed UDP connections and both peers will create UDP connections manually.