### PR TITLE
Fix panic in boltdb on golang 1.14.2

### DIFF
--- a/core/storage/boltdb/boltdbtest/db.go
+++ b/core/storage/boltdb/boltdbtest/db.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/asdine/storm"
+	"github.com/asdine/storm/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/core/storage/boltdb/migrations/migration.go
+++ b/core/storage/boltdb/migrations/migration.go
@@ -20,7 +20,7 @@ package migrations
 import (
 	"time"
 
-	"github.com/asdine/storm"
+	"github.com/asdine/storm/v3"
 )
 
 // Migration represents a migration we want to run on bolt db

--- a/core/storage/boltdb/migrations/session-to-history.go
+++ b/core/storage/boltdb/migrations/session-to-history.go
@@ -20,7 +20,7 @@ package migrations
 import (
 	"time"
 
-	"github.com/asdine/storm"
+	"github.com/asdine/storm/v3"
 	consumer_session "github.com/mysteriumnetwork/node/consumer/session"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/identity"

--- a/core/storage/boltdb/migrator_test.go
+++ b/core/storage/boltdb/migrator_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/asdine/storm"
+	"github.com/asdine/storm/v3"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb/boltdbtest"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb/migrations"
 	"github.com/stretchr/testify/assert"

--- a/core/storage/boltdb/storage.go
+++ b/core/storage/boltdb/storage.go
@@ -20,7 +20,7 @@ package boltdb
 import (
 	"path/filepath"
 
-	"github.com/asdine/storm"
+	"github.com/asdine/storm/v3"
 	"github.com/pkg/errors"
 )
 

--- a/core/storage/errors.go
+++ b/core/storage/errors.go
@@ -17,7 +17,7 @@
 
 package storage
 
-import "github.com/asdine/storm"
+import "github.com/asdine/storm/v3"
 
 var (
 	// ErrNotFound not found

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,10 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/DataDog/zstd v1.4.1 // indirect
-	github.com/Sereal/Sereal v0.0.0-20190618215532-0b8ac451a863 // indirect
 	github.com/andybalholm/brotli v1.0.0 // indirect
 	github.com/arthurkiller/rollingwriter v1.1.2
 	github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05
-	github.com/asdine/storm v2.1.2+incompatible
+	github.com/asdine/storm/v3 v3.1.1
 	github.com/awnumar/memguard v0.21.0
 	github.com/aws/aws-sdk-go-v2 v0.15.0
 	github.com/cenkalti/backoff/v4 v4.0.0
@@ -65,14 +63,12 @@ require (
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
 	github.com/stretchr/testify v1.4.1-0.20200130210847-518a1491c713
 	github.com/urfave/cli/v2 v2.1.1
-	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/xtaci/kcp-go/v5 v5.5.8
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
-	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
-	golang.zx2c4.com/wireguard v0.0.20200121
+	golang.org/x/sys v0.0.0-20200408040146-ea54a3c99b9b
+	golang.zx2c4.com/wireguard v0.0.20200320
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200324154536-ceff61240acf
-	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/protobuf v1.20.1
 	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05/go.mod h1:JS7h
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/asdine/storm v2.1.2+incompatible h1:dczuIkyqwY2LrtXPz8ixMrU/OFgZp71kbKTHGrXYt/Q=
-github.com/asdine/storm v2.1.2+incompatible/go.mod h1:RarYDc9hq1UPLImuiXK3BIWPJLdIygvV3PsInK0FbVQ=
+github.com/asdine/storm/v3 v3.1.1 h1:5ESJvmcNhQQOFcvpxkIHcZs7mp8Z6XGdBqEoAgf+11g=
+github.com/asdine/storm/v3 v3.1.1/go.mod h1:LEpXwGt4pIqrE/XcTvCnZHT5MgZCV6Ub9q7yQzOFWr0=
 github.com/awnumar/memcall v0.0.0-20191004114545-73db50fd9f80 h1:8kObYoBO4LNmQ+fLiScBfxEdxF1w2MHlvH/lr9MLaTg=
 github.com/awnumar/memcall v0.0.0-20191004114545-73db50fd9f80/go.mod h1:S911igBPR9CThzd/hYQQmTc9SWNu3ZHIlCGaWsWsoJo=
 github.com/awnumar/memguard v0.21.0 h1:BZvZ69RXlIQPChLJnpJ0u5cIJQmsWLGfNa6XX5/UZGU=
@@ -667,6 +667,8 @@ github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxt
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
+go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1 h1:Sq1fR+0c58RME5EoqKdjkiQAmPjmfHlZOoRI6fTUOcs=
@@ -748,6 +750,7 @@ golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191003171128-d98b1b443823/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191105084925-a882066a44e0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -801,8 +804,10 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200408040146-ea54a3c99b9b h1:h03Ur1RlPrGTjua4koYdpGl8W0eYo8p1uI9w7RPlkdk=
+golang.org/x/sys v0.0.0-20200408040146-ea54a3c99b9b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -839,6 +844,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.zx2c4.com/wireguard v0.0.20200121 h1:vcswa5Q6f+sylDfjqyrVNNrjsFUUbPsgAQTBCAg/Qf8=
 golang.zx2c4.com/wireguard v0.0.20200121/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
+golang.zx2c4.com/wireguard v0.0.20200320 h1:1vE6zVeO7fix9cJX1Z9ZQ+ikPIIx7vIyU0o0tLDD88g=
+golang.zx2c4.com/wireguard v0.0.20200320/go.mod h1:lDian4Sw4poJ04SgHh35nzMVwGSYlPumkdnHcucAQoY=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200324154536-ceff61240acf h1:rWUZHukj3poXegPQMZOXgxjTGIBe3mLNHNVvL5DsHus=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200324154536-ceff61240acf/go.mod h1:UdS9frhv65KTfwxME1xE8+rHYoFpbm36gOud1GhBe9c=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=


### PR DESCRIPTION
```
fatal error: checkptr: unsafe pointer conversion

goroutine 43 [running]:
runtime.throw(0x4c9682e, 0x23)
	/usr/local/Cellar/go/1.14.2/libexec/src/runtime/panic.go:1116 +0x72 fp=0xc0000c13d8 sp=0xc0000c13a8 pc=0x4036da2
runtime.checkptrAlignment(0xc000312ed0, 0x4c20320, 0x1)
	/usr/local/Cellar/go/1.14.2/libexec/src/runtime/checkptr.go:20 +0xc9 fp=0xc0000c1408 sp=0xc0000c13d8 pc=0x4008a99
go.etcd.io/bbolt.(*Bucket).write(0xc0000c1580, 0x0, 0x0, 0x0)
	/Users/soffokl/go/pkg/mod/go.etcd.io/bbolt@v1.3.3/bucket.go:624 +0x15c fp=0xc0000c1470 sp=0xc0000c1408 pc=0x4225efc
go.etcd.io/bbolt.(*Bucket).CreateBucket(0xc0003d80f8, 0xc00031d400, 0xa, 0x10, 0xc00031d400, 0x4c82fc2, 0xa)
	/Users/soffokl/go/pkg/mod/go.etcd.io/bbolt@v1.3.3/bucket.go:181 +0x465 fp=0xc0000c1630 sp=0xc0000c1470 pc=0x4222345
go.etcd.io/bbolt.(*Bucket).CreateBucketIfNotExists(0xc0003d80f8, 0xc00031d400, 0xa, 0x10, 0xa, 0x10, 0x0)
	/Users/soffokl/go/pkg/mod/go.etcd.io/bbolt@v1.3.3/bucket.go:199 +0x5e fp=0xc0000c1698 sp=0xc0000c1630 pc=0x42226ee
go.etcd.io/bbolt.(*Tx).CreateBucketIfNotExists(...)
	/Users/soffokl/go/pkg/mod/go.etcd.io/bbolt@v1.3.3/tx.go:115
github.com/asdine/storm.(*node).CreateBucketIfNotExists(0xc000344e00, 0xc0003d80e0, 0x4c82fc2, 0xa, 0xc0003c63b8, 0x406d2dc, 0x40877ff)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/bucket.go:20 +0x263 fp=0xc0000c1738 sp=0xc0000c1698 pc=0x42cf1b3
github.com/asdine/storm.(*node).setBytes(0xc000344e00, 0xc0003d80e0, 0x4c82fc2, 0xa, 0xc00031d3d8, 0x7, 0x8, 0xc00031d3d0, 0x7, 0x8, ...)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/kv.go:77 +0x67 fp=0xc0000c17b8 sp=0xc0000c1738 pc=0x42d8a77
github.com/asdine/storm.(*node).SetBytes.func1(0xc0003d80e0, 0x0, 0x4035086)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/kv.go:72 +0x9b fp=0xc0000c1838 sp=0xc0000c17b8 pc=0x42eb4cb
github.com/asdine/storm.(*node).readWriteTx.func2(0xc0003d80e0, 0xc00031d301, 0xc0003d80e0)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/node.go:113 +0x47 fp=0xc0000c1870 sp=0xc0000c1838 pc=0x42eba27
go.etcd.io/bbolt.(*DB).Update(0xc0003c6200, 0xc0000c1968, 0x0, 0x0)
	/Users/soffokl/go/pkg/mod/go.etcd.io/bbolt@v1.3.3/db.go:694 +0xec fp=0xc0000c1918 sp=0xc0000c1870 pc=0x422ff8c
github.com/asdine/storm.(*node).readWriteTx(0xc000344e00, 0xc000304910, 0x4dd3620, 0xc0000b0040)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/node.go:112 +0x1c9 fp=0xc0000c1988 sp=0xc0000c1918 pc=0x42dac19
github.com/asdine/storm.(*node).SetBytes(0xc000344e00, 0x4c82fc2, 0xa, 0x4b5f800, 0x4db5da0, 0xc00031d3d0, 0x7, 0x8, 0xa, 0xc00031d3a0)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/kv.go:71 +0x226 fp=0xc0000c1a38 sp=0xc0000c1988 pc=0x42d88c6
github.com/asdine/storm.(*node).Set(0xc000344e00, 0x4c82fc2, 0xa, 0x4b5f800, 0x4db5da0, 0x4b5f800, 0x4db5db0, 0x4dc6460, 0xc0000a25b0)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/kv.go:125 +0x9a fp=0xc0000c1ab8 sp=0xc0000c1a38 pc=0x42d902a
github.com/asdine/storm.(*DB).checkVersion(0xc000320f60, 0x42, 0x180)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/storm.go:98 +0x195 fp=0xc0000c1b38 sp=0xc0000c1ab8 pc=0x42e9645
github.com/asdine/storm.Open(0xc000380910, 0x42, 0x0, 0x0, 0x0, 0x1, 0xc000380910, 0x42)
	/Users/soffokl/go/pkg/mod/github.com/asdine/storm@v2.1.2+incompatible/storm.go:65 +0x41d fp=0xc0000c1c38 sp=0xc0000c1b38 pc=0x42e906d
github.com/mysteriumnetwork/node/core/storage/boltdb.openDB(0xc000380910, 0x42, 0x2, 0xc000380910, 0x42)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/core/storage/boltdb/storage.go:39 +0x58 fp=0xc0000c1ca8 sp=0xc0000c1c38 pc=0x4a9e508
github.com/mysteriumnetwork/node/core/storage/boltdb.NewStorage(0xc00033c440, 0x3a, 0x0, 0x0, 0x0)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/core/storage/boltdb/storage.go:34 +0x9d fp=0xc0000c1d18 sp=0xc0000c1ca8 pc=0x4a9e44d
github.com/mysteriumnetwork/node/core/storage/boltdb.createDBAndMigrator(0xc000316ea0, 0xc00033c440, 0x3a, 0x4f4c5b0, 0x4f4c610)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/core/storage/boltdb/migrator_test.go:52 +0x4a fp=0xc0000c1d88 sp=0xc0000c1d18 pc=0x4a9f46a
github.com/mysteriumnetwork/node/core/storage/boltdb.TestSavesMigrationRun(0xc000316ea0)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/core/storage/boltdb/migrator_test.go:62 +0xe0 fp=0xc0000c1ed0 sp=0xc0000c1d88 pc=0x4a9f650
testing.tRunner(0xc000316ea0, 0x4caeb60)
	/usr/local/Cellar/go/1.14.2/libexec/src/testing/testing.go:991 +0x1ec fp=0xc0000c1fd0 sp=0xc0000c1ed0 pc=0x418718c
runtime.goexit()
	/usr/local/Cellar/go/1.14.2/libexec/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0000c1fd8 sp=0xc0000c1fd0 pc=0x406b611
created by testing.(*T).Run
	/usr/local/Cellar/go/1.14.2/libexec/src/testing/testing.go:1042 +0x661
```