### PR TITLE
Send first invoice with retry

### DIFF
--- a/p2p/channel.go
+++ b/p2p/channel.go
@@ -37,9 +37,10 @@ var (
 	// If this env variable is set channel will log raw messages from send and receive loops.
 	debugTransport = os.Getenv("P2P_DEBUG_TRANSPORT") == "1"
 
-	// ErrSendTimeout represent send timeout error.
+	// ErrSendTimeout indicates send timeout error.
 	ErrSendTimeout = errors.New("p2p send timeout")
 
+	// ErrHandlerNotFound indicates that peer is not registered handler yet.
 	ErrHandlerNotFound = errors.New("p2p peer handler not found")
 )
 

--- a/p2p/channel_test.go
+++ b/p2p/channel_test.go
@@ -171,7 +171,9 @@ func TestChannelFullCommunicationFlow(t *testing.T) {
 
 	t.Run("Test peer returns handler not found error", func(t *testing.T) {
 		_, err := consumer.Send(context.Background(), "ping", &Message{Data: []byte("hello")})
-		assert.EqualError(t, err, "public peer error: handler \"ping\" is not registered")
+		if !errors.Is(err, ErrHandlerNotFound) {
+			t.Fatalf("expect handler not found err, got %v", err)
+		}
 	})
 }
 

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -80,9 +80,10 @@ const (
 	headerFieldTopic     = "Topic"
 	headerStatusCode     = "Status-Code"
 
-	statusCodeOK          = 1
-	statusCodePublicErr   = 2
-	statusCodeInternalErr = 3
+	statusCodeOK                 = 1
+	statusCodePublicErr          = 2
+	statusCodeInternalErr        = 3
+	statusCodeHandlerNotFoundErr = 4
 )
 
 // transportMsg is internal structure for sending and receiving messages.

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -113,6 +113,8 @@ func InvoiceFactoryCreator(
 			ChargePeriodLeeway:         15 * time.Minute,
 			ExchangeMessageChan:        exchangeChan,
 			ExchangeMessageWaitTimeout: promiseTimeout,
+			FirstInvoiceSendTimeout:    10 * time.Second,
+			FirstInvoiceSendDuration:   1 * time.Second,
 			ProviderID:                 providerID,
 			AccountantCaller:           accountantCaller,
 			AccountantPromiseStorage:   accountantPromiseStorage,

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -105,6 +105,8 @@ func Test_InvoiceTracker_Start_Stop(t *testing.T) {
 		ChargePeriod:               time.Nanosecond,
 		ChargePeriodLeeway:         15 * time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
+		FirstInvoiceSendDuration:   time.Nanosecond,
+		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
 		AccountantID:               identity.FromAddress(acc.Address.Hex()),
@@ -385,6 +387,8 @@ func Test_InvoiceTracker_BubblesErrors(t *testing.T) {
 		TimeTracker:                &tracker,
 		ChargePeriod:               time.Millisecond,
 		ChargePeriodLeeway:         15 * time.Minute,
+		FirstInvoiceSendDuration:   time.Millisecond,
+		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
@@ -448,6 +452,8 @@ func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
 		TimeTracker:                &tracker,
 		ChargePeriod:               time.Nanosecond,
 		ChargePeriodLeeway:         15 * time.Minute,
+		FirstInvoiceSendDuration:   time.Nanosecond,
+		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
@@ -474,7 +480,7 @@ func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
 	assert.NoError(t, <-errChan)
 }
 
-func Test_InvoiceTracker_SendsInvoice_Return_Max_Send_Error(t *testing.T) {
+func Test_InvoiceTracker_SendsFirstInvoice_Return_Timeout_Err(t *testing.T) {
 	dir, err := ioutil.TempDir("", "invoice_tracker_test")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
@@ -526,8 +532,8 @@ func Test_InvoiceTracker_SendsInvoice_Return_Max_Send_Error(t *testing.T) {
 
 	err = <-errChan
 
-	if !stdErrors.Is(err, ErrInvoiceSendMaxFailCountReached) {
-		t.Fatalf("expected err %v, got: %v", ErrInvoiceSendMaxFailCountReached, err)
+	if !stdErrors.Is(err, ErrFirstInvoiceSendTimeout) {
+		t.Fatalf("expected err %v, got: %v", ErrFirstInvoiceSendTimeout, err)
 	}
 }
 
@@ -558,6 +564,8 @@ func Test_InvoiceTracker_FreeServiceSendsInvoices(t *testing.T) {
 		TimeTracker:                &tracker,
 		ChargePeriod:               time.Nanosecond,
 		ChargePeriodLeeway:         15 * time.Second,
+		FirstInvoiceSendDuration:   time.Nanosecond,
+		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),


### PR DESCRIPTION
When sending first invoice handle p2p handler not found error which may occur while consumer is setting up payments. 