### PR TITLE
Efficient keystore unlock operation

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -685,7 +685,7 @@ func (di *Dependencies) bootstrapIdentityComponents(options node.Options) {
 		ks = keystore.NewKeyStore(options.Directories.Keystore, keystore.StandardScryptN, keystore.StandardScryptP)
 	}
 
-	di.Keystore = identity.NewKeystoreFilesystem(options.Directories.Keystore, ks, keystore.DecryptKey)
+	di.Keystore = identity.NewKeystoreFilesystem(options.Directories.Keystore, ks)
 	di.IdentityManager = identity.NewIdentityManager(di.Keystore, di.EventBus)
 	di.SignerFactory = func(id identity.Identity) identity.Signer {
 		return identity.NewSigner(di.Keystore, id)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/arthurkiller/rollingwriter v1.1.2
 	github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05
 	github.com/asdine/storm/v3 v3.1.1
-	github.com/awnumar/memguard v0.21.0
 	github.com/aws/aws-sdk-go-v2 v0.15.0
 	github.com/cenkalti/backoff/v4 v4.0.0
 	github.com/cheggaaa/pb/v3 v3.0.1
@@ -16,7 +15,6 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/ethereum/go-ethereum v1.9.6
 	github.com/frankban/quicktest v1.5.0 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
@@ -24,7 +22,6 @@ require (
 	github.com/gin-gonic/gin v1.4.0
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.4.0
-	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/huin/goupnp v1.0.0
 	github.com/jackpal/gateway v1.0.5
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,10 +52,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asdine/storm/v3 v3.1.1 h1:5ESJvmcNhQQOFcvpxkIHcZs7mp8Z6XGdBqEoAgf+11g=
 github.com/asdine/storm/v3 v3.1.1/go.mod h1:LEpXwGt4pIqrE/XcTvCnZHT5MgZCV6Ub9q7yQzOFWr0=
-github.com/awnumar/memcall v0.0.0-20191004114545-73db50fd9f80 h1:8kObYoBO4LNmQ+fLiScBfxEdxF1w2MHlvH/lr9MLaTg=
-github.com/awnumar/memcall v0.0.0-20191004114545-73db50fd9f80/go.mod h1:S911igBPR9CThzd/hYQQmTc9SWNu3ZHIlCGaWsWsoJo=
-github.com/awnumar/memguard v0.21.0 h1:BZvZ69RXlIQPChLJnpJ0u5cIJQmsWLGfNa6XX5/UZGU=
-github.com/awnumar/memguard v0.21.0/go.mod h1:+ejY3DekvjnDWBXHwL5xB5p4Il77kDsrIz+UOUNrm2Q=
 github.com/aws/aws-sdk-go-v2 v0.11.0 h1:TMUl791B9lF/R8t3msh7id+mHxOXrQY6DAqLNEpre8w=
 github.com/aws/aws-sdk-go-v2 v0.11.0/go.mod h1:cpXCmy3BB+lqwGweJjdawczHW3a+g8QgcFHcoOVoHao=
 github.com/aws/aws-sdk-go-v2 v0.15.0 h1:mQCV2MV4I0L02Nwi1xs0HM7yWbrcWjjUOy1UAv27sw8=
@@ -118,8 +114,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/didip/tollbooth/v5 v5.1.1-0.20190907014804-c5a3bbb8c0a3/go.mod h1:d9rzwOULswrD3YIrAQmP3bfjxab32Df4IaO6+D25l9g=
-github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
-github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -289,8 +283,6 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
@@ -475,8 +467,6 @@ github.com/mysteriumnetwork/go-ci v0.0.0-20190912064927-c54e2b0b3b5c h1:Tt24qNve
 github.com/mysteriumnetwork/go-ci v0.0.0-20190912064927-c54e2b0b3b5c/go.mod h1:GlJmsQDFyRmV9psEs/Mt/humLALu8xmZ7blXQ6Rc9Rs=
 github.com/mysteriumnetwork/go-ci v0.0.0-20200121125840-b99aac3d815c h1:8LI4spVFC7pcYxSaVkW2pB9y1UjdLBdYLwfG14tIXg0=
 github.com/mysteriumnetwork/go-ci v0.0.0-20200121125840-b99aac3d815c/go.mod h1:GlJmsQDFyRmV9psEs/Mt/humLALu8xmZ7blXQ6Rc9Rs=
-github.com/mysteriumnetwork/go-ci v0.0.0-20200316165146-af25c6390269 h1:CQrEJButil3tqscYLd9mOr7X0M6r5epK2en5nyRBnKQ=
-github.com/mysteriumnetwork/go-ci v0.0.0-20200316165146-af25c6390269/go.mod h1:GlJmsQDFyRmV9psEs/Mt/humLALu8xmZ7blXQ6Rc9Rs=
 github.com/mysteriumnetwork/go-ci v0.0.0-20200415074834-39fc864b0ed4 h1:t18FszkN3GHd3lE95/5I6YlrvhiQCdWP58JOeVfhi1E=
 github.com/mysteriumnetwork/go-ci v0.0.0-20200415074834-39fc864b0ed4/go.mod h1:GlJmsQDFyRmV9psEs/Mt/humLALu8xmZ7blXQ6Rc9Rs=
 github.com/mysteriumnetwork/go-dvpn-web v0.0.38 h1:XeiEuki+OCaOjVHhbQtpSQwxZAJI2DN2C/Pwh8enIEs=
@@ -491,8 +481,6 @@ github.com/mysteriumnetwork/metrics v0.0.3 h1:I4Dv99MTmKPh37xJkNbjr6/YqAkK0nihIK
 github.com/mysteriumnetwork/metrics v0.0.3/go.mod h1:LE6fOzc0hlThLPYbrtyr8oLiaW3KFuGSKKNb4bOILYU=
 github.com/mysteriumnetwork/nats.go v1.4.1-0.20200303115848-b4a5324c56ed h1:x9CzKvMnu+8VH9z8lvB/6ZldbpwlLkFuraU0ycH4j5U=
 github.com/mysteriumnetwork/nats.go v1.4.1-0.20200303115848-b4a5324c56ed/go.mod h1:Mj4ZoTFxQltcDoC/Mn8EgO7SkK1dUJQixLgX04p0cN0=
-github.com/mysteriumnetwork/payments v0.0.11 h1:tfGL8Q20rZCeuSF0nELCyho3qHfpbYiqN6vMQnFGF/8=
-github.com/mysteriumnetwork/payments v0.0.11/go.mod h1:yzYaUbvzPFxi3Gj0WwhOiE/2lohZVTDQ55tpIAPk3JA=
 github.com/mysteriumnetwork/payments v0.0.13-0.20200430114543-8b00d4439302 h1:Lg5Z8Gx9iaWR02kM5It70nFRo+2yGLhqgutH+34APrE=
 github.com/mysteriumnetwork/payments v0.0.13-0.20200430114543-8b00d4439302/go.mod h1:e7j40M4OJQOekLcBsHvvBQfuRglmUx/uYR/msogDhlU=
 github.com/nats-io/gnatsd v1.4.1 h1:RconcfDeWpKCD6QIIwiVFcvForlXpWeJP7i5/lDLy44=
@@ -718,7 +706,6 @@ golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 h1:0hQKqeLdqlt5iIwVOBErRi
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200406173513-056763e48d71 h1:DOmugCavvUtnUD114C1Wh+UgTgQZ4pMLzXxi1pSt+/Y=
@@ -819,10 +806,8 @@ golang.org/x/sys v0.0.0-20190913121621-c3b328c6e5a7 h1:wYqz/tQaWUgGKyx+B/rssSE6w
 golang.org/x/sys v0.0.0-20190913121621-c3b328c6e5a7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191003212358-c178f38b412c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=

--- a/identity/integration_test.go
+++ b/identity/integration_test.go
@@ -20,18 +20,33 @@ package identity
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts"
+	ethKs "github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	idAddress = "0x53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"
+	idAccount = accounts.Account{
+		Address: common.HexToAddress("53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"),
+	}
+	idKey, _ = crypto.HexToECDSA("6f88637b68ee88816e73f663aef709d7009836c98ae91ef31e3dfac7be3a1657")
+)
+
 func Test_UnlockAndSignAndVerify(t *testing.T) {
-	ks := NewKeystoreFilesystem("dir", NewMockKeystoreWith(MockKeys), MockDecryptFunc)
+	ks := NewKeystoreFilesystem("dir", &ethKeystoreMock{account: idAccount})
+	ks.loadKey = func(addr common.Address, filename, auth string) (*ethKs.Key, error) {
+		return &ethKs.Key{Address: addr, PrivateKey: idKey}, nil
+	}
 
 	manager := NewIdentityManager(ks, eventbus.New())
-	err := manager.Unlock("0x53a835143c0ef3bbcbfa796d7eb738ca7dd28f68", "")
+	err := manager.Unlock(idAddress, "")
 	assert.NoError(t, err)
 
-	signer := NewSigner(ks, FromAddress("0x53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"))
+	signer := NewSigner(ks, FromAddress(idAddress))
 	signature, err := signer.Sign([]byte("Boop!"))
 	assert.NoError(t, err)
 	assert.Exactly(
@@ -40,6 +55,6 @@ func Test_UnlockAndSignAndVerify(t *testing.T) {
 		signature,
 	)
 
-	verifier := NewVerifierIdentity(FromAddress("0x53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"))
+	verifier := NewVerifierIdentity(FromAddress(idAddress))
 	assert.True(t, verifier.Verify([]byte("Boop!"), signature))
 }

--- a/identity/integration_test.go
+++ b/identity/integration_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Test_UnlockAndSignAndVerify(t *testing.T) {
-	ks := NewKeystoreFilesystem("dir", NewMockKeystore(MockKeys), MockDecryptFunc)
+	ks := NewKeystoreFilesystem("dir", NewMockKeystoreWith(MockKeys), MockDecryptFunc)
 
 	manager := NewIdentityManager(ks, eventbus.New())
 	err := manager.Unlock("0x53a835143c0ef3bbcbfa796d7eb738ca7dd28f68", "")

--- a/identity/keystore_filesystem.go
+++ b/identity/keystore_filesystem.go
@@ -20,147 +20,145 @@ package identity
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha512"
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"sync"
+	"time"
 
-	"github.com/awnumar/memguard"
 	"github.com/ethereum/go-ethereum/accounts"
 	ethKs "github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/crypto/hkdf"
 )
 
-type ks interface {
+type ethKeystore interface {
 	Accounts() []accounts.Account
 	NewAccount(passphrase string) (accounts.Account, error)
 	Find(a accounts.Account) (accounts.Account, error)
-	Unlock(a accounts.Account, passphrase string) error
-	Lock(addr common.Address) error
-	SignHash(a accounts.Account, hash []byte) ([]byte, error)
-	Export(a accounts.Account, passphrase, newPassphrase string) (keyJSON []byte, err error)
 }
 
 // NewKeystoreFilesystem create new keystore, which keeps keys in filesystem.
-func NewKeystoreFilesystem(directory string, ks ks, keyDecryptFunc func(keyjson []byte, auth string) (*ethKs.Key, error)) *Keystore {
+func NewKeystoreFilesystem(directory string, ks ethKeystore) *Keystore {
 	return &Keystore{
-		ethKeystore:    ks,
-		keyDecryptFunc: keyDecryptFunc,
-		derivedKeys:    make(map[common.Address]*memguard.Enclave),
+		ethKeystore: ks,
+		loadKey:     loadStoredKey,
+		unlocked:    make(map[common.Address]*unlocked),
 	}
 }
 
 // Keystore handles everything that's related to eth accounts.
 type Keystore struct {
-	ethKeystore    ks
-	keyDecryptFunc func(keyjson []byte, auth string) (*ethKs.Key, error)
+	ethKeystore
+	loadKey func(addr common.Address, filename, auth string) (*ethKs.Key, error)
 
-	derivedKeys    map[common.Address]*memguard.Enclave
-	derivedKeyLock sync.Mutex
+	unlocked map[common.Address]*unlocked // Currently unlocked account (decrypted private keys)
+	mu       sync.RWMutex
 }
 
-// Accounts returns all accounts.
-func (ks *Keystore) Accounts() []accounts.Account {
-	return ks.ethKeystore.Accounts()
-}
-
-// NewAccount creates a new account.
-func (ks *Keystore) NewAccount(passphrase string) (accounts.Account, error) {
-	return ks.ethKeystore.NewAccount(passphrase)
-}
-
-// Find finds an account.
-func (ks *Keystore) Find(a accounts.Account) (accounts.Account, error) {
-	return ks.ethKeystore.Find(a)
-}
-
-// Unlock unlocks an account.
+// Unlock unlocks the given account indefinitely.
 func (ks *Keystore) Unlock(a accounts.Account, passphrase string) error {
-	err := ks.ethKeystore.Unlock(a, passphrase)
-	if err != nil {
-		return err
-	}
+	return ks.TimedUnlock(a, passphrase, 0)
+}
 
-	derived, err := ks.deriveKey(a, passphrase)
-	if err != nil {
-		return err
+// Lock removes the private key with the given address from memory.
+func (ks *Keystore) Lock(addr common.Address) error {
+	ks.mu.Lock()
+	if unl, found := ks.unlocked[addr]; found {
+		ks.mu.Unlock()
+		ks.expire(addr, unl, time.Duration(0)*time.Nanosecond)
+	} else {
+		ks.mu.Unlock()
 	}
-
-	ks.rememberDerivedKey(a.Address, derived)
 	return nil
 }
 
-// Lock locks an account.
-func (ks *Keystore) Lock(addr common.Address) error {
-	defer ks.forgetDerivedKey(addr)
-	return ks.ethKeystore.Lock(addr)
-}
-
-func (ks *Keystore) rememberDerivedKey(a common.Address, key []byte) {
-	ks.derivedKeyLock.Lock()
-	defer ks.derivedKeyLock.Unlock()
-	enclave := memguard.NewEnclave(key)
-	ks.derivedKeys[a] = enclave
-}
-
-func (ks *Keystore) forgetDerivedKey(a common.Address) {
-	ks.derivedKeyLock.Lock()
-	defer ks.derivedKeyLock.Unlock()
-	delete(ks.derivedKeys, a)
-}
-
-func (ks *Keystore) getDerivedKey(a common.Address) ([]byte, error) {
-	ks.derivedKeyLock.Lock()
-	defer ks.derivedKeyLock.Unlock()
-
-	if _, ok := ks.derivedKeys[a]; !ok {
-		return nil, errors.New("no key found")
-	}
-
-	enclave := ks.derivedKeys[a]
-	buffer, err := enclave.Open()
+// TimedUnlock unlocks the given account with the passphrase. The account
+// stays unlocked for the duration of timeout. A timeout of 0 unlocks the account
+// until the program exits. The account must match a unique key file.
+//
+// If the account address is already unlocked for a duration, TimedUnlock extends or
+// shortens the active unlock timeout. If the address was previously unlocked
+// indefinitely the timeout is not altered.
+func (ks *Keystore) TimedUnlock(a accounts.Account, passphrase string, timeout time.Duration) error {
+	a, key, err := ks.getDecryptedKey(a, passphrase)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	defer buffer.Destroy()
 
-	bytes := buffer.Bytes()
-
-	copied := make([]byte, len(bytes))
-	copy(copied, bytes)
-	return copied, nil
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	u, found := ks.unlocked[a.Address]
+	if found {
+		if u.abort == nil {
+			// The address was unlocked indefinitely, so unlocking
+			// it with a timeout would be confusing.
+			zeroKey(key.PrivateKey)
+			return nil
+		}
+		// Terminate the expire goroutine and replace it below.
+		close(u.abort)
+	}
+	if timeout > 0 {
+		u = &unlocked{Key: key, abort: make(chan struct{})}
+		go ks.expire(a.Address, u, timeout)
+	} else {
+		u = &unlocked{Key: key}
+	}
+	ks.unlocked[a.Address] = u
+	return nil
 }
 
-func (ks *Keystore) deriveKey(a accounts.Account, passphrase string) ([]byte, error) {
-	kjson, err := ks.ethKeystore.Export(a, passphrase, passphrase)
+func (ks *Keystore) getDecryptedKey(a accounts.Account, auth string) (accounts.Account, *ethKs.Key, error) {
+	a, err := ks.ethKeystore.Find(a)
 	if err != nil {
-		return nil, err
+		return a, nil, err
 	}
+	key, err := ks.loadKey(a.Address, a.URL.Path, auth)
+	return a, key, err
+}
 
-	k, err := ks.keyDecryptFunc(kjson, passphrase)
-	if err != nil {
-		return nil, err
+func (ks *Keystore) expire(addr common.Address, u *unlocked, timeout time.Duration) {
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+	select {
+	case <-u.abort:
+		// just quit
+	case <-t.C:
+		ks.mu.Lock()
+		// only drop if it's still the same key instance that dropLater
+		// was launched with. we can check that using pointer equality
+		// because the map stores a new pointer every time the key is
+		// unlocked.
+		if ks.unlocked[addr] == u {
+			zeroKey(u.PrivateKey)
+			delete(ks.unlocked, addr)
+		}
+		ks.mu.Unlock()
 	}
-	defer memguard.WipeBytes(k.PrivateKey.D.Bytes())
-
-	hashFunc := sha512.New
-	hkdfDeriver := hkdf.New(hashFunc, k.PrivateKey.D.Bytes(), nil, nil)
-	key := make([]byte, 32)
-	_, err = io.ReadFull(hkdfDeriver, key)
-	return key, err
 }
 
 // Encrypt takes a derived key for the given address and encrypts the plaintext.
 func (ks *Keystore) Encrypt(addr common.Address, plaintext []byte) ([]byte, error) {
-	key, err := ks.getDerivedKey(addr)
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	key, found := ks.unlocked[addr]
+	if !found {
+		return nil, ethKs.ErrLocked
+	}
+
+	keyDerived, err := key.deriveKey()
 	if err != nil {
 		return nil, err
 	}
-	defer memguard.WipeBytes(key)
 
-	c, err := aes.NewCipher(key)
+	c, err := aes.NewCipher(keyDerived)
 	if err != nil {
 		return nil, err
 	}
@@ -180,13 +178,20 @@ func (ks *Keystore) Encrypt(addr common.Address, plaintext []byte) ([]byte, erro
 
 // Decrypt takes a derived key for the given address and decrypts the encrypted message.
 func (ks *Keystore) Decrypt(addr common.Address, encrypted []byte) ([]byte, error) {
-	key, err := ks.getDerivedKey(addr)
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	key, found := ks.unlocked[addr]
+	if !found {
+		return nil, ethKs.ErrLocked
+	}
+
+	keyDerived, err := key.deriveKey()
 	if err != nil {
 		return nil, err
 	}
-	defer memguard.WipeBytes(key)
 
-	c, err := aes.NewCipher(key)
+	c, err := aes.NewCipher(keyDerived)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +210,55 @@ func (ks *Keystore) Decrypt(addr common.Address, encrypted []byte) ([]byte, erro
 	return gcm.Open(nil, nonce, encrypted, nil)
 }
 
-// SignHash signs the given hash.
+// SignHash calculates a ECDSA signature for the given hash. The produced
+// signature is in the [R || S || V] format where V is 0 or 1.
 func (ks *Keystore) SignHash(a accounts.Account, hash []byte) ([]byte, error) {
-	return ks.ethKeystore.SignHash(a, hash)
+	// Look up the key to sign with and abort if it cannot be found
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	unlockedKey, found := ks.unlocked[a.Address]
+	if !found {
+		return nil, ethKs.ErrLocked
+	}
+	// Sign the hash using plain ECDSA operations
+	return crypto.Sign(hash, unlockedKey.PrivateKey)
+}
+
+// zeroKey zeroes a private key in memory.
+func zeroKey(k *ecdsa.PrivateKey) {
+	b := k.D.Bits()
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+type unlocked struct {
+	*ethKs.Key
+	abort chan struct{}
+}
+
+func (u *unlocked) deriveKey() ([]byte, error) {
+	hashFunc := sha512.New
+	hkdfDerived := hkdf.New(hashFunc, u.Key.PrivateKey.D.Bytes(), nil, nil)
+	key := make([]byte, 32)
+	_, err := io.ReadFull(hkdfDerived, key)
+	return key, err
+}
+
+func loadStoredKey(addr common.Address, filename, auth string) (*ethKs.Key, error) {
+	// Load the key from the keystore and decrypt its contents
+	keyjson, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	key, err := ethKs.DecryptKey(keyjson, auth)
+	if err != nil {
+		return nil, err
+	}
+	// Make sure we're really operating on the requested key (no swap attacks)
+	if key.Address != addr {
+		return nil, fmt.Errorf("key content mismatch: have account %x, want %x", key.Address, addr)
+	}
+	return key, nil
 }

--- a/identity/keystore_filesystem_test.go
+++ b/identity/keystore_filesystem_test.go
@@ -32,7 +32,7 @@ func Test_DerivedEncryption(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := NewKeystoreFilesystem(dir, NewMockKeystore(MockKeys), MockDecryptFunc)
+	ks := NewKeystoreFilesystem(dir, NewMockKeystoreWith(MockKeys), MockDecryptFunc)
 
 	acc, err := ks.NewAccount("")
 	assert.NoError(t, err)
@@ -90,7 +90,7 @@ var result []byte
 func Benchmark_DerivedEncryption(b *testing.B) {
 	dir, _ := ioutil.TempDir(os.TempDir(), "derived_encryption_bench")
 	defer os.RemoveAll(dir)
-	ks := NewKeystoreFilesystem(dir, NewMockKeystore(MockKeys), MockDecryptFunc)
+	ks := NewKeystoreFilesystem(dir, NewMockKeystoreWith(MockKeys), MockDecryptFunc)
 	acc, _ := ks.NewAccount("")
 	_ = ks.Unlock(acc, "")
 
@@ -106,7 +106,7 @@ func Benchmark_DerivedEncryption(b *testing.B) {
 func Benchmark_DerivedDecryption(b *testing.B) {
 	dir, _ := ioutil.TempDir(os.TempDir(), "derived_encryption_bench")
 	defer os.RemoveAll(dir)
-	ks := NewKeystoreFilesystem(dir, NewMockKeystore(MockKeys), MockDecryptFunc)
+	ks := NewKeystoreFilesystem(dir, NewMockKeystoreWith(MockKeys), MockDecryptFunc)
 	acc, _ := ks.NewAccount("")
 	_ = ks.Unlock(acc, "")
 	encrypted, _ := ks.Encrypt(acc.Address, []byte(secretMessage))

--- a/identity/keystore_mock.go
+++ b/identity/keystore_mock.go
@@ -36,14 +36,19 @@ type mockKeystore struct {
 
 // MockKeys represents the mocked keys
 var MockKeys = map[common.Address]MockKey{
-	common.HexToAddress("53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"): MockKey{
+	common.HexToAddress("53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"): {
 		PkHex: "6f88637b68ee88816e73f663aef709d7009836c98ae91ef31e3dfac7be3a1657",
 		Pass:  "",
 	},
 }
 
-// NewMockKeystore returns a new mock keystore
-func NewMockKeystore(keys map[common.Address]MockKey) *mockKeystore {
+// NewMockKeystore returns empty mock keystore
+func NewMockKeystore() *mockKeystore {
+	return NewMockKeystoreWith(map[common.Address]MockKey{})
+}
+
+// NewMockKeystoreWith returns a new mock keystore with specified keys
+func NewMockKeystoreWith(keys map[common.Address]MockKey) *mockKeystore {
 	copied := make(map[common.Address]MockKey)
 	for key, value := range keys {
 		copied[key] = value

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_IdentityManager(t *testing.T) {
-	ks := NewKeystoreFilesystem("dir", NewMockKeystore(MockKeys), MockDecryptFunc)
+	ks := NewKeystoreFilesystem("dir", NewMockKeystoreWith(MockKeys), MockDecryptFunc)
 	idm := &identityManager{
 		keystoreManager: ks,
 		eventBus:        eventbus.New(),

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_IdentityManager(t *testing.T) {
-	ks := NewKeystoreFilesystem("dir", NewMockKeystoreWith(MockKeys), MockDecryptFunc)
+	ks := NewMockKeystoreWith(MockKeys)
 	idm := &identityManager{
 		keystoreManager: ks,
 		eventBus:        eventbus.New(),

--- a/identity/signer_test.go
+++ b/identity/signer_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestSigningMessageWithUnlockedAccount(t *testing.T) {
-	ks := NewKeystoreFilesystem("dir", NewMockKeystore(MockKeys), MockDecryptFunc)
+	ks := NewKeystoreFilesystem("dir", NewMockKeystoreWith(MockKeys), MockDecryptFunc)
 
 	manager := NewIdentityManager(ks, eventbus.New())
 	err := manager.Unlock("0x53a835143c0ef3bbcbfa796d7eb738ca7dd28f68", "")

--- a/session/pingpong/accountant_promise_settler_test.go
+++ b/session/pingpong/accountant_promise_settler_test.go
@@ -19,9 +19,7 @@ package pingpong
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -43,14 +41,11 @@ func TestPromiseSettler_resyncState_returns_errors(t *testing.T) {
 	}
 	mrsp := &mockRegistrationStatusProvider{}
 	mapg := &mockAccountantPromiseGetter{}
-	dir, err := ioutil.TempDir("", "testPromiseSettler_resyncState_returns_errors")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 
 	settler := NewAccountantPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, cfg)
-	err = settler.resyncState(mockID)
+	err := settler.resyncState(mockID)
 	assert.Equal(t, fmt.Sprintf("could not get provider channel for %v: %v", mockID, errMock.Error()), err.Error())
 
 	channelStatusProvider.channelReturnError = nil
@@ -67,15 +62,12 @@ func TestPromiseSettler_resyncState_handles_no_promise(t *testing.T) {
 	mapg := &mockAccountantPromiseGetter{
 		err: ErrNotFound,
 	}
-	dir, err := ioutil.TempDir("", "TestPromiseSettler_resyncState_handles_no_promise")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 
 	id := identity.FromAddress("test")
 	settler := NewAccountantPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, cfg)
-	err = settler.resyncState(id)
+	err := settler.resyncState(id)
 	assert.NoError(t, err)
 
 	v := settler.currentState[id]
@@ -97,14 +89,11 @@ func TestPromiseSettler_resyncState_takes_promise_into_account(t *testing.T) {
 			},
 		},
 	}
-	dir, err := ioutil.TempDir("", "TestPromiseSettler_resyncState_takes_promise_into_account")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 
 	settler := NewAccountantPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, cfg)
-	err = settler.resyncState(mockID)
+	err := settler.resyncState(mockID)
 	assert.NoError(t, err)
 
 	v := settler.currentState[mockID]
@@ -126,18 +115,13 @@ func TestPromiseSettler_loadInitialState(t *testing.T) {
 		},
 	}
 	mapg := &mockAccountantPromiseGetter{}
-	dir, err := ioutil.TempDir("", "TestPromiseSettler_loadInitialState")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 
 	settler := NewAccountantPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, cfg)
-
 	settler.currentState[mockID] = settlementState{}
 
 	// check if existing gets skipped
-	err = settler.loadInitialState(mockID)
+	err := settler.loadInitialState(mockID)
 	assert.NoError(t, err)
 
 	v := settler.currentState[mockID]
@@ -196,12 +180,7 @@ func TestPromiseSettler_handleServiceEvent(t *testing.T) {
 		},
 	}
 	mapg := &mockAccountantPromiseGetter{}
-	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleServiceEvent")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
-
+	ks := identity.NewMockKeystore()
 	settler := NewAccountantPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, cfg)
 
 	statusesWithNoChangeExpected := []string{string(servicestate.Starting), string(servicestate.NotRunning)}
@@ -238,12 +217,7 @@ func TestPromiseSettler_handleRegistrationEvent(t *testing.T) {
 		},
 	}
 	mapg := &mockAccountantPromiseGetter{}
-	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleRegistrationEvent")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
-
+	ks := identity.NewMockKeystore()
 	settler := NewAccountantPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, cfg)
 
 	statusesWithNoChangeExpected := []registry.RegistrationStatus{registry.RegisteredConsumer, registry.Unregistered, registry.InProgress, registry.Promoting, registry.RegistrationError}
@@ -279,11 +253,7 @@ func TestPromiseSettler_handleAccountantPromiseReceived(t *testing.T) {
 		},
 	}
 	mapg := &mockAccountantPromiseGetter{}
-	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleAccountantPromiseReceived")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 
 	// no receive on unknown provider
 	settler := NewAccountantPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, cfg)
@@ -353,11 +323,7 @@ func TestPromiseSettler_handleNodeStart(t *testing.T) {
 	}
 
 	mapg := &mockAccountantPromiseGetter{}
-	dir, err := ioutil.TempDir("", "TestPromiseSettler_handleAccountantPromiseReceived")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 
 	acc1, err := ks.NewAccount("")
 	assert.NoError(t, err)

--- a/session/pingpong/accountant_promise_storage_test.go
+++ b/session/pingpong/accountant_promise_storage_test.go
@@ -34,7 +34,7 @@ func TestAccountantPromiseStorage(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -188,7 +188,7 @@ func exchangeMessageReceiver(dialog communication.Dialog, channel p2p.ChannelHan
 
 // ExchangeFactoryFunc returns a backwards compatible version of the exchange factory.
 func ExchangeFactoryFunc(
-	keystore *identity.Keystore,
+	keystore hashSigner,
 	signer identity.SignerFactory,
 	totalStorage consumerTotalsStorage,
 	channelImplementation string,

--- a/session/pingpong/invoice_payer.go
+++ b/session/pingpong/invoice_payer.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/eventbus"
@@ -87,13 +88,17 @@ type InvoicePayer struct {
 	dataTransferredLock sync.Mutex
 }
 
+type hashSigner interface {
+	SignHash(a accounts.Account, hash []byte) ([]byte, error)
+}
+
 // InvoicePayerDeps contains all the dependencies for the exchange message tracker.
 type InvoicePayerDeps struct {
 	InvoiceChan               chan crypto.Invoice
 	PeerExchangeMessageSender PeerExchangeMessageSender
 	ConsumerTotalsStorage     consumerTotalsStorage
 	TimeTracker               timeTracker
-	Ks                        *identity.Keystore
+	Ks                        hashSigner
 	Identity, Peer            identity.Identity
 	Proposal                  market.ServiceProposal
 	SessionID                 string

--- a/session/pingpong/invoice_payer_test.go
+++ b/session/pingpong/invoice_payer_test.go
@@ -56,7 +56,7 @@ func Test_InvoicePayer_Start_Stop(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -104,7 +104,7 @@ func Test_InvoicePayer_SendsMessage(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -177,7 +177,7 @@ func Test_InvoicePayer_SendsMessage_OnFreeService(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -243,7 +243,7 @@ func Test_InvoicePayer_BubblesErrors(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -525,11 +525,7 @@ func TestInvoicePayer_calculateAmountToPromise(t *testing.T) {
 }
 
 func TestInvoicePayer_issueExchangeMessage_publishesEvents(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestInvoicePayer_issueExchangeMessage_test")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -586,11 +582,7 @@ func TestInvoicePayer_issueExchangeMessage_publishesEvents(t *testing.T) {
 }
 
 func TestInvoicePayer_issueExchangeMessage(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestInvoicePayer_issueExchangeMessage_test")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -601,7 +593,7 @@ func TestInvoicePayer_issueExchangeMessage(t *testing.T) {
 
 	type fields struct {
 		peerExchangeMessageSender *MockPeerExchangeMessageSender
-		keystore                  *identity.Keystore
+		keystore                  hashSigner
 		identity                  identity.Identity
 		peer                      identity.Identity
 		lastInvoice               crypto.Invoice

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -74,7 +74,7 @@ func Test_InvoiceTracker_Start_Stop(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -128,7 +128,7 @@ func Test_InvoiceTracker_Start_RefusesUnregisteredUser(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -180,7 +180,7 @@ func Test_InvoiceTracker_Start_BubblesRegistrationCheckErrors(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -233,7 +233,7 @@ func Test_InvoiceTracker_Start_RefusesLargeFee(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -285,7 +285,7 @@ func Test_InvoiceTracker_Start_BubblesAccountantCheckError(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -339,7 +339,7 @@ func Test_InvoiceTracker_BubblesErrors(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 
@@ -401,7 +401,7 @@ func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 	mockSender := &MockPeerInvoiceSender{
@@ -458,7 +458,7 @@ func Test_InvoiceTracker_SendsFirstInvoice_Return_Timeout_Err(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 	mockSender := &MockPeerInvoiceSender{
@@ -513,7 +513,7 @@ func Test_InvoiceTracker_FreeServiceSendsInvoices(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 	mockSender := &MockPeerInvoiceSender{
@@ -573,7 +573,7 @@ func generateExchangeMessage(t *testing.T, amount uint64, invoice crypto.Invoice
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	ks := identity.NewKeystoreFilesystem(dir, identity.NewMockKeystore(identity.MockKeys), identity.MockDecryptFunc)
+	ks := identity.NewMockKeystore()
 	acc, err := ks.NewAccount("")
 	assert.Nil(t, err)
 


### PR DESCRIPTION
Now keystore unlock operation decrypts stored key just once.
In order to derive a key, we was unable to not access `keyStorePassphrase` struct, which lead us to workarounds like `ks.ethKeystore.Export()` which decrypts&encrypts key. After that we needed to call `Decrypt()` again.

Ethereum keystore is implemented  coupled to their case of transaction signing/verifying flow. As we're not reusing that, unlock/lock for or case, while still inheriting from Ethereum that we need - key storage & signing algorithm.

Fixes: #2134