### PR TITLE
Pass context for nat pinger cancellation

### DIFF
--- a/core/connection/interface.go
+++ b/core/connection/interface.go
@@ -18,6 +18,8 @@
 package connection
 
 import (
+	"context"
+
 	"github.com/mysteriumnetwork/node/communication"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
@@ -31,7 +33,7 @@ type ConsumerConfig interface{}
 
 // Connection represents a connection
 type Connection interface {
-	Start(ConnectOptions) error
+	Start(context.Context, ConnectOptions) error
 	Wait() error
 	Stop()
 	GetConfig() (ConsumerConfig, error)

--- a/core/connection/stubs_test.go
+++ b/core/connection/stubs_test.go
@@ -18,6 +18,7 @@
 package connection
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -155,7 +156,7 @@ func (foc *connectionMock) GetConfig() (ConsumerConfig, error) {
 	return nil, nil
 }
 
-func (foc *connectionMock) Start(connectionParams ConnectOptions) error {
+func (foc *connectionMock) Start(ctx context.Context, connectionParams ConnectOptions) error {
 	foc.RLock()
 	defer foc.RUnlock()
 

--- a/mobile/mysterium/openvpn_connection_setup.go
+++ b/mobile/mysterium/openvpn_connection_setup.go
@@ -18,6 +18,7 @@
 package mysterium
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -148,7 +149,7 @@ func (c *openvpnConnection) Statistics() (connection.Statistics, error) {
 	return c.stats, nil
 }
 
-func (c *openvpnConnection) Start(options connection.ConnectOptions) error {
+func (c *openvpnConnection) Start(ctx context.Context, options connection.ConnectOptions) error {
 	sessionConfig := openvpn.VPNConfig{}
 	err := json.Unmarshal(options.SessionConfig, &sessionConfig)
 	if err != nil {
@@ -196,7 +197,7 @@ func (c *openvpnConnection) Start(options connection.ConnectOptions) error {
 		c.natPinger.SetProtectSocketCallback(c.tunnelSetup.SocketProtect)
 
 		remoteIP := sessionConfig.RemoteIP
-		_, _, err = c.natPinger.PingProvider(remoteIP, c.ports, sessionConfig.Ports, sessionConfig.LocalPort)
+		_, _, err = c.natPinger.PingProvider(ctx, remoteIP, c.ports, sessionConfig.Ports, sessionConfig.LocalPort)
 		if err != nil {
 			return errors.Wrap(err, "could not ping provider")
 		}

--- a/mobile/mysterium/wireguard_connection_setup.go
+++ b/mobile/mysterium/wireguard_connection_setup.go
@@ -19,6 +19,7 @@ package mysterium
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -112,7 +113,7 @@ func (c *wireguardConnection) Statistics() (connection.Statistics, error) {
 	}, nil
 }
 
-func (c *wireguardConnection) Start(options connection.ConnectOptions) (err error) {
+func (c *wireguardConnection) Start(ctx context.Context, options connection.ConnectOptions) (err error) {
 	var config wireguard.ServiceConfig
 	err = json.Unmarshal(options.SessionConfig, &config)
 	if err != nil {
@@ -133,7 +134,7 @@ func (c *wireguardConnection) Start(options connection.ConnectOptions) (err erro
 		config.Provider.Endpoint.Port = options.ProviderNATConn.RemoteAddr().(*net.UDPAddr).Port
 	} else if len(config.Ports) > 0 { // TODO this backward compatibility block needs to be removed once we migrate to the p2p communication.
 		ip := config.Provider.Endpoint.IP.String()
-		lPort, rPort, err := c.natPinger.PingProvider(ip, c.ports, config.Ports, 0)
+		lPort, rPort, err := c.natPinger.PingProvider(ctx, ip, c.ports, config.Ports, 0)
 		if err != nil {
 			return errors.Wrap(err, "could not ping provider")
 		}

--- a/mobile/mysterium/wireguard_connection_setup_test.go
+++ b/mobile/mysterium/wireguard_connection_setup_test.go
@@ -18,6 +18,7 @@
 package mysterium
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net"
@@ -36,7 +37,7 @@ func TestConnectionStartStop(t *testing.T) {
 
 	// Start connection.
 	sessionConfig, _ := json.Marshal(newServiceConfig())
-	err := conn.Start(connection.ConnectOptions{
+	err := conn.Start(context.Background(), connection.ConnectOptions{
 		DNS:           "1.2.3.4",
 		SessionConfig: sessionConfig,
 	})
@@ -63,7 +64,7 @@ func TestConnectionStopAfterHandshakeError(t *testing.T) {
 	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
 	sessionConfig, _ := json.Marshal(newServiceConfig())
 
-	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+	err := conn.Start(context.Background(), connection.ConnectOptions{SessionConfig: sessionConfig})
 	assert.Error(t, handshakeTimeoutErr, err)
 	assert.Equal(t, connection.Connecting, <-conn.State())
 	assert.Equal(t, connection.Disconnecting, <-conn.State())
@@ -76,7 +77,7 @@ func TestConnectionStopOnceAfterHandshakeErrorAndStopCall(t *testing.T) {
 	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
 	sessionConfig, _ := json.Marshal(newServiceConfig())
 
-	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+	err := conn.Start(context.Background(), connection.ConnectOptions{SessionConfig: sessionConfig})
 
 	stopCh := make(chan struct{})
 	go func() {

--- a/nat/traversal/noop.go
+++ b/nat/traversal/noop.go
@@ -17,7 +17,10 @@
 
 package traversal
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
 // NoopPinger does nothing
 type NoopPinger struct{}
@@ -28,12 +31,12 @@ func NewNoopPinger() NATPinger {
 }
 
 // PingProviderPeer does nothing.
-func (np *NoopPinger) PingProviderPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
+func (np *NoopPinger) PingProviderPeer(ctx context.Context, ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
 	return []*net.UDPConn{}, nil
 }
 
 // PingConsumerPeer does nothing.
-func (np *NoopPinger) PingConsumerPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
+func (np *NoopPinger) PingConsumerPeer(ctx context.Context, ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
 	return []*net.UDPConn{}, nil
 }
 
@@ -52,12 +55,13 @@ func (np *NoopPinger) SetProtectSocketCallback(socketProtect func(socket int) bo
 func (np *NoopPinger) Stop() {}
 
 // PingProvider does nothing
-func (np *NoopPinger) PingProvider(_ string, _, _ []int, _ int) (int, int, error) {
+func (np *NoopPinger) PingProvider(ctx context.Context, _ string, _, _ []int, _ int) (int, int, error) {
 	return 0, 0, nil
 }
 
 // PingConsumer does nothing
-func (np *NoopPinger) PingConsumer(ip string, localPorts, remotePorts []int, mappingKey string) {}
+func (np *NoopPinger) PingConsumer(ctx context.Context, ip string, localPorts, remotePorts []int, mappingKey string) {
+}
 
 // BindServicePort does nothing
 func (np *NoopPinger) BindServicePort(key string, port int) {}

--- a/p2p/common.go
+++ b/p2p/common.go
@@ -18,6 +18,7 @@
 package p2p
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -42,11 +43,11 @@ type brokerConnector interface {
 }
 
 type natConsumerPinger interface {
-	PingProviderPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error)
+	PingProviderPeer(ctx context.Context, ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error)
 }
 
 type natProviderPinger interface {
-	PingConsumerPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error)
+	PingConsumerPeer(ctx context.Context, ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error)
 }
 
 func configExchangeSubject(providerID identity.Identity, serviceType string) string {

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -109,7 +109,7 @@ func (m *dialer) Dial(ctx context.Context, consumerID identity.Identity, service
 		}
 	} else {
 		log.Debug().Msgf("Pinging provider %s with IP %s using ports %v:%v", providerID.Address, config.pingIP(), config.localPorts, config.peerPorts)
-		conns, err := m.consumerPinger.PingProviderPeer(config.pingIP(), config.localPorts, config.peerPorts, consumerInitialTTL, requiredConnCount)
+		conns, err := m.consumerPinger.PingProviderPeer(ctx, config.pingIP(), config.localPorts, config.peerPorts, consumerInitialTTL, requiredConnCount)
 		if err != nil {
 			return nil, fmt.Errorf("could not ping peer: %w", err)
 		}

--- a/p2p/dialer_test.go
+++ b/p2p/dialer_test.go
@@ -145,7 +145,7 @@ type mockConsumerNATPinger struct {
 	conns []*net.UDPConn
 }
 
-func (m *mockConsumerNATPinger) PingProviderPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
+func (m *mockConsumerNATPinger) PingProviderPeer(ctx context.Context, ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
 	return m.conns, nil
 }
 
@@ -153,7 +153,7 @@ type mockProviderNATPinger struct {
 	conns []*net.UDPConn
 }
 
-func (m *mockProviderNATPinger) PingConsumerPeer(ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
+func (m *mockProviderNATPinger) PingConsumerPeer(ctx context.Context, ip string, localPorts, remotePorts []int, initialTTL int, n int) (conns []*net.UDPConn, err error) {
 	return m.conns, nil
 }
 

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -18,6 +18,7 @@
 package p2p
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -140,7 +141,7 @@ func (m *listener) Listen(providerID identity.Identity, serviceType string, chan
 			}
 		} else {
 			log.Debug().Msgf("Pinging consumer with IP %s using ports %v:%v", config.pingIP(), config.localPorts, config.peerPorts)
-			conns, err := m.providerPinger.PingConsumerPeer(config.pingIP(), config.localPorts, config.peerPorts, providerInitialTTL, requiredConnCount)
+			conns, err := m.providerPinger.PingConsumerPeer(context.Background(), config.pingIP(), config.localPorts, config.peerPorts, providerInitialTTL, requiredConnCount)
 			if err != nil {
 				log.Err(err).Msg("Could not ping peer")
 				return

--- a/services/noop/connection.go
+++ b/services/noop/connection.go
@@ -18,6 +18,7 @@
 package noop
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -51,7 +52,7 @@ func (c *Connection) Statistics() (connection.Statistics, error) {
 }
 
 // Start implements the connection.Connection interface
-func (c *Connection) Start(params connection.ConnectOptions) error {
+func (c *Connection) Start(ctx context.Context, params connection.ConnectOptions) error {
 	c.noopConnection.Add(1)
 	c.isRunning = true
 

--- a/services/openvpn/client.go
+++ b/services/openvpn/client.go
@@ -18,6 +18,7 @@
 package openvpn
 
 import (
+	"context"
 	"encoding/json"
 	"sync"
 	"time"
@@ -116,7 +117,7 @@ func (c *Client) Statistics() (connection.Statistics, error) {
 }
 
 // Start starts the connection
-func (c *Client) Start(options connection.ConnectOptions) error {
+func (c *Client) Start(ctx context.Context, options connection.ConnectOptions) error {
 	log.Info().Msg("Starting connection")
 
 	sessionConfig := VPNConfig{}
@@ -133,7 +134,7 @@ func (c *Client) Start(options connection.ConnectOptions) error {
 	// TODO this backward compatibility block needs to be removed once we will fully migrate to the p2p communication.
 	if len(sessionConfig.Ports) > 0 {
 		ip := sessionConfig.RemoteIP
-		lPort, rPort, err := c.natPinger.PingProvider(ip, c.ports, sessionConfig.Ports, sessionConfig.LocalPort)
+		lPort, rPort, err := c.natPinger.PingProvider(ctx, ip, c.ports, sessionConfig.Ports, sessionConfig.LocalPort)
 		if err != nil {
 			c.removeAllowedIPRule()
 			return errors.Wrap(err, "could not ping provider")

--- a/services/openvpn/client_test.go
+++ b/services/openvpn/client_test.go
@@ -18,6 +18,7 @@
 package openvpn
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mysteriumnetwork/node/core/connection"
@@ -34,7 +35,7 @@ func TestConnection_ErrorsOnInvalidConfig(t *testing.T) {
 	conn, err := NewClient("./", "./", "./", fakeSignerFactory, ip.NewResolverMock("1.1.1.1"), &MockNATPinger{})
 	connectionOptions := connection.ConnectOptions{}
 	assert.Nil(t, err)
-	err = conn.Start(connectionOptions)
+	err = conn.Start(context.Background(), connectionOptions)
 	assert.EqualError(t, err, "failed to unmarshal session config: unexpected end of JSON input")
 }
 
@@ -48,6 +49,6 @@ func TestConnection_CreatesConnection(t *testing.T) {
 type MockNATPinger struct{}
 
 // PingProvider does nothing
-func (mnp *MockNATPinger) PingProvider(_ string, _, _ []int, _ int) (int, int, error) {
+func (mnp *MockNATPinger) PingProvider(_ context.Context, _ string, _, _ []int, _ int) (int, int, error) {
 	return 0, 0, nil
 }

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -18,6 +18,7 @@
 package connection
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"sync"
@@ -100,7 +101,7 @@ func (c *Connection) Statistics() (connection.Statistics, error) {
 }
 
 // Start establish wireguard connection to the service provider.
-func (c *Connection) Start(options connection.ConnectOptions) (err error) {
+func (c *Connection) Start(ctx context.Context, options connection.ConnectOptions) (err error) {
 	var config wg.ServiceConfig
 	if err := json.Unmarshal(options.SessionConfig, &config); err != nil {
 		return errors.Wrap(err, "failed to unmarshal connection config")
@@ -126,7 +127,7 @@ func (c *Connection) Start(options connection.ConnectOptions) (err error) {
 		config.Provider.Endpoint.Port = options.ProviderNATConn.RemoteAddr().(*net.UDPAddr).Port
 	} else if len(config.Ports) > 0 { // TODO this backward compatibility block needs to be removed once we migrate to the p2p communication.
 		ip := config.Provider.Endpoint.IP.String()
-		lPort, rPort, err := c.natPinger.PingProvider(ip, c.ports, config.Ports, 0)
+		lPort, rPort, err := c.natPinger.PingProvider(ctx, ip, c.ports, config.Ports, 0)
 		if err != nil {
 			return errors.Wrap(err, "could not ping provider")
 		}

--- a/services/wireguard/connection/connection_test.go
+++ b/services/wireguard/connection/connection_test.go
@@ -18,6 +18,7 @@
 package connection
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net"
@@ -36,7 +37,7 @@ func TestConnectionStartStop(t *testing.T) {
 
 	// Start connection.
 	sessionConfig, _ := json.Marshal(newServiceConfig())
-	err := conn.Start(connection.ConnectOptions{
+	err := conn.Start(context.Background(), connection.ConnectOptions{
 		DNS:           "1.2.3.4",
 		SessionConfig: sessionConfig,
 	})
@@ -63,7 +64,7 @@ func TestConnectionStopAfterHandshakeError(t *testing.T) {
 	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
 	sessionConfig, _ := json.Marshal(newServiceConfig())
 
-	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+	err := conn.Start(context.Background(), connection.ConnectOptions{SessionConfig: sessionConfig})
 	assert.Error(t, handshakeTimeoutErr, err)
 	assert.Equal(t, connection.Connecting, <-conn.State())
 	assert.Equal(t, connection.Disconnecting, <-conn.State())
@@ -76,7 +77,7 @@ func TestConnectionStopOnceAfterHandshakeErrorAndStopCall(t *testing.T) {
 	conn.handshakeWaiter = &mockHandshakeWaiter{err: handshakeTimeoutErr}
 	sessionConfig, _ := json.Marshal(newServiceConfig())
 
-	err := conn.Start(connection.ConnectOptions{SessionConfig: sessionConfig})
+	err := conn.Start(context.Background(), connection.ConnectOptions{SessionConfig: sessionConfig})
 
 	stopCh := make(chan struct{})
 	go func() {

--- a/session/manager.go
+++ b/session/manager.go
@@ -194,7 +194,7 @@ func (manager *Manager) Start(session *Session, consumerID identity.Identity, co
 
 	// TODO pingerParams is a backward compatibility limitation. Remove it once most of the clients will be updated.
 	if pingerParams != nil {
-		go manager.natPinger.PingConsumer(pingerParams.IP, pingerParams.LocalPorts, pingerParams.RemotePorts, pingerParams.ProxyPortMappingKey)
+		go manager.natPinger.PingConsumer(context.Background(), pingerParams.IP, pingerParams.LocalPorts, pingerParams.RemotePorts, pingerParams.ProxyPortMappingKey)
 	}
 	go manager.keepAliveLoop(session, manager.channel)
 	manager.sessionStorage.Add(*session)


### PR DESCRIPTION
Expose context up from the connection manager so it can set global deadline for connecting and use the same for cancellation when user clicks cancel.

Also small improvement for nat pinger on provider side to wait all available pings instead of just n required.

Fixes https://github.com/mysteriumnetwork/node/issues/2018