### PR TITLE
Do not allow to overwrite accountant promise to lower value

### DIFF
--- a/session/pingpong/accountant_promise_storage.go
+++ b/session/pingpong/accountant_promise_storage.go
@@ -29,7 +29,7 @@ import (
 const accountantPromiseBucketName = "accountant_promises"
 
 // ErrAttemptToOverwrite occurs when a promise with lower value is attempted to be overwritten on top of an existing promise.
-var ErrAttemptToOverwrite = errors.New("attempted to overwrite a promise with lower value")
+var ErrAttemptToOverwrite = errors.New("attempted to overwrite a promise with and equal or lower value")
 
 // AccountantPromiseStorage allows for storing of accountant promises.
 type AccountantPromiseStorage struct {

--- a/session/pingpong/accountant_promise_storage.go
+++ b/session/pingpong/accountant_promise_storage.go
@@ -28,6 +28,9 @@ import (
 
 const accountantPromiseBucketName = "accountant_promises"
 
+// ErrAttemptToOverwrite occurs when a promise with lower value is attempted to be overwritten on top of an existing promise.
+var ErrAttemptToOverwrite = errors.New("attempted to overwrite a promise with lower value")
+
 // AccountantPromiseStorage allows for storing of accountant promises.
 type AccountantPromiseStorage struct {
 	lock sync.Mutex
@@ -54,6 +57,15 @@ func (aps *AccountantPromiseStorage) Store(id identity.Identity, accountantID co
 	aps.lock.Lock()
 	defer aps.lock.Unlock()
 
+	previousPromise, err := aps.get(id, accountantID)
+	if err != nil && err != ErrNotFound {
+		return err
+	}
+
+	if previousPromise.Promise.Amount >= promise.Promise.Amount {
+		return ErrAttemptToOverwrite
+	}
+
 	channel, err := crypto.GenerateProviderChannelID(id.Address, accountantID.Hex())
 	if err != nil {
 		return errors.Wrap(err, "could not generate provider channel address")
@@ -62,11 +74,7 @@ func (aps *AccountantPromiseStorage) Store(id identity.Identity, accountantID co
 	return errors.Wrap(aps.bolt.SetValue(accountantPromiseBucketName, channel, promise), "could not store accountant promise")
 }
 
-// Get fetches the promise for the given accountant.
-func (aps *AccountantPromiseStorage) Get(id identity.Identity, accountantID common.Address) (AccountantPromise, error) {
-	aps.lock.Lock()
-	defer aps.lock.Unlock()
-
+func (aps *AccountantPromiseStorage) get(id identity.Identity, accountantID common.Address) (AccountantPromise, error) {
 	channel, err := crypto.GenerateProviderChannelID(id.Address, accountantID.Hex())
 	if err != nil {
 		return AccountantPromise{}, errors.Wrap(err, "could not generate provider channel address")
@@ -82,4 +90,11 @@ func (aps *AccountantPromiseStorage) Get(id identity.Identity, accountantID comm
 		}
 	}
 	return *result, err
+}
+
+// Get fetches the promise for the given accountant.
+func (aps *AccountantPromiseStorage) Get(id identity.Identity, accountantID common.Address) (AccountantPromise, error) {
+	aps.lock.Lock()
+	defer aps.lock.Unlock()
+	return aps.get(id, accountantID)
 }

--- a/session/pingpong/accountant_promise_storage_test.go
+++ b/session/pingpong/accountant_promise_storage_test.go
@@ -18,6 +18,7 @@
 package pingpong
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -104,4 +105,13 @@ func TestAccountantPromiseStorage(t *testing.T) {
 	promise, err = accountantStorage.Get(id, secondAccountant)
 	assert.NoError(t, err)
 	assert.EqualValues(t, firstPromise, promise)
+
+	overwritingPromise := AccountantPromise{
+		Promise:     *fp,
+		R:           "some r",
+		AgreementID: 123,
+	}
+	overwritingPromise.Promise.Amount = 0
+	err = accountantStorage.Store(id, secondAccountant, overwritingPromise)
+	assert.True(t, errors.Is(err, ErrAttemptToOverwrite))
 }

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -335,7 +335,7 @@ func (it *InvoiceTracker) requestPromise(r []byte, em crypto.ExchangeMessage) er
 		AgreementID: it.agreementID,
 	}
 	err = it.deps.AccountantPromiseStorage.Store(it.deps.ProviderID, it.deps.AccountantID, ap)
-	if err != nil {
+	if err != nil && !stdErr.Is(err, ErrAttemptToOverwrite) {
 		return errors.Wrap(err, "could not store accountant promise")
 	}
 
@@ -377,7 +377,7 @@ func (it *InvoiceTracker) revealPromise() error {
 
 	accountantPromise.Revealed = true
 	err = it.deps.AccountantPromiseStorage.Store(it.deps.ProviderID, it.deps.AccountantID, accountantPromise)
-	if err != nil {
+	if err != nil && !stdErr.Is(err, ErrAttemptToOverwrite) {
 		return errors.Wrap(err, "could not store accountant promise")
 	}
 


### PR DESCRIPTION
The accountant promise has an ever increasing value. Storage now validates this before overwriting.