### PR TITLE
Same connection contract in Tequilapi server, client, SSE events

### DIFF
--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -29,10 +29,10 @@ import (
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/identity"
-	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/mysteriumnetwork/node/services"
 	"github.com/mysteriumnetwork/node/tequilapi/client"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
@@ -146,7 +146,7 @@ func (sc *serviceCommand) runServices(ctx *cli.Context, providerID string, servi
 	return nil
 }
 
-func (sc *serviceCommand) runService(providerID, serviceType string, options service.Options, pm market.PaymentMethod) {
+func (sc *serviceCommand) runService(providerID, serviceType string, options service.Options, pm contract.PaymentMethodDTO) {
 	_, err := sc.tequilapi.ServiceStart(providerID, serviceType, options, sc.ap, pm)
 	if err != nil {
 		sc.errorChannel <- errors.Wrapf(err, "failed to run service %s", serviceType)
@@ -168,12 +168,12 @@ func parseIdentityFlags(ctx *cli.Context) service.OptionsIdentity {
 	}
 }
 
-func parseFlagsByServiceType(ctx *cli.Context, serviceType string) (service.Options, market.PaymentMethod, error) {
+func parseFlagsByServiceType(ctx *cli.Context, serviceType string) (service.Options, contract.PaymentMethodDTO, error) {
 	if f, ok := serviceTypesFlagsParser[serviceType]; ok {
 		opt, pm := f(ctx)
 		return opt, pm, nil
 	}
-	return service.OptionsIdentity{}, nil, errors.Errorf("unknown service type: %q", serviceType)
+	return service.OptionsIdentity{}, contract.PaymentMethodDTO{}, errors.Errorf("unknown service type: %q", serviceType)
 }
 
 func printTermWarning(licenseCommandName string) {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -508,7 +508,7 @@ func (di *Dependencies) bootstrapTequilapi(nodeOptions node.Options, listener ne
 	tequilapi_endpoints.AddRoutesForIdentities(router, di.IdentityManager, di.IdentitySelector, di.IdentityRegistry, di.ConsumerBalanceTracker, di.ChannelAddressCalculator, di.AccountantPromiseSettler)
 	tequilapi_endpoints.AddRoutesForConnection(router, di.ConnectionManager, di.StateKeeper, di.ProposalRepository, di.IdentityRegistry)
 	tequilapi_endpoints.AddRoutesForConnectionSessions(router, di.SessionStorage)
-	tequilapi_endpoints.AddRoutesForConnectionLocation(router, di.ConnectionManager, di.IPResolver, di.LocationResolver, di.LocationResolver)
+	tequilapi_endpoints.AddRoutesForConnectionLocation(router, di.IPResolver, di.LocationResolver, di.LocationResolver)
 	tequilapi_endpoints.AddRoutesForProposals(router, di.ProposalRepository, di.QualityClient)
 	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, serviceTypesRequestParser)
 	tequilapi_endpoints.AddRoutesForServiceSessions(router, di.StateKeeper)

--- a/core/quality/morqa_transport.go
+++ b/core/quality/morqa_transport.go
@@ -71,74 +71,74 @@ func nodeVersionToMetricsEvent(info appInfo) *metrics.Event {
 	}
 }
 
-func sessionEventToMetricsEvent(context sessionEventContext) *metrics.Event {
+func sessionEventToMetricsEvent(ctx sessionEventContext) *metrics.Event {
 	return &metrics.Event{
-		Signature:  context.Consumer,
-		TargetId:   context.Provider,
+		Signature:  ctx.Consumer,
+		TargetId:   ctx.Provider,
 		IsProvider: false,
 		Metric: &metrics.Event_SessionEventPayload{
 			SessionEventPayload: &metrics.SessionEventPayload{
-				Event: context.Event,
+				Event: ctx.Event,
 				Session: &metrics.SessionPayload{
-					Id:             context.ID,
-					ServiceType:    context.ServiceType,
-					ProviderContry: context.ProviderCountry,
-					ConsumerContry: context.ConsumerCountry,
-					AccountantId:   context.AccountantID,
+					Id:             ctx.ID,
+					ServiceType:    ctx.ServiceType,
+					ProviderContry: ctx.ProviderCountry,
+					ConsumerContry: ctx.ConsumerCountry,
+					AccountantId:   ctx.AccountantID,
 				},
 			},
 		},
 	}
 }
 
-func sessionDataToMetricsEvent(context sessionDataContext) *metrics.Event {
+func sessionDataToMetricsEvent(ctx sessionDataContext) *metrics.Event {
 	return &metrics.Event{
-		Signature:  context.Consumer,
-		TargetId:   context.Provider,
+		Signature:  ctx.Consumer,
+		TargetId:   ctx.Provider,
 		IsProvider: false,
 		Metric: &metrics.Event_SessionStatisticsPayload{
 			SessionStatisticsPayload: &metrics.SessionStatisticsPayload{
-				BytesSent:     context.Tx,
-				BytesReceived: context.Rx,
+				BytesSent:     ctx.Tx,
+				BytesReceived: ctx.Rx,
 				Session: &metrics.SessionPayload{
-					Id:             context.ID,
-					ServiceType:    context.ServiceType,
-					ProviderContry: context.ProviderCountry,
-					ConsumerContry: context.ConsumerCountry,
-					AccountantId:   context.AccountantID,
+					Id:             ctx.ID,
+					ServiceType:    ctx.ServiceType,
+					ProviderContry: ctx.ProviderCountry,
+					ConsumerContry: ctx.ConsumerCountry,
+					AccountantId:   ctx.AccountantID,
 				},
 			},
 		},
 	}
 }
 
-func sessionTokensToMetricsEvent(context sessionTokensContext) *metrics.Event {
+func sessionTokensToMetricsEvent(ctx sessionTokensContext) *metrics.Event {
 	return &metrics.Event{
-		Signature:  context.Consumer,
-		TargetId:   context.Provider,
+		Signature:  ctx.Consumer,
+		TargetId:   ctx.Provider,
 		IsProvider: false,
 		Metric: &metrics.Event_SessionTokensPayload{
 			SessionTokensPayload: &metrics.SessionTokensPayload{
-				Tokens: context.Tokens,
+				Tokens: ctx.Tokens,
 				Session: &metrics.SessionPayload{
-					Id:             context.ID,
-					ServiceType:    context.ServiceType,
-					ProviderContry: context.ProviderCountry,
-					ConsumerContry: context.ConsumerCountry,
-					AccountantId:   context.AccountantID,
+					Id:             ctx.ID,
+					ServiceType:    ctx.ServiceType,
+					ProviderContry: ctx.ProviderCountry,
+					ConsumerContry: ctx.ConsumerCountry,
+					AccountantId:   ctx.AccountantID,
 				},
 			},
 		},
 	}
 }
 
-func proposalEventToMetricsEvent(context market.ServiceProposal, info appInfo) *metrics.Event {
-	location := context.ServiceDefinition.GetLocation()
+func proposalEventToMetricsEvent(ctx market.ServiceProposal, info appInfo) *metrics.Event {
+	location := ctx.ServiceDefinition.GetLocation()
 	return &metrics.Event{
 		Metric: &metrics.Event_ProposalPayload{
 			ProposalPayload: &metrics.ProposalPayload{
-				ProviderId:  context.ProviderID,
-				ServiceType: context.ServiceType,
+				ProviderId:  ctx.ProviderID,
+				ServiceType: ctx.ServiceType,
 				NodeType:    location.NodeType,
 				Country:     location.Country,
 				Version: &metrics.VersionPayload{

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -112,7 +112,7 @@ func recheckBalancesWithAccountant(t *testing.T, consumerID string, consumerSpen
 	assert.Equal(t, promised, providerEarnings, fmt.Sprintf("Provider reported earning %v  accountant says %v", providerEarnings, promised))
 }
 
-func validateProviderEarnings(t *testing.T, proposal client.ProposalDTO, providerEarnings uint64, consumerTequila *tequilapi_client.Client) {
+func validateProviderEarnings(t *testing.T, proposal contract.ProposalDTO, providerEarnings uint64, consumerTequila *tequilapi_client.Client) {
 	sessions, err := consumerTequila.ConnectionSessions()
 	assert.NoError(t, err)
 
@@ -132,7 +132,7 @@ func validateProviderEarnings(t *testing.T, proposal client.ProposalDTO, provide
 		Duration: time.Duration(proposal.PaymentMethod.Rate.PerSeconds) * time.Second,
 		Price:    money.NewMoney(proposal.PaymentMethod.Price.Amount, money.CurrencyMyst),
 		Bytes:    proposal.PaymentMethod.Rate.PerBytes,
-		Type:     proposal.PaymentMethodType,
+		Type:     proposal.PaymentMethod.Type,
 	}
 
 	// we're running the tests for 30 secs, but due to the initial handshakes this could take longer.
@@ -190,8 +190,8 @@ func consumerRegistrationFlow(t *testing.T, tequilapi *tequilapi_client.Client, 
 }
 
 // expect exactly one proposal
-func consumerPicksProposal(t *testing.T, tequilapi *tequilapi_client.Client, serviceType string) tequilapi_client.ProposalDTO {
-	var proposals []tequilapi_client.ProposalDTO
+func consumerPicksProposal(t *testing.T, tequilapi *tequilapi_client.Client, serviceType string) contract.ProposalDTO {
+	var proposals []contract.ProposalDTO
 	err := waitForConditionFor(
 		30*time.Second,
 		func() (state bool, stateErr error) {
@@ -207,7 +207,7 @@ func consumerPicksProposal(t *testing.T, tequilapi *tequilapi_client.Client, ser
 	return proposals[0]
 }
 
-func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consumerID, accountantID, serviceType string, proposal tequilapi_client.ProposalDTO) uint64 {
+func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consumerID, accountantID, serviceType string, proposal contract.ProposalDTO) uint64 {
 	connectionStatus, err := tequilapi.ConnectionStatus()
 	assert.NoError(t, err)
 	assert.Equal(t, "NotConnected", connectionStatus.Status)
@@ -222,7 +222,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 	})
 	assert.NoError(t, err)
 
-	connectionStatus, err = tequilapi.ConnectionCreate(consumerID, proposal.ProviderID, accountantID, serviceType, tequilapi_client.ConnectOptions{
+	connectionStatus, err = tequilapi.ConnectionCreate(consumerID, proposal.ProviderID, accountantID, serviceType, contract.ConnectOptions{
 		DisableKillSwitch: false,
 	})
 

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -60,7 +60,7 @@ func (client *Client) GetIdentities() (ids []contract.IdentityRefDTO, err error)
 
 // NewIdentity creates a new client identity
 func (client *Client) NewIdentity(passphrase string) (id contract.IdentityRefDTO, err error) {
-	response, err := client.http.Post("identities", contract.IdentityRequest{Passphrase: &passphrase})
+	response, err := client.http.Post("identities", contract.IdentityCreateRequest{Passphrase: &passphrase})
 	if err != nil {
 		return
 	}
@@ -72,7 +72,7 @@ func (client *Client) NewIdentity(passphrase string) (id contract.IdentityRefDTO
 
 // CurrentIdentity unlocks and returns the last used, new or first identity
 func (client *Client) CurrentIdentity(identity, passphrase string) (id contract.IdentityRefDTO, err error) {
-	response, err := client.http.Put("identities/current", contract.IdentityRequest{
+	response, err := client.http.Put("identities/current", contract.IdentityCurrentRequest{
 		Address:    &identity,
 		Passphrase: &passphrase,
 	})
@@ -311,7 +311,7 @@ func (client *Client) ProposalsByPrice(lowerTime, upperTime, lowerGB, upperGB ui
 func (client *Client) Unlock(identity, passphrase string) error {
 	path := fmt.Sprintf("identities/%s/unlock", identity)
 
-	response, err := client.http.Put(path, contract.IdentityRequest{Passphrase: &passphrase})
+	response, err := client.http.Put(path, contract.IdentityUnlockRequest{Passphrase: &passphrase})
 	if err != nil {
 		return err
 	}

--- a/tequilapi/client/client_test.go
+++ b/tequilapi/client/client_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -81,7 +82,7 @@ func TestConnectionErrorIsReturnedByClientInsteadOfDoubleParsing(t *testing.T) {
 		},
 	}
 
-	_, err := client.ConnectionCreate("consumer", "provider", "accountant", "service", ConnectOptions{})
+	_, err := client.ConnectionCreate("consumer", "provider", "accountant", "service", contract.ConnectOptions{})
 	assert.Error(t, err)
 	assert.EqualError(t, err, "server response invalid: Internal server error (http://test-api-whatever/connection). Possible error: me haz faild")
 	//when doing http request, response body should always be closed by client - otherwise persistent connections are leaking

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -19,71 +19,14 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 
-	"github.com/mysteriumnetwork/node/core/connection"
-	"github.com/mysteriumnetwork/node/money"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 )
 
 // Fees represents the transactor fee
 type Fees struct {
 	Registration uint64 `json:"registration"`
 	Settlement   uint64 `json:"settlement"`
-}
-
-// StatusDTO holds connection status and session id
-type StatusDTO struct {
-	ConsumerID string      `json:"consumer_id"`
-	Status     string      `json:"status"`
-	SessionID  string      `json:"session_id"`
-	Proposal   ProposalDTO `json:"proposal"`
-}
-
-// ProposalList describes list of proposals
-type ProposalList struct {
-	Proposals []ProposalDTO `json:"proposals"`
-}
-
-// ProposalDTO describes service proposal
-type ProposalDTO struct {
-	ID                int                  `json:"id"`
-	ProviderID        string               `json:"provider_id"`
-	ServiceType       string               `json:"service_type"`
-	ServiceDefinition ServiceDefinitionDTO `json:"service_definition"`
-	AccessPolicies    []AccessPolicy       `json:"access_policies"`
-	PaymentMethodType string               `json:"payment_method_type"`
-	PaymentMethod     paymentMethodRes     `json:"payment_method"`
-}
-
-type paymentMethodRes struct {
-	Type  string         `json:"type"`
-	Price money.Money    `json:"price"`
-	Rate  paymentRateRes `json:"rate"`
-}
-
-type paymentRateRes struct {
-	PerSeconds uint64 `json:"per_seconds"`
-	PerBytes   uint64 `json:"per_bytes"`
-}
-
-// AccessPolicy represents the access controls for proposal
-type AccessPolicy struct {
-	ID     string `json:"id"`
-	Source string `json:"source"`
-}
-
-func (p ProposalDTO) String() string {
-	return fmt.Sprintf("Id: %d , Provider: %s, Country: %s", p.ID, p.ProviderID, p.ServiceDefinition.LocationOriginate.Country)
-}
-
-// ServiceDefinitionDTO describes service of proposal
-type ServiceDefinitionDTO struct {
-	LocationOriginate ServiceLocationDTO `json:"location_originate"`
-}
-
-// ServiceLocationDTO describes location of proposal
-type ServiceLocationDTO struct {
-	Country string `json:"country"`
 }
 
 // HealthcheckDTO holds returned healthcheck response
@@ -120,12 +63,6 @@ type RegistrationDataDTO struct {
 	Registered bool   `json:"registered"`
 }
 
-// ConnectOptions copied from tequilapi endpoint
-type ConnectOptions struct {
-	DisableKillSwitch bool                 `json:"kill_switch"`
-	DNS               connection.DNSOption `json:"dns"`
-}
-
 // ConnectionSessionListDTO copied from tequilapi endpoint
 type ConnectionSessionListDTO struct {
 	Sessions []ConnectionSessionDTO `json:"sessions"`
@@ -150,12 +87,12 @@ type ServiceListDTO []ServiceInfoDTO
 
 // ServiceInfoDTO represents running service information
 type ServiceInfoDTO struct {
-	ID          string          `json:"id"`
-	ProviderID  string          `json:"provider_id"`
-	ServiceType string          `json:"type"`
-	Options     json.RawMessage `json:"options"`
-	Status      string          `json:"status"`
-	Proposal    ProposalDTO     `json:"proposal"`
+	ID          string               `json:"id"`
+	ProviderID  string               `json:"provider_id"`
+	ServiceType string               `json:"type"`
+	Options     json.RawMessage      `json:"options"`
+	Status      string               `json:"status"`
+	Proposal    contract.ProposalDTO `json:"proposal"`
 }
 
 // ServiceSessionListDTO copied from tequilapi endpoint

--- a/tequilapi/contract/connection.go
+++ b/tequilapi/contract/connection.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mysteriumnetwork/payments/crypto"
 )
 
-// NewConnectionStatisticsDTO maps consumer connection details.
+// NewConnectionStatisticsDTO maps to API connection stats.
 func NewConnectionStatisticsDTO(connection connection.Status, statistics connection.Statistics, throughput bandwidth.Throughput, invoice crypto.Invoice) ConnectionStatisticsDTO {
 	return ConnectionStatisticsDTO{
 		Duration:           int(connection.Duration().Seconds()),
@@ -36,7 +36,7 @@ func NewConnectionStatisticsDTO(connection connection.Status, statistics connect
 	}
 }
 
-// ConnectionStatisticsDTO represents consumer connection details.
+// ConnectionStatisticsDTO holds consumer connection details.
 // swagger:model ConnectionStatisticsDTO
 type ConnectionStatisticsDTO struct {
 	// example: 1024

--- a/tequilapi/contract/connection.go
+++ b/tequilapi/contract/connection.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mysteriumnetwork/node/consumer/bandwidth"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/datasize"
+	"github.com/mysteriumnetwork/node/tequilapi/validation"
 	"github.com/mysteriumnetwork/payments/crypto"
 )
 
@@ -118,4 +119,62 @@ type ConnectionStatisticsDTO struct {
 
 	// example: 500000
 	TokensSpent uint64 `json:"tokens_spent"`
+}
+
+// ConnectionCreateRequest request used to start a connection.
+// swagger:model ConnectionCreateRequestDTO
+type ConnectionCreateRequest struct {
+	// consumer identity
+	// required: true
+	// example: 0x0000000000000000000000000000000000000001
+	ConsumerID string `json:"consumer_id"`
+
+	// provider identity
+	// required: true
+	// example: 0x0000000000000000000000000000000000000002
+	ProviderID string `json:"provider_id"`
+
+	// accountant identity
+	// required: true
+	// example: 0x0000000000000000000000000000000000000003
+	AccountantID string `json:"accountant_id"`
+
+	// service type. Possible values are "openvpn", "wireguard" and "noop"
+	// required: false
+	// default: openvpn
+	// example: openvpn
+	ServiceType string `json:"service_type"`
+
+	// connect options
+	// required: false
+	ConnectOptions ConnectOptions `json:"connect_options,omitempty"`
+}
+
+// Validate validates fields in request
+func (cr ConnectionCreateRequest) Validate() *validation.FieldErrorMap {
+	errs := validation.NewErrorMap()
+	if len(cr.ConsumerID) == 0 {
+		errs.ForField("consumer_id").AddError("required", "Field is required")
+	}
+	if len(cr.ProviderID) == 0 {
+		errs.ForField("provider_id").AddError("required", "Field is required")
+	}
+	if len(cr.AccountantID) == 0 {
+		errs.ForField("accountant_id").AddError("required", "Field is required")
+	}
+	return errs
+}
+
+// ConnectOptions holds tequilapi connect options
+// swagger:model ConnectOptionsDTO
+type ConnectOptions struct {
+	// kill switch option restricting communication only through VPN
+	// required: false
+	// example: true
+	DisableKillSwitch bool `json:"kill_switch"`
+	// DNS to use
+	// required: false
+	// default: auto
+	// example: auto, provider, system, "1.1.1.1,8.8.8.8"
+	DNS connection.DNSOption `json:"dns"`
 }

--- a/tequilapi/contract/connection.go
+++ b/tequilapi/contract/connection.go
@@ -29,18 +29,18 @@ import (
 var emptyAddress = common.Address{}
 
 // NewConnectionStatusDTO maps to API connection status.
-func NewConnectionStatusDTO(connection connection.Status) ConnectionStatusDTO {
+func NewConnectionStatusDTO(session connection.Status) ConnectionStatusDTO {
 	response := ConnectionStatusDTO{
-		Status:     string(connection.State),
-		ConsumerID: connection.ConsumerID.Address,
-		SessionID:  string(connection.SessionID),
+		Status:     string(session.State),
+		ConsumerID: session.ConsumerID.Address,
+		SessionID:  string(session.SessionID),
 	}
-	if connection.AccountantID != emptyAddress {
-		response.AccountantAddress = connection.AccountantID.Hex()
+	if session.AccountantID != emptyAddress {
+		response.AccountantAddress = session.AccountantID.Hex()
 	}
-	// nNne exists, for not started connection
-	if connection.Proposal.ProviderID != "" {
-		proposalRes := NewProposalDTO(connection.Proposal)
+	// None exists, for not started connection
+	if session.Proposal.ProviderID != "" {
+		proposalRes := NewProposalDTO(session.Proposal)
 		response.Proposal = &proposalRes
 	}
 	return response
@@ -66,12 +66,12 @@ type ConnectionStatusDTO struct {
 }
 
 // NewConnectionDTO maps to API connection.
-func NewConnectionDTO(connection connection.Status, statistics connection.Statistics, throughput bandwidth.Throughput, invoice crypto.Invoice) ConnectionDTO {
+func NewConnectionDTO(session connection.Status, statistics connection.Statistics, throughput bandwidth.Throughput, invoice crypto.Invoice) ConnectionDTO {
 	dto := ConnectionDTO{
-		ConnectionStatusDTO: NewConnectionStatusDTO(connection),
+		ConnectionStatusDTO: NewConnectionStatusDTO(session),
 	}
 	if !statistics.At.IsZero() {
-		statsDto := NewConnectionStatisticsDTO(connection, statistics, throughput, invoice)
+		statsDto := NewConnectionStatisticsDTO(session, statistics, throughput, invoice)
 		dto.Statistics = &statsDto
 	}
 	return dto
@@ -85,9 +85,9 @@ type ConnectionDTO struct {
 }
 
 // NewConnectionStatisticsDTO maps to API connection stats.
-func NewConnectionStatisticsDTO(connection connection.Status, statistics connection.Statistics, throughput bandwidth.Throughput, invoice crypto.Invoice) ConnectionStatisticsDTO {
+func NewConnectionStatisticsDTO(session connection.Status, statistics connection.Statistics, throughput bandwidth.Throughput, invoice crypto.Invoice) ConnectionStatisticsDTO {
 	return ConnectionStatisticsDTO{
-		Duration:           int(connection.Duration().Seconds()),
+		Duration:           int(session.Duration().Seconds()),
 		BytesSent:          statistics.BytesSent,
 		BytesReceived:      statistics.BytesReceived,
 		ThroughputSent:     datasize.BitSize(throughput.Up).Bits(),

--- a/tequilapi/contract/identity.go
+++ b/tequilapi/contract/identity.go
@@ -90,3 +90,9 @@ type IdentityRegistrationResponse struct {
 	// Returns true if identity is registered in payments smart contract
 	Registered bool `json:"registered"`
 }
+
+// ListProposalsResponse holds list of proposals.
+// swagger:model ListProposalsResponse
+type ListProposalsResponse struct {
+	Proposals []*ProposalDTO `json:"proposals"`
+}

--- a/tequilapi/contract/identity.go
+++ b/tequilapi/contract/identity.go
@@ -67,20 +67,50 @@ func NewIdentityListResponse(ids []identity.Identity) ListIdentitiesResponse {
 	return result
 }
 
-// IdentityRequest request used for identity actions.
-// swagger:model IdentityRequestDTO
-type IdentityRequest struct {
+// IdentityCreateRequest request used for new identity creation.
+// swagger:model IdentityCreateRequestDTO
+type IdentityCreateRequest struct {
+	Passphrase *string `json:"passphrase"`
+}
+
+// Validate validates fields in request
+func (r IdentityCreateRequest) Validate() *validation.FieldErrorMap {
+	errors := validation.NewErrorMap()
+	if r.Passphrase == nil {
+		errors.ForField("passphrase").AddError("required", "Field is required")
+	}
+	return errors
+}
+
+// IdentityUnlockRequest request used for identity unlocking.
+// swagger:model IdentityUnlockRequestDTO
+type IdentityUnlockRequest struct {
+	Passphrase *string `json:"passphrase"`
+}
+
+// Validate validates fields in request
+func (r IdentityUnlockRequest) Validate() *validation.FieldErrorMap {
+	errors := validation.NewErrorMap()
+	if r.Passphrase == nil {
+		errors.ForField("passphrase").AddError("required", "Field is required")
+	}
+	return errors
+}
+
+// IdentityCurrentRequest request used for current identity remembering.
+// swagger:model IdentityCurrentRequestDTO
+type IdentityCurrentRequest struct {
 	Address    *string `json:"id"`
 	Passphrase *string `json:"passphrase"`
 }
 
-// ValidateIdentityRequest validates request.
-func ValidateIdentityRequest(req IdentityRequest) (errors *validation.FieldErrorMap) {
-	errors = validation.NewErrorMap()
-	if req.Passphrase == nil {
+// Validate validates fields in request
+func (r IdentityCurrentRequest) Validate() *validation.FieldErrorMap {
+	errors := validation.NewErrorMap()
+	if r.Passphrase == nil {
 		errors.ForField("passphrase").AddError("required", "Field is required")
 	}
-	return
+	return errors
 }
 
 // IdentityRegistrationResponse represents registration status and needed data for registering of given identity

--- a/tequilapi/contract/identity.go
+++ b/tequilapi/contract/identity.go
@@ -94,5 +94,5 @@ type IdentityRegistrationResponse struct {
 // ListProposalsResponse holds list of proposals.
 // swagger:model ListProposalsResponse
 type ListProposalsResponse struct {
-	Proposals []*ProposalDTO `json:"proposals"`
+	Proposals []ProposalDTO `json:"proposals"`
 }

--- a/tequilapi/contract/proposal.go
+++ b/tequilapi/contract/proposal.go
@@ -24,8 +24,8 @@ import (
 )
 
 // NewProposalDTO maps to API service proposal.
-func NewProposalDTO(p market.ServiceProposal) *ProposalDTO {
-	return &ProposalDTO{
+func NewProposalDTO(p market.ServiceProposal) ProposalDTO {
+	return ProposalDTO{
 		ID:          p.ID,
 		ProviderID:  p.ProviderID,
 		ServiceType: p.ServiceType,

--- a/tequilapi/contract/proposal.go
+++ b/tequilapi/contract/proposal.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+import (
+	"github.com/mysteriumnetwork/node/core/quality"
+	"github.com/mysteriumnetwork/node/market"
+	"github.com/mysteriumnetwork/node/money"
+)
+
+// NewProposalDTO maps to API service proposal.
+func NewProposalDTO(p market.ServiceProposal) *ProposalDTO {
+	return &ProposalDTO{
+		ID:          p.ID,
+		ProviderID:  p.ProviderID,
+		ServiceType: p.ServiceType,
+		ServiceDefinition: ServiceDefinitionDTO{
+			LocationOriginate: ServiceLocationDTO{
+				Continent: p.ServiceDefinition.GetLocation().Continent,
+				Country:   p.ServiceDefinition.GetLocation().Country,
+				City:      p.ServiceDefinition.GetLocation().City,
+
+				ASN:      p.ServiceDefinition.GetLocation().ASN,
+				ISP:      p.ServiceDefinition.GetLocation().ISP,
+				NodeType: p.ServiceDefinition.GetLocation().NodeType,
+			},
+		},
+		AccessPolicies: p.AccessPolicies,
+		PaymentMethod: PaymentMethodDTO{
+			Type:  p.PaymentMethod.GetType(),
+			Price: p.PaymentMethod.GetPrice(),
+			Rate: PaymentRateDTO{
+				PerSeconds: uint64(p.PaymentMethod.GetRate().PerTime.Seconds()),
+				PerBytes:   p.PaymentMethod.GetRate().PerByte,
+			},
+		},
+	}
+}
+
+// ProposalDTO holds service proposal details.
+// swagger:model ProposalDTO
+type ProposalDTO struct {
+	// per provider unique serial number of service description provided
+	// example: 5
+	ID int `json:"id"`
+
+	// provider who offers service
+	// example: 0x0000000000000000000000000000000000000001
+	ProviderID string `json:"provider_id"`
+
+	// type of service provider offers
+	// example: openvpn
+	ServiceType string `json:"service_type"`
+
+	// qualitative service definition
+	ServiceDefinition ServiceDefinitionDTO `json:"service_definition"`
+
+	// Metrics of the service
+	Metrics *ProposalMetricsDTO `json:"metrics,omitempty"`
+
+	// AccessPolicies
+	AccessPolicies *[]market.AccessPolicy `json:"access_policies,omitempty"`
+
+	// PaymentMethod
+	PaymentMethod PaymentMethodDTO `json:"payment_method"`
+}
+
+// ServiceDefinitionDTO holds specific service details.
+// swagger:model ServiceDefinitionDTO
+type ServiceDefinitionDTO struct {
+	LocationOriginate ServiceLocationDTO `json:"location_originate"`
+}
+
+// ServiceLocationDTO holds service location metadata.
+// swagger:model ServiceLocationDTO
+type ServiceLocationDTO struct {
+	// example: EU
+	Continent string `json:"continent,omitempty"`
+	// example: NL
+	Country string `json:"country,omitempty"`
+	// example: Amsterdam
+	City string `json:"city,omitempty"`
+
+	// Autonomous System Number
+	// example: 00001
+	ASN int `json:"asn"`
+	// example: Telia Lietuva, AB
+	ISP string `json:"isp,omitempty"`
+	// example: residential
+	NodeType string `json:"node_type,omitempty"`
+}
+
+// ProposalMetricsDTO holds proposal quality metrics from Quality Oracle.
+// swagger:model ProposalMetricsDTO
+type ProposalMetricsDTO struct {
+	ConnectCount quality.ConnectCount `json:"connect_count"`
+}
+
+// PaymentMethodDTO holds payment method details.
+// swagger:model PaymentMethodDTO
+type PaymentMethodDTO struct {
+	Type  string         `json:"type"`
+	Price money.Money    `json:"price"`
+	Rate  PaymentRateDTO `json:"rate"`
+}
+
+// PaymentRateDTO holds payment frequencies.
+// swagger:model PaymentRateDTO
+type PaymentRateDTO struct {
+	PerSeconds uint64 `json:"per_seconds"`
+	PerBytes   uint64 `json:"per_bytes"`
+}

--- a/tequilapi/contract/proposal.go
+++ b/tequilapi/contract/proposal.go
@@ -18,6 +18,8 @@
 package contract
 
 import (
+	"fmt"
+
 	"github.com/mysteriumnetwork/node/core/quality"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
@@ -41,13 +43,18 @@ func NewProposalDTO(p market.ServiceProposal) ProposalDTO {
 			},
 		},
 		AccessPolicies: p.AccessPolicies,
-		PaymentMethod: PaymentMethodDTO{
-			Type:  p.PaymentMethod.GetType(),
-			Price: p.PaymentMethod.GetPrice(),
-			Rate: PaymentRateDTO{
-				PerSeconds: uint64(p.PaymentMethod.GetRate().PerTime.Seconds()),
-				PerBytes:   p.PaymentMethod.GetRate().PerByte,
-			},
+		PaymentMethod:  NewPaymentMethodDTO(p.PaymentMethod),
+	}
+}
+
+// NewPaymentMethodDTO maps to API payment method.
+func NewPaymentMethodDTO(m market.PaymentMethod) PaymentMethodDTO {
+	return PaymentMethodDTO{
+		Type:  m.GetType(),
+		Price: m.GetPrice(),
+		Rate: PaymentRateDTO{
+			PerSeconds: uint64(m.GetRate().PerTime.Seconds()),
+			PerBytes:   m.GetRate().PerByte,
 		},
 	}
 }
@@ -78,6 +85,10 @@ type ProposalDTO struct {
 
 	// PaymentMethod
 	PaymentMethod PaymentMethodDTO `json:"payment_method"`
+}
+
+func (p ProposalDTO) String() string {
+	return fmt.Sprintf("Id: %d , Provider: %s, Country: %s", p.ID, p.ProviderID, p.ServiceDefinition.LocationOriginate.Country)
 }
 
 // ServiceDefinitionDTO holds specific service details.

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -97,7 +97,7 @@ type connectionResponse struct {
 	SessionID string `json:"session_id,omitempty"`
 
 	// example: {"id":1,"provider_id":"0x71ccbdee7f6afe85a5bc7106323518518cd23b94","servcie_type":"openvpn","service_definition":{"location_originate":{"asn":"","country":"CA"}}}
-	Proposal *proposalDTO `json:"proposal,omitempty"`
+	Proposal *contract.ProposalDTO `json:"proposal,omitempty"`
 }
 
 // swagger:model IPDTO
@@ -364,7 +364,7 @@ func toConnectionResponse(status connection.Status) connectionResponse {
 	}
 
 	if status.Proposal.ProviderID != "" {
-		proposalRes := proposalToRes(status.Proposal)
+		proposalRes := contract.NewProposalDTO(status.Proposal)
 		response.Proposal = proposalRes
 	}
 	return response

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -365,7 +365,7 @@ func toConnectionResponse(status connection.Status) connectionResponse {
 
 	if status.Proposal.ProviderID != "" {
 		proposalRes := contract.NewProposalDTO(status.Proposal)
-		response.Proposal = proposalRes
+		response.Proposal = &proposalRes
 	}
 	return response
 }

--- a/tequilapi/endpoints/connection_location.go
+++ b/tequilapi/endpoints/connection_location.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
@@ -72,7 +71,6 @@ func locationToRes(l location.Location) locationResponse {
 
 // ConnectionLocationEndpoint struct represents /connection/location resource and it's subresources.
 type ConnectionLocationEndpoint struct {
-	manager                connection.Manager
 	ipResolver             ip.Resolver
 	locationResolver       location.Resolver
 	locationOriginResolver location.OriginResolver
@@ -80,13 +78,11 @@ type ConnectionLocationEndpoint struct {
 
 // NewConnectionLocationEndpoint creates and returns connection location endpoint.
 func NewConnectionLocationEndpoint(
-	manager connection.Manager,
 	ipResolver ip.Resolver,
 	locationResolver location.Resolver,
 	locationOriginResolver location.OriginResolver,
 ) *ConnectionLocationEndpoint {
 	return &ConnectionLocationEndpoint{
-		manager:                manager,
 		ipResolver:             ipResolver,
 		locationResolver:       locationResolver,
 		locationOriginResolver: locationOriginResolver,
@@ -175,13 +171,12 @@ func (le *ConnectionLocationEndpoint) GetOriginLocation(writer http.ResponseWrit
 // AddRoutesForConnectionLocation adds connection location routes to given router
 func AddRoutesForConnectionLocation(
 	router *httprouter.Router,
-	manager connection.Manager,
 	ipResolver ip.Resolver,
 	locationResolver location.Resolver,
 	locationOriginResolver location.OriginResolver,
 ) {
 
-	connectionLocationEndpoint := NewConnectionLocationEndpoint(manager, ipResolver, locationResolver, locationOriginResolver)
+	connectionLocationEndpoint := NewConnectionLocationEndpoint(ipResolver, locationResolver, locationOriginResolver)
 	router.GET("/connection/ip", connectionLocationEndpoint.GetConnectionIP)
 	router.GET("/connection/location", connectionLocationEndpoint.GetConnectionLocation)
 	router.GET("/location", connectionLocationEndpoint.GetOriginLocation)

--- a/tequilapi/endpoints/connection_location_test.go
+++ b/tequilapi/endpoints/connection_location_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/pkg/errors"
@@ -70,11 +69,6 @@ func TestAddRoutesForConnectionLocationAddsRoutes(t *testing.T) {
 	locationResolver := &locationResolverMock{ip: "1.2.3.4", ipOrigin: "1.2.3.1"}
 	AddRoutesForConnectionLocation(
 		router,
-		&mockConnectionManager{
-			onStatusReturn: connection.Status{
-				State: connection.Connected,
-			},
-		},
 		ip.NewResolverMock("123.123.123.123"),
 		locationResolver,
 		locationResolver,
@@ -135,9 +129,8 @@ func TestAddRoutesForConnectionLocationAddsRoutes(t *testing.T) {
 }
 
 func TestGetIPEndpointSucceeds(t *testing.T) {
-	manager := mockConnectionManager{}
 	ipResolver := ip.NewResolverMock("123.123.123.123")
-	endpoint := NewConnectionLocationEndpoint(&manager, ipResolver, nil, nil)
+	endpoint := NewConnectionLocationEndpoint(ipResolver, nil, nil)
 	resp := httptest.NewRecorder()
 
 	endpoint.GetConnectionIP(resp, nil, nil)
@@ -153,9 +146,8 @@ func TestGetIPEndpointSucceeds(t *testing.T) {
 }
 
 func TestGetIPEndpointReturnsErrorWhenIPDetectionFails(t *testing.T) {
-	manager := mockConnectionManager{}
 	ipResolver := ip.NewResolverMockFailing(errors.New("fake error"))
-	endpoint := NewConnectionLocationEndpoint(&manager, ipResolver, nil, nil)
+	endpoint := NewConnectionLocationEndpoint(ipResolver, nil, nil)
 	resp := httptest.NewRecorder()
 
 	endpoint.GetConnectionIP(resp, nil, nil)

--- a/tequilapi/endpoints/identities.go
+++ b/tequilapi/endpoints/identities.go
@@ -78,7 +78,7 @@ func (endpoint *identitiesAPI) List(resp http.ResponseWriter, _ *http.Request, _
 //     name: body
 //     description: Parameter in body (passphrase) required for creating new identity
 //     schema:
-//       $ref: "#/definitions/IdentityRequestDTO"
+//       $ref: "#/definitions/IdentityCurrentRequestDTO"
 // responses:
 //   200:
 //     description: Unlocked identity returned
@@ -97,15 +97,14 @@ func (endpoint *identitiesAPI) List(resp http.ResponseWriter, _ *http.Request, _
 //     schema:
 //       "$ref": "#/definitions/ErrorMessageDTO"
 func (endpoint *identitiesAPI) Current(resp http.ResponseWriter, request *http.Request, params httprouter.Params) {
-	var req contract.IdentityRequest
+	var req contract.IdentityCurrentRequest
 	err := json.NewDecoder(request.Body).Decode(&req)
 	if err != nil {
 		utils.SendError(resp, err, http.StatusBadRequest)
 		return
 	}
 
-	errorMap := contract.ValidateIdentityRequest(req)
-	if errorMap.HasErrors() {
+	if errorMap := req.Validate(); errorMap.HasErrors() {
 		utils.SendValidationErrorMessage(resp, errorMap)
 		return
 	}
@@ -134,7 +133,7 @@ func (endpoint *identitiesAPI) Current(resp http.ResponseWriter, request *http.R
 //     name: body
 //     description: Parameter in body (passphrase) required for creating new identity
 //     schema:
-//       $ref: "#/definitions/IdentityRequestDTO"
+//       $ref: "#/definitions/IdentityCreateRequestDTO"
 // responses:
 //   200:
 //     description: Identity created
@@ -153,15 +152,14 @@ func (endpoint *identitiesAPI) Current(resp http.ResponseWriter, request *http.R
 //     schema:
 //       "$ref": "#/definitions/ErrorMessageDTO"
 func (endpoint *identitiesAPI) Create(resp http.ResponseWriter, httpReq *http.Request, _ httprouter.Params) {
-	var req contract.IdentityRequest
+	var req contract.IdentityCreateRequest
 	err := json.NewDecoder(httpReq.Body).Decode(&req)
 	if err != nil {
 		utils.SendError(resp, err, http.StatusBadRequest)
 		return
 	}
 
-	errorMap := contract.ValidateIdentityRequest(req)
-	if errorMap.HasErrors() {
+	if errorMap := req.Validate(); errorMap.HasErrors() {
 		utils.SendValidationErrorMessage(resp, errorMap)
 		return
 	}
@@ -190,7 +188,7 @@ func (endpoint *identitiesAPI) Create(resp http.ResponseWriter, httpReq *http.Re
 //   name: body
 //   description: Parameter in body (passphrase) required for unlocking identity
 //   schema:
-//     $ref: "#/definitions/IdentityRequestDTO"
+//     $ref: "#/definitions/IdentityUnlockRequestDTO"
 // responses:
 //   202:
 //     description: Identity unlocked
@@ -214,15 +212,14 @@ func (endpoint *identitiesAPI) Unlock(resp http.ResponseWriter, httpReq *http.Re
 		return
 	}
 
-	var req contract.IdentityRequest
+	var req contract.IdentityUnlockRequest
 	err = json.NewDecoder(httpReq.Body).Decode(&req)
 	if err != nil {
 		utils.SendError(resp, err, http.StatusBadRequest)
 		return
 	}
 
-	errorMap := contract.ValidateIdentityRequest(req)
-	if errorMap.HasErrors() {
+	if errorMap := req.Validate(); errorMap.HasErrors() {
 		utils.SendValidationErrorMessage(resp, errorMap)
 		return
 	}

--- a/tequilapi/endpoints/proposals.go
+++ b/tequilapi/endpoints/proposals.go
@@ -122,7 +122,7 @@ func (pe *proposalsEndpoint) List(resp http.ResponseWriter, req *http.Request, p
 		return
 	}
 
-	proposalsRes := contract.ListProposalsResponse{Proposals: []*contract.ProposalDTO{}}
+	proposalsRes := contract.ListProposalsResponse{Proposals: []contract.ProposalDTO{}}
 	for _, p := range proposals {
 		proposalsRes.Proposals = append(proposalsRes.Proposals, contract.NewProposalDTO(p))
 	}
@@ -151,16 +151,16 @@ func AddRoutesForProposals(router *httprouter.Router, proposalRepository proposa
 }
 
 // addProposalMetrics adds quality metrics to proposals.
-func addProposalMetrics(proposals []*contract.ProposalDTO, metrics []quality.ConnectMetric) {
+func addProposalMetrics(proposals []contract.ProposalDTO, metrics []quality.ConnectMetric) {
 	// Convert metrics slice to map for fast lookup.
 	metricsMap := map[string]quality.ConnectMetric{}
 	for _, m := range metrics {
 		metricsMap[m.ProposalID.ProviderID+m.ProposalID.ServiceType] = m
 	}
 
-	for _, p := range proposals {
+	for i, p := range proposals {
 		if mc, ok := metricsMap[p.ProviderID+p.ServiceType]; ok {
-			p.Metrics = &contract.ProposalMetricsDTO{ConnectCount: mc.ConnectCount}
+			proposals[i].Metrics = &contract.ProposalMetricsDTO{ConnectCount: mc.ConnectCount}
 		}
 	}
 }

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -351,7 +351,7 @@ func toServiceInfoResponse(id service.ID, instance *service.Instance) serviceInf
 		Type:       proposal.ServiceType,
 		Options:    instance.Options(),
 		Status:     string(instance.State()),
-		Proposal:   *contract.NewProposalDTO(instance.Proposal()),
+		Proposal:   contract.NewProposalDTO(instance.Proposal()),
 	}
 }
 

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/services"
 	"github.com/mysteriumnetwork/node/session/pingpong"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 	"github.com/mysteriumnetwork/node/tequilapi/validation"
 	"github.com/rs/zerolog/log"
@@ -55,7 +56,7 @@ type serviceRequest struct {
 	AccessPolicies accessPoliciesRequest `json:"access_policies"`
 
 	// PaymentMethod describes payment options that should be used for service creation.
-	PaymentMethod paymentMethodRes `json:"payment_method"`
+	PaymentMethod contract.PaymentMethodDTO `json:"payment_method"`
 }
 
 // accessPolicy represents the access controls
@@ -87,7 +88,7 @@ type serviceInfo struct {
 	// example: Running
 	Status string `json:"status"`
 
-	Proposal proposalDTO `json:"proposal"`
+	Proposal contract.ProposalDTO `json:"proposal"`
 
 	AccessPolicies *[]market.AccessPolicy `json:"access_policies,omitempty"`
 }
@@ -289,11 +290,11 @@ func AddRoutesForService(router *httprouter.Router, serviceManager ServiceManage
 
 func (se *ServiceEndpoint) toServiceRequest(req *http.Request) (serviceRequest, error) {
 	jsonData := struct {
-		ProviderID     string                `json:"provider_id"`
-		Type           string                `json:"type"`
-		Options        *json.RawMessage      `json:"options"`
-		AccessPolicies accessPoliciesRequest `json:"access_policies"`
-		PaymentMethod  paymentMethodRes      `json:"payment_method"`
+		ProviderID     string                    `json:"provider_id"`
+		Type           string                    `json:"type"`
+		Options        *json.RawMessage          `json:"options"`
+		AccessPolicies accessPoliciesRequest     `json:"access_policies"`
+		PaymentMethod  contract.PaymentMethodDTO `json:"payment_method"`
 	}{
 		AccessPolicies: accessPoliciesRequest{
 			Ids: services.SharedConfiguredOptions().AccessPolicyList,
@@ -350,7 +351,7 @@ func toServiceInfoResponse(id service.ID, instance *service.Instance) serviceInf
 		Type:       proposal.ServiceType,
 		Options:    instance.Options(),
 		Status:     string(instance.State()),
-		Proposal:   *proposalToRes(instance.Proposal()),
+		Proposal:   *contract.NewProposalDTO(instance.Proposal()),
 	}
 }
 

--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -220,7 +220,7 @@ type consumerStateRes struct {
 type consumerConnectionRes struct {
 	State      connection.State                  `json:"state"`
 	Statistics *contract.ConnectionStatisticsDTO `json:"statistics,omitempty"`
-	Proposal   *proposalDTO                      `json:"proposal,omitempty"`
+	Proposal   *contract.ProposalDTO             `json:"proposal,omitempty"`
 }
 
 func mapState(event stateEvent.State) stateRes {
@@ -245,7 +245,7 @@ func mapState(event stateEvent.State) stateRes {
 	}
 	// If none exists, conn manager still has empty proposal
 	if event.Connection.Session.Proposal.ProviderID != "" {
-		connectionRes.Proposal = proposalToRes(event.Connection.Session.Proposal)
+		connectionRes.Proposal = contract.NewProposalDTO(event.Connection.Session.Proposal)
 	}
 
 	res := stateRes{

--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -245,7 +245,8 @@ func mapState(event stateEvent.State) stateRes {
 	}
 	// If none exists, conn manager still has empty proposal
 	if event.Connection.Session.Proposal.ProviderID != "" {
-		connectionRes.Proposal = contract.NewProposalDTO(event.Connection.Session.Proposal)
+		proposalRes := contract.NewProposalDTO(event.Connection.Session.Proposal)
+		connectionRes.Proposal = &proposalRes
 	}
 
 	res := stateRes{

--- a/tequilapi/endpoints/sse_handler_test.go
+++ b/tequilapi/endpoints/sse_handler_test.go
@@ -138,7 +138,7 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
     "sessions": null,
     "consumer": {
       "connection": {
-        "state": ""
+        "status": ""
       }
     },
     "identities": []
@@ -168,7 +168,7 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
     "sessions": null,
     "consumer": {
       "connection": {
-        "state": ""
+        "status": ""
       }
     },
     "identities": []
@@ -205,7 +205,7 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
     "sessions": null,
     "consumer": {
       "connection": {
-        "state": "Connecting"
+        "status": "Connecting"
       }
     },
     "identities": [


### PR DESCRIPTION
Updates: #1779

Added accountant address used in connection 
1 SSE field changed from `consumer.connection.state` ->  `consumer.connection.status`
