### PR TITLE
Do not block connection state event publishing

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -848,7 +848,7 @@ func (di *Dependencies) handleConnStateChange() error {
 	}
 
 	latestState := connection.NotConnected
-	return di.EventBus.Subscribe(connection.AppTopicConnectionState, func(e connection.AppEventConnectionState) {
+	return di.EventBus.SubscribeAsync(connection.AppTopicConnectionState, func(e connection.AppEventConnectionState) {
 		// Here we care only about connected and disconnected events.
 		if e.State != connection.Connected && e.State != connection.NotConnected {
 			return

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -791,7 +791,7 @@ func (m *connectionManager) setupTrafficBlock(disableKillSwitch bool) error {
 }
 
 func (m *connectionManager) publishStateEvent(state State) {
-	m.eventPublisher.Publish(AppTopicConnectionState, AppEventConnectionState{
+	go m.eventPublisher.Publish(AppTopicConnectionState, AppEventConnectionState{
 		State:       state,
 		SessionInfo: m.Status(),
 	})

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -579,7 +579,7 @@ func (mb *MobileNode) OverrideOpenvpnConnection(tunnelSetup Openvpn3TunnelSetup)
 			mb.ipResolver,
 		)
 	}
-	_ = mb.eventBus.Subscribe(connection.AppTopicConnectionState, st.handleState)
+	_ = mb.eventBus.SubscribeAsync(connection.AppTopicConnectionState, st.handleState)
 	mb.connectionRegistry.Register("openvpn", factory)
 	return st
 }

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -90,9 +90,8 @@ func NewConnectionEndpoint(manager connection.Manager, stateProvider stateProvid
 //     schema:
 //       "$ref": "#/definitions/ErrorMessageDTO"
 func (ce *ConnectionEndpoint) Status(resp http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	connection := ce.stateProvider.GetState().Connection
-	statusResponse := contract.NewConnectionStatusDTO(connection.Session)
-
+	status := ce.manager.Status()
+	statusResponse := contract.NewConnectionStatusDTO(status)
 	utils.WriteAsJSON(statusResponse, resp)
 }
 


### PR DESCRIPTION
As we have 10 subscribers for `AppTopicConnectionState` topic which is published during connect if one of the subscribers blocks the whole connect blocks. This was the case for reconnect logic as if there is no internet connection when connected it was not able to reconnect.

Fixes https://github.com/mysteriumnetwork/node/issues/2126
