### PR TITLE
Do not overwrite accountant promise on R recovery

### DIFF
--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -614,7 +614,11 @@ func (it *InvoiceTracker) handleAccountantError(err error) error {
 		if !ok {
 			return errors.New("could not cast errNeedsRecovery to accountantError")
 		}
-		return it.recoverR(aer)
+		recoveryErr := it.recoverR(aer)
+		if recoveryErr != nil {
+			return recoveryErr
+		}
+		return errHandled
 	case stdErr.Is(err, ErrAccountantNoPreviousPromise):
 		log.Info().Msg("no previous promise on accountant, will mark R as revealed")
 		return nil


### PR DESCRIPTION
Previously, the accountant promise would get overwritten on recovery to 0 values. 

This happened due to a nil return value from recover R. This is now handled by emitting errHandled instead.