### PR TITLE
Add location and ip detection retries

### DIFF
--- a/config/flags_location.go
+++ b/config/flags_location.go
@@ -28,7 +28,7 @@ var (
 	FlagIPDetectorURL = cli.StringFlag{
 		Name:  "ip-detector",
 		Usage: "Address (URL form) of IP detection service",
-		Value: "https://testnet-location.mysterium.network/api/v1/location",
+		Value: "https://testnet-location.mysterium.network/api/v1/ip",
 	}
 	// FlagLocationType location detector type.
 	FlagLocationType = cli.StringFlag{

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -117,8 +117,8 @@ func (tc *testContext) SetupTest() {
 
 	tc.config = Config{
 		IPCheck: IPCheckConfig{
-			MaxAttempts:             3,
-			SleepDurationAfterCheck: 1 * time.Millisecond,
+			MaxAttempts:             2,
+			SleepDurationAfterCheck: time.Nanosecond,
 		},
 		KeepAlive: KeepAliveConfig{
 			SendInterval:    100 * time.Millisecond,

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -102,7 +102,7 @@ func DefaultNodeOptions() *MobileNodeOptions {
 		EtherClientRPC:                  metadata.TestnetDefinition.EtherClientRPC,
 		FeedbackURL:                     "https://feedback.mysterium.network",
 		QualityOracleURL:                "https://quality.mysterium.network/api/v1",
-		IPDetectorURL:                   "https://api.ipify.org/?format=json",
+		IPDetectorURL:                   "https://testnet-location.mysterium.network/api/v1/ip",
 		LocationDetectorURL:             "https://testnet-location.mysterium.network/api/v1/location",
 		TransactorEndpointAddress:       metadata.TestnetDefinition.TransactorAddress,
 		TransactorRegistryAddress:       metadata.TestnetDefinition.RegistryAddress,

--- a/requests/request.go
+++ b/requests/request.go
@@ -19,6 +19,7 @@ package requests
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,7 +39,15 @@ func NewGetRequest(apiURI, path string, params url.Values) (*http.Request, error
 	if params != nil {
 		path = fmt.Sprintf("%v?%v", path, params.Encode())
 	}
-	return newRequest(http.MethodGet, apiURI, path, nil)
+	return newRequest(context.Background(), http.MethodGet, apiURI, path, nil)
+}
+
+// NewGetRequestWithContext generates http Get request
+func NewGetRequestWithContext(ctx context.Context, apiURI, path string, params url.Values) (*http.Request, error) {
+	if params != nil {
+		path = fmt.Sprintf("%v?%v", path, params.Encode())
+	}
+	return newRequest(ctx, http.MethodGet, apiURI, path, nil)
 }
 
 // NewPostRequest generates http Post request
@@ -47,7 +56,7 @@ func NewPostRequest(apiURI, path string, requestBody interface{}) (*http.Request
 	if err != nil {
 		return nil, err
 	}
-	return newRequest(http.MethodPost, apiURI, path, encodedBody)
+	return newRequest(context.Background(), http.MethodPost, apiURI, path, encodedBody)
 }
 
 // NewSignedRequest signs payload and generates http request
@@ -66,7 +75,7 @@ func NewSignedRequest(httpMethod, apiURI, path string, requestBody interface{}, 
 		return nil, err
 	}
 
-	req, err := newRequest(httpMethod, apiURI, path, encodedBody)
+	req, err := newRequest(context.Background(), httpMethod, apiURI, path, encodedBody)
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +104,12 @@ func encodeToJSON(value interface{}) ([]byte, error) {
 	return json.Marshal(value)
 }
 
-func newRequest(method, apiURI, path string, body []byte) (*http.Request, error) {
+func newRequest(ctx context.Context, method, apiURI, path string, body []byte) (*http.Request, error) {
 	url := apiURI
 	if len(path) > 0 {
 		url = fmt.Sprintf("%v/%v", apiURI, path)
 	}
-	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -67,8 +67,6 @@ var ErrExchangeValidationFailed = errors.New("exchange validation failed")
 // ErrConsumerNotRegistered represents the error that the consumer is not registered
 var ErrConsumerNotRegistered = errors.New("consumer not registered")
 
-const providerFirstInvoiceTolerance = 0.8
-
 // PeerInvoiceSender allows to send invoices.
 type PeerInvoiceSender interface {
 	Send(crypto.Invoice) error
@@ -508,7 +506,7 @@ func (it *InvoiceTracker) sendInvoice() error {
 	// To compensate for this, be a bit more lenient on the first invoice - ask for a reduced amount.
 	// Over the long run, this becomes redundant as the difference should become miniscule.
 	if it.lastExchangeMessage.AgreementTotal == 0 {
-		shouldBe = uint64(math.Trunc(float64(shouldBe) * providerFirstInvoiceTolerance))
+		shouldBe = uint64(math.Min(float64(1), float64(shouldBe)))
 		log.Debug().Msgf("Being lenient for the first payment, asking for %v", shouldBe)
 	}
 


### PR DESCRIPTION
1. Add retries for ip and location detection. 
2. Use separate https://testnet-location.mysterium.network/api/v1/ip endpoint for public ip detection.
3. Send first invoice with fixed value = 1.
