### PR TITLE
Disable unit tests cache when running all unit tests

### DIFF
--- a/ci/test/test.go
+++ b/ci/test/test.go
@@ -29,7 +29,7 @@ func TestWithCoverage() error {
 	if err != nil {
 		return err
 	}
-	args := append([]string{"test", "-race", "-timeout", "5m", "-cover", "-coverprofile", "coverage.txt", "-covermode", "atomic"}, packages...)
+	args := append([]string{"test", "-race", "-count=1", "-timeout", "5m", "-cover", "-coverprofile", "coverage.txt", "-covermode", "atomic"}, packages...)
 	return sh.RunV("go", args...)
 }
 
@@ -39,7 +39,7 @@ func Test() error {
 	if err != nil {
 		return err
 	}
-	args := append([]string{"test", "-race", "-timeout", "5m"}, packages...)
+	args := append([]string{"test", "-race", "-count=1", "-timeout", "5m"}, packages...)
 	return sh.RunV("go", args...)
 }
 


### PR DESCRIPTION
This should help to catch data races locally more often.