### PR TITLE
Fixes NAT e2e

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -843,7 +843,7 @@ func (di *Dependencies) handleConnStateChange() error {
 			di.QualityClient.Reconnect()
 			di.BrokerConnector.ReconnectAll()
 			if err := di.EtherClient.Reconnect(); err != nil {
-				log.Error().Msgf("Ethereum client failed to reconnect")
+				log.Error().Err(err).Msg("Ethereum client failed to reconnect")
 			}
 		}
 		latestState = e.State

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -182,22 +182,24 @@ func (cbt *ConsumerBalanceTracker) handleTopUpEvent(id string) {
 
 // ForceBalanceUpdate forces a balance update and returns the updated balance
 func (cbt *ConsumerBalanceTracker) ForceBalanceUpdate(id identity.Identity) uint64 {
+	fallback := cbt.GetBalance(id)
+
 	addr, err := cbt.channelAddressCalculator.GetChannelAddress(id)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not calculate channel address")
-		return 0
+		return fallback
 	}
 
 	cc, err := cbt.consumerBalanceChecker.GetConsumerChannel(addr, cbt.mystSCAddress)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not get consumer channel")
-		return 0
+		return fallback
 	}
 
 	grandTotal, err := cbt.consumerGrandTotalsStorage.Get(id, cbt.accountantAddress)
 	if err != nil && err != ErrNotFound {
 		log.Error().Err(err).Msg("Could not get consumer grand total promised")
-		return 0
+		return fallback
 	}
 
 	cbt.balancesLock.Lock()


### PR DESCRIPTION
Will fall back to previous balance in case there's an issue with force refresh.

It seems that the reconnect does not work reliably for ethereum client though as this was caused by the following chain:

disconnect event emitted -> disconnect event causes eth client reconnect -> client fails to reconnect(a log is printed) -> tests call force balance update from consumer through tequila -> a 0 value is returned on force balance refresh due to the failed eth client request.