### PR TITLE
Faster e2e implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ tequilapi_spec.json
 /e2e/myst-provider/db
 tequilapi.json
 e2e/myst-provider/*.log.*
+e2e/prometheus/data
 mage_output_file.go
 coverage.txt
 localnet/volume/consumer
 localnet/volume/provider/db
+deployer

--- a/bin/docker/alpine-prebuilt/Dockerfile
+++ b/bin/docker/alpine-prebuilt/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.11
 
 # Install packages
 RUN apk add --update --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv

--- a/bin/docker/alpine-prebuilt/Dockerfile
+++ b/bin/docker/alpine-prebuilt/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.6
+
+# Install packages
+RUN apk add --update --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv
+
+COPY bin/helpers/prepare-run-env.sh /usr/local/bin/prepare-run-env.sh
+COPY bin/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+COPY bin/package/config/common /etc/mysterium-node
+COPY bin/package/config/linux /etc/mysterium-node
+
+COPY ./build/e2e/myst /usr/bin/myst
+

--- a/bin/docker/alpine/Dockerfile
+++ b/bin/docker/alpine/Dockerfile
@@ -17,7 +17,7 @@ ADD . .
 RUN bin/build
 
 
-FROM alpine:3.6
+FROM alpine:3.11
 
 # Install packages
 RUN apk add --update --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv

--- a/ci/test/e2e.go
+++ b/ci/test/e2e.go
@@ -19,15 +19,48 @@ package test
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
 	"github.com/mysteriumnetwork/node/e2e"
 	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/rs/zerolog/log"
 )
 
+var crossCompileFlags = map[string]string{
+	"GOARCH":      "amd64",
+	"GOOS":        "linux",
+	"CGO_ENABLED": "0",
+}
+
+// BuildMystBinaryForE2eDocker builds myst binary for e2e tests.
+func BuildMystBinaryForE2eDocker() error {
+	return sh.RunWith(crossCompileFlags, "go", "build", "-o", "./build/e2e/myst", "./cmd/mysterium_node/mysterium_node.go")
+}
+
+// BuildE2eTestBinary builds the e2e test binary.
+func BuildE2eTestBinary() error {
+	err := sh.RunWith(crossCompileFlags, "go", "test", "-c", "./e2e/")
+	if err != nil {
+		return err
+	}
+
+	_ = os.Mkdir("./build/e2e/", os.ModeDir)
+	return os.Rename("./e2e.test", "./build/e2e/test")
+}
+
+// BuildE2eDeployerBinary builds the deployer binary for e2e tests.
+func BuildE2eDeployerBinary() error {
+	return sh.RunWith(crossCompileFlags, "go", "build", "-o", "./build/e2e/deployer", "./e2e/blockchain/deployer.go")
+}
+
 // TestE2EBasic runs end-to-end tests
 func TestE2EBasic() error {
 	logconfig.Bootstrap()
+
+	mg.Deps(BuildMystBinaryForE2eDocker, BuildE2eTestBinary, BuildE2eDeployerBinary)
+
 	composeFiles := []string{
 		"./docker-compose.e2e-basic.yml",
 	}
@@ -42,6 +75,9 @@ func TestE2EBasic() error {
 // TestE2ENAT runs end-to-end tests in NAT environment
 func TestE2ENAT() error {
 	logconfig.Bootstrap()
+
+	mg.Deps(BuildMystBinaryForE2eDocker, BuildE2eTestBinary, BuildE2eDeployerBinary)
+
 	composeFiles := []string{
 		"./docker-compose.e2e-traversal.yml",
 	}
@@ -56,6 +92,9 @@ func TestE2ENAT() error {
 // TestE2ECompatibility runs end-to-end tests with older node version to make check compatibility
 func TestE2ECompatibility() error {
 	logconfig.Bootstrap()
+
+	mg.Deps(BuildMystBinaryForE2eDocker, BuildE2eTestBinary, BuildE2eDeployerBinary)
+
 	composeFiles := []string{
 		"./docker-compose.e2e-compatibility.yml",
 	}

--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -133,7 +133,7 @@ services:
   myst-provider:
     build:
       context: .
-      dockerfile: ./bin/docker/alpine/Dockerfile
+      dockerfile: ./bin/docker/alpine-prebuilt/Dockerfile
     depends_on:
       - broker
       - mysterium-api
@@ -179,7 +179,7 @@ services:
   myst-consumer:
     build:
       context: .
-      dockerfile: ./bin/docker/alpine/Dockerfile
+      dockerfile: ./bin/docker/alpine-prebuilt/Dockerfile
     depends_on:
       - broker
       - mysterium-api
@@ -217,10 +217,9 @@ services:
   go-runner:
     build:
       context: .
-      dockerfile: ./e2e/gorunner/Dockerfile
+      dockerfile: ./e2e/gorunner/Dockerfile.precompiled
     cap_add:
       - NET_ADMIN
     volumes:
-      - ./:/node
-      - $GOPATH/pkg/mod:/go/pkg/mod
+      - ./e2e/blockchain/keystore:/node/keystore
     working_dir: /node

--- a/docker-compose.e2e-compatibility.yml
+++ b/docker-compose.e2e-compatibility.yml
@@ -213,7 +213,7 @@ services:
   myst-provider-local:
     build:
       context: .
-      dockerfile: ./bin/docker/alpine/Dockerfile
+      dockerfile: ./bin/docker/alpine-prebuilt/Dockerfile
     depends_on:
       - broker
       - mysterium-api
@@ -257,7 +257,7 @@ services:
   myst-consumer-local:
     build:
       context: .
-      dockerfile: ./bin/docker/alpine/Dockerfile
+      dockerfile: ./bin/docker/alpine-prebuilt/Dockerfile
     depends_on:
       - broker
       - mysterium-api
@@ -294,10 +294,9 @@ services:
   go-runner:
     build:
       context: .
-      dockerfile: ./e2e/gorunner/Dockerfile
+      dockerfile: ./e2e/gorunner/Dockerfile.precompiled
     cap_add:
       - NET_ADMIN
     volumes:
-      - ./:/node
-      - $GOPATH/pkg/mod:/go/pkg/mod
+      - ./e2e/blockchain/keystore:/node/keystore
     working_dir: /node

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -239,7 +239,7 @@ services:
   myst-consumer:
     build:
       context: .
-      dockerfile: ./bin/docker/alpine/Dockerfile
+      dockerfile: ./bin/docker/alpine-prebuilt/Dockerfile
     environment:
       - DEFAULT_ROUTE=10.100.1.2
     depends_on:
@@ -283,7 +283,7 @@ services:
   myst-provider:
     build:
       context: .
-      dockerfile: ./bin/docker/alpine/Dockerfile
+      dockerfile: ./bin/docker/alpine-prebuilt/Dockerfile
     environment:
       - DEFAULT_ROUTE=10.100.0.2
     depends_on:
@@ -335,10 +335,9 @@ services:
   go-runner:
     build:
       context: .
-      dockerfile: ./e2e/gorunner/Dockerfile
+      dockerfile: ./e2e/gorunner/Dockerfile.precompiled
     volumes:
-      - ./:/node
-      - $GOPATH/pkg/mod:/go/pkg/mod
+      - ./e2e/blockchain/keystore:/node/keystore
     working_dir: /node
     dns: 172.30.0.254
     cap_add:

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -56,7 +56,6 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 	})
 
 	var consumerID string
-	// no need to register provider, as he will auto-register
 	t.Run("ConsumerCreatesAndRegistersIdentityFlow", func(t *testing.T) {
 		consumerID = identityCreateFlow(t, tequilapiConsumer, consumerPassphrase)
 		consumerRegistrationFlow(t, tequilapiConsumer, consumerID, consumerPassphrase)
@@ -155,6 +154,12 @@ func providerRegistrationFlow(t *testing.T, tequilapi *tequilapi_client.Client, 
 	err := tequilapi.Unlock(id, idPassphrase)
 	assert.NoError(t, err)
 
+	assert.Eventually(t, func() bool {
+		idStatus, _ := tequilapi.Identity(id)
+		return "RegisteredProvider" == idStatus.RegistrationStatus
+	}, time.Second*5, time.Millisecond*500)
+
+	// once we're registered, check some other information
 	idStatus, err := tequilapi.Identity(id)
 	assert.NoError(t, err)
 	assert.Equal(t, "RegisteredProvider", idStatus.RegistrationStatus)

--- a/e2e/gorunner/Dockerfile.precompiled
+++ b/e2e/gorunner/Dockerfile.precompiled
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.11
 
 RUN apk add --update --no-cache bash gcc musl-dev make linux-headers iptables ipset ca-certificates openvpn bash sudo openresolv
 

--- a/e2e/gorunner/Dockerfile.precompiled
+++ b/e2e/gorunner/Dockerfile.precompiled
@@ -1,0 +1,6 @@
+FROM alpine:3.6
+
+RUN apk add --update --no-cache bash gcc musl-dev make linux-headers iptables ipset ca-certificates openvpn bash sudo openresolv
+
+COPY ./build/e2e/test /usr/bin/test
+COPY ./build/e2e/deployer /usr/bin/deployer

--- a/e2e/runner.go
+++ b/e2e/runner.go
@@ -137,7 +137,7 @@ func (r *Runner) Init() error {
 
 	log.Info().Msg("Force rebuilding go runner")
 	if err := r.compose("build", "go-runner"); err != nil {
-		return errors.Wrap(err, "building go-runner!")
+		return fmt.Errorf("could not build go runner %w", err)
 	}
 
 	log.Info().Msg("Deploying contracts")

--- a/e2e/runner.go
+++ b/e2e/runner.go
@@ -69,13 +69,13 @@ func (r *Runner) Test(providerHost, consumerHost string) error {
 	log.Info().Msg("Running tests for env: " + r.testEnv)
 
 	err := r.compose("run", "go-runner",
-		"go", "test", "-v", "./e2e/...", "-args",
-		"--provider.tequilapi-host", providerHost,
-		"--provider.tequilapi-port=4050",
-		"--consumer.tequilapi-host", consumerHost,
-		"--consumer.tequilapi-port=4050",
-		"--geth.url=ws://ganache:8545",
-		"--consumer.services", r.services,
+		"/usr/bin/test", "-test.v",
+		"-provider.tequilapi-host", providerHost,
+		"-provider.tequilapi-port=4050",
+		"-consumer.tequilapi-host", consumerHost,
+		"-consumer.tequilapi-port=4050",
+		"-geth.url=ws://ganache:8545",
+		"-consumer.services", r.services,
 	)
 	return errors.Wrap(err, "tests failed!")
 }
@@ -100,9 +100,11 @@ func (r *Runner) Init() error {
 	if err := r.compose("pull"); err != nil {
 		return errors.Wrap(err, "could not pull images")
 	}
-	if err := r.compose("up", "-d", "broker", "ganache", "ipify", "morqa"); err != nil {
+
+	if err := r.compose("up", "-d", "broker", "ganache", "ipify", "morqa", "mongodb"); err != nil {
 		return errors.Wrap(err, "starting other services failed!")
 	}
+
 	log.Info().Msg("Starting DB")
 	if err := r.compose("up", "-d", "db"); err != nil {
 		return errors.Wrap(err, "starting DB failed!")
@@ -133,10 +135,15 @@ func (r *Runner) Init() error {
 		return errors.Wrap(err, "starting mysterium-api failed!")
 	}
 
+	log.Info().Msg("Force rebuilding go runner")
+	if err := r.compose("build", "go-runner"); err != nil {
+		return errors.Wrap(err, "building go-runner!")
+	}
+
 	log.Info().Msg("Deploying contracts")
 	err := r.compose("run", "go-runner",
-		"go", "run", "./e2e/blockchain/deployer.go",
-		"--keystore.directory=./e2e/blockchain/keystore",
+		"/usr/bin/deployer",
+		"--keystore.directory=./keystore",
 		"--ether.address=0x354Bd098B4eF8c9E70B7F21BE2d455DF559705d7",
 		fmt.Sprintf("--ether.passphrase=%v", r.etherPassphrase),
 		"--geth.url=ws://ganache:8545")

--- a/mobile/mysterium/openvpn_connection_setup.go
+++ b/mobile/mysterium/openvpn_connection_setup.go
@@ -27,11 +27,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
+	openvpn3 "github.com/mysteriumnetwork/go-openvpn/openvpn3"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/port"
 	"github.com/mysteriumnetwork/node/identity"
-	openvpn3 "github.com/mysteriumnetwork/node/mobile/mysterium/openvpn3"
 	"github.com/mysteriumnetwork/node/nat/traversal"
 	"github.com/mysteriumnetwork/node/services/openvpn"
 	"github.com/mysteriumnetwork/node/services/openvpn/session"

--- a/mobile/mysterium/openvpn_connection_setup.go
+++ b/mobile/mysterium/openvpn_connection_setup.go
@@ -27,11 +27,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
-	"github.com/mysteriumnetwork/go-openvpn/openvpn3"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/port"
 	"github.com/mysteriumnetwork/node/identity"
+	openvpn3 "github.com/mysteriumnetwork/node/mobile/mysterium/openvpn3"
 	"github.com/mysteriumnetwork/node/nat/traversal"
 	"github.com/mysteriumnetwork/node/services/openvpn"
 	"github.com/mysteriumnetwork/node/services/openvpn/session"


### PR DESCRIPTION
New:
 mage teste2ebasic  43.23s user 18.09s system 21% cpu **4:45.21** total

Old:
mage teste2ebasic  29.06s user 12.90s system 8% cpu **8:42.82** total

As a bonus, the mac now stays cool to the touch when running e2e. The savings will be smaller on linux, but I expect them to still be noticeable.