### PR TITLE
Close NAT pinger connection on timeout

### DIFF
--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -372,6 +372,7 @@ func waitMsg(ctx context.Context, conn *net.UDPConn, msg string) error {
 	case <-ok:
 		return nil
 	case <-ctx.Done():
+		conn.Close()
 		return fmt.Errorf("timeout waiting for %q msg: %w", msg, ctx.Err())
 	}
 }


### PR DESCRIPTION
We have to stop reading from connection if we timed out waiting for it.

Closes: #2195