### PR TITLE
Fix flaky nat pinger test

### DIFF
--- a/services/openvpn/service/proxy.go
+++ b/services/openvpn/service/proxy.go
@@ -51,7 +51,7 @@ func copyStreams(dstConn *net.UDPConn, srcConn *net.UDPConn) {
 
 	totalBytes, err := io.CopyBuffer(dstConn, srcConn, buf)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to write/read a stream to/from natProxy")
+		log.Error().Err(err).Msg("Failed to write/read a stream to/from service natProxy")
 	}
 
 	log.Debug().Msgf("Total bytes transferred from %s to %s: %d",


### PR DESCRIPTION
This pinger test was not using consumer proxy since socket protect func was nil and some times test was failing as pinger was able to close consumer conn. Now test includes case when both consumer and provider uses nat proxy connections.