### PR TITLE
Protect identity use or creation by mutex

### DIFF
--- a/identity/selector/handler.go
+++ b/identity/selector/handler.go
@@ -18,6 +18,8 @@
 package selector
 
 import (
+	"sync"
+
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -30,6 +32,7 @@ type IdentityRegistry interface {
 }
 
 type handler struct {
+	mu            sync.Mutex
 	manager       identity.Manager
 	registry      IdentityRegistry
 	cache         identity.IdentityCacheInterface
@@ -52,6 +55,9 @@ func NewHandler(
 }
 
 func (h *handler) UseOrCreate(address, passphrase string) (id identity.Identity, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	if len(address) > 0 {
 		log.Debug().Msg("Using existing identity")
 		return h.useExisting(address, passphrase)


### PR DESCRIPTION
If UseOrCreate is called concurrently it will try to register identity into mysterium api and second call will fail. Added mutex to protect from such cases.

Fixes https://github.com/mysteriumnetwork/node/issues/2093