### PR TITLE
Fast registration

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -191,27 +191,7 @@ func (c *cliApp) registerIdentity(actionArgs []string) {
 		return
 	}
 
-	info("Waiting for registration to complete")
-	timeout := time.After(3 * time.Minute)
-	for {
-		select {
-		case <-timeout:
-			warn("Identity registration timed out")
-			return
-		case <-time.After(2 * time.Second):
-			status, err := c.tequilapi.IdentityRegistrationStatus(address)
-			if err != nil {
-				warn(err)
-			}
-			fmt.Print(status.Status, ".. ")
-
-			if status.Registered {
-				fmt.Println()
-				success("Identity registered")
-				return
-			}
-		}
-	}
+	info("Registration succesful, you can now connect.")
 }
 
 const usageTopupIdentity = "topup <identity>"

--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -191,7 +191,7 @@ func (c *cliApp) registerIdentity(actionArgs []string) {
 		return
 	}
 
-	info("Registration succesful, you can now connect.")
+	info("Registration successful, you can now connect.")
 }
 
 const usageTopupIdentity = "topup <identity>"

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -449,6 +449,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		di.ChannelAddressCalculator,
 		di.ConsumerTotalsStorage,
 		di.AccountantCaller,
+		di.Transactor,
 	)
 
 	err := di.ConsumerBalanceTracker.Subscribe(di.EventBus)

--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -71,13 +71,14 @@ services:
       --mnemonic "amused glory pen avocado toilet dragon entry kitchen cliff retreat canyon danger"
 
   transactor:
-    image: mysteriumnetwork/transactor:0.1.4
+    image: mysteriumnetwork/transactor:0.3.0
     environment:
       PORT: 8888
     expose:
       - 8888
     depends_on:
       - ganache
+      - mongodb
     command: >
       -settlemntFee 1000
       -mystSCAddress 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
@@ -86,6 +87,10 @@ services:
       -ourIdentity 0x354bd098b4ef8c9e70b7f21be2d455df559705d7
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75
       -balanceCheckInterval 1s
+      -MongoUser transactor
+      -MongoPass transactor
+      -MongoHost mongodb:27017
+      -MongoReplSet ""
     volumes:
       - ./e2e/blockchain/keystore:/keystore
 
@@ -98,7 +103,7 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
 
   accountant:
-    image: mysteriumnetwork/hermes:0.4.0
+    image: mysteriumnetwork/hermes:0.5.0
     environment:
       PORT: 8889
     expose:

--- a/docker-compose.e2e-compatibility.yml
+++ b/docker-compose.e2e-compatibility.yml
@@ -71,13 +71,14 @@ services:
       --mnemonic "amused glory pen avocado toilet dragon entry kitchen cliff retreat canyon danger"
 
   transactor:
-    image: mysteriumnetwork/transactor:0.1.4
+    image: mysteriumnetwork/transactor:0.3.0
     environment:
       PORT: 8888
     expose:
       - 8888
     depends_on:
       - ganache
+      - mongodb
     command: >
       -settlemntFee 10000
       -mystSCAddress 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
@@ -86,11 +87,15 @@ services:
       -ourIdentity 0x354bd098b4ef8c9e70b7f21be2d455df559705d7
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75
       -balanceCheckInterval 1s
+      -MongoUser transactor
+      -MongoPass transactor
+      -MongoHost mongodb:27017
+      -MongoReplSet ""
     volumes:
       - ./e2e/blockchain/keystore:/keystore
 
   accountant:
-    image: mysteriumnetwork/hermes:0.4.0
+    image: mysteriumnetwork/hermes:0.5.0
     environment:
       PORT: 8889
     expose:

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -149,7 +149,7 @@ services:
         ipv4_address: 172.31.0.202
 
   transactor:
-    image: mysteriumnetwork/transactor:0.1.4
+    image: mysteriumnetwork/transactor:0.3.0
     environment:
       PORT: 8888
     expose:
@@ -161,6 +161,7 @@ services:
       - net.ipv4.conf.eth1.rp_filter=0
     depends_on:
       - ganache
+      - mongodb
     command: >
       -settlemntFee 10000
       -mystSCAddress 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
@@ -169,6 +170,10 @@ services:
       -ourIdentity 0x354bd098b4ef8c9e70b7f21be2d455df559705d7
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75
       -balanceCheckInterval 1s
+      -MongoUser transactor
+      -MongoPass transactor
+      -MongoHost mongodb:27017
+      -MongoReplSet ""
     volumes:
       - ./e2e/blockchain/keystore:/keystore
     dns: 172.30.0.254
@@ -179,7 +184,7 @@ services:
         ipv4_address: 172.31.0.203
 
   accountant:
-    image: mysteriumnetwork/hermes:0.4.0
+    image: mysteriumnetwork/hermes:0.5.0
     environment:
       PORT: 8889
     expose:

--- a/e2e/mongo-init.e2e.js
+++ b/e2e/mongo-init.e2e.js
@@ -1,3 +1,5 @@
+db.auth('root', 'root');
+db = db.getSiblingDB('accountant');
 db.createUser(
     {
         user: "accountant",
@@ -9,4 +11,17 @@ db.createUser(
             }
         ]
     }
+);
+db = db.getSiblingDB('transactor');
+db.createUser(
+    {
+        user: "transactor",
+        pwd: "transactor",
+        roles: [
+            {
+                role: "readWrite",
+                db: "transactor"
+            }
+        ]
+    }    
 );

--- a/identity/registry/transactor.go
+++ b/identity/registry/transactor.go
@@ -363,3 +363,40 @@ func (t *Transactor) signSetBeneficiaryRequest(signer identity.Signer, req pc.Se
 
 	return signature.Bytes(), nil
 }
+
+// TransactorRegistrationEntryStatus represents the registration status.
+type TransactorRegistrationEntryStatus string
+
+const (
+	// TransactorRegistrationEntryStatusCreated tells us that the registration is created.
+	TransactorRegistrationEntryStatusCreated = TransactorRegistrationEntryStatus("created")
+	// TransactorRegistrationEntryStatusPriceIncreased tells us that registration was requeued with an increased price.
+	TransactorRegistrationEntryStatusPriceIncreased = TransactorRegistrationEntryStatus("priceIncreased")
+	// TransactorRegistrationEntryStatusFailed tells us that the registration has failed.
+	TransactorRegistrationEntryStatusFailed = TransactorRegistrationEntryStatus("failed")
+	// TransactorRegistrationEntryStatusSucceed tells us that the registration has succeeded.
+	TransactorRegistrationEntryStatusSucceed = TransactorRegistrationEntryStatus("succeed")
+)
+
+// TransactorStatusResponse represents the current registration status.
+type TransactorStatusResponse struct {
+	IdentityID   string                            `json:"identity_id"`
+	Status       TransactorRegistrationEntryStatus `json:"status"`
+	TxHash       string                            `json:"tx_hash"`
+	CreatedAt    time.Time                         `json:"created_at"`
+	UpdatedAt    time.Time                         `json:"updated_at"`
+	BountyAmount uint64                            `json:"bounty_amount"`
+}
+
+// FetchRegistrationStatus fetches current transactor registration status for given identity.
+func (t *Transactor) FetchRegistrationStatus(id string) (TransactorStatusResponse, error) {
+	f := TransactorStatusResponse{}
+
+	req, err := requests.NewGetRequest(t.endpointAddress, fmt.Sprintf("identity/%v/status", id), nil)
+	if err != nil {
+		return f, fmt.Errorf("failed to fetch transactor registration status: %w", err)
+	}
+
+	err = t.httpClient.DoRequestAndParseResponse(req, &f)
+	return f, err
+}

--- a/session/pingpong/accountant_caller.go
+++ b/session/pingpong/accountant_caller.go
@@ -335,6 +335,9 @@ var ErrAccountantNotFound = errors.New("resource not found")
 // ErrTooManyRequests occurs when we call the reveal R or request promise errors asynchronously at the same time.
 var ErrTooManyRequests = errors.New("too many simultaneous requests")
 
+// ErrConsumerUnregistered indicates that the consumer is not registered.
+var ErrConsumerUnregistered = errors.New("consumer unregistered")
+
 var accountantCauseToError = map[string]error{
 	ErrAccountantInvalidSignature.Error():         ErrAccountantInvalidSignature,
 	ErrAccountantInternal.Error():                 ErrAccountantInternal,
@@ -349,6 +352,7 @@ var accountantCauseToError = map[string]error{
 	ErrAccountantNotFound.Error():                 ErrAccountantNotFound,
 	ErrNeedsRRecovery.Error():                     ErrNeedsRRecovery,
 	ErrTooManyRequests.Error():                    ErrTooManyRequests,
+	ErrConsumerUnregistered.Error():               ErrConsumerUnregistered,
 }
 
 type rRecoveryDetails struct {

--- a/session/pingpong/accountant_promise_settler_test.go
+++ b/session/pingpong/accountant_promise_settler_test.go
@@ -472,8 +472,11 @@ var mockProviderChannel = client.ProviderChannel{
 }
 
 type mockTransactor struct {
-	feesToReturn registry.FeesResponse
 	feesError    error
+	feesToReturn registry.FeesResponse
+
+	statusToReturn registry.TransactorStatusResponse
+	statusError    error
 }
 
 func (mt *mockTransactor) FetchSettleFees() (registry.FeesResponse, error) {
@@ -486,4 +489,8 @@ func (mt *mockTransactor) SettleAndRebalance(id string, promise crypto.Promise) 
 
 func (mt *mockTransactor) SettleWithBeneficiary(_, _, _ string, _ crypto.Promise) error {
 	return nil
+}
+
+func (mt *mockTransactor) FetchRegistrationStatus(id string) (registry.TransactorStatusResponse, error) {
+	return mt.statusToReturn, mt.statusError
 }

--- a/session/pingpong/consumer_balance_tracker_test.go
+++ b/session/pingpong/consumer_balance_tracker_test.go
@@ -57,7 +57,7 @@ func TestConsumerBalanceTracker_Fresh_Registration(t *testing.T) {
 	}
 	calc := mockChannelAddressCalculator{}
 
-	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{})
+	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{}, &mockTransactor{})
 
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
@@ -96,6 +96,78 @@ func TestConsumerBalanceTracker_Fresh_Registration(t *testing.T) {
 	}, defaultWaitTime, defaultWaitInterval)
 }
 
+func TestConsumerBalanceTracker_Fast_Registration(t *testing.T) {
+	id1 := identity.FromAddress("0x000000001")
+	accountantID := common.HexToAddress("0x000000acc")
+	t.Run("Takes balance from accountant response", func(t *testing.T) {
+		bus := eventbus.New()
+		mcts := mockConsumerTotalsStorage{
+			bus: bus,
+		}
+		bc := mockConsumerBalanceChecker{
+			channelToReturn: client.ConsumerChannel{
+				Balance: big.NewInt(initialBalance),
+				Settled: big.NewInt(0),
+			},
+		}
+		calc := mockChannelAddressCalculator{}
+
+		var ba uint64 = 10000000
+		cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{}, &mockTransactor{
+			statusToReturn: registry.TransactorStatusResponse{
+				Status:       registry.TransactorRegistrationEntryStatusCreated,
+				BountyAmount: ba,
+			},
+		})
+
+		err := cbt.Subscribe(bus)
+		assert.NoError(t, err)
+
+		bus.Publish(registry.AppTopicIdentityRegistration, registry.AppEventIdentityRegistration{
+			ID:     id1,
+			Status: registry.InProgress,
+		})
+
+		assert.Eventually(t, func() bool {
+			return cbt.GetBalance(id1) == ba
+		}, defaultWaitTime, defaultWaitInterval)
+	})
+	t.Run("Falls back to blockchain balance if no bounty is specified on transactor", func(t *testing.T) {
+		bus := eventbus.New()
+		mcts := mockConsumerTotalsStorage{
+			bus: bus,
+		}
+		var ba uint64 = 10000000
+		bc := mockConsumerBalanceChecker{
+			channelToReturn: client.ConsumerChannel{
+				Balance: big.NewInt(initialBalance),
+				Settled: big.NewInt(0),
+			},
+			mystBalanceToReturn: big.NewInt(0).SetUint64(ba),
+		}
+		calc := mockChannelAddressCalculator{}
+
+		cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{}, &mockTransactor{
+			statusToReturn: registry.TransactorStatusResponse{
+				Status:       registry.TransactorRegistrationEntryStatusCreated,
+				BountyAmount: 0,
+			},
+		})
+
+		err := cbt.Subscribe(bus)
+		assert.NoError(t, err)
+
+		bus.Publish(registry.AppTopicIdentityRegistration, registry.AppEventIdentityRegistration{
+			ID:     id1,
+			Status: registry.InProgress,
+		})
+
+		assert.Eventually(t, func() bool {
+			return cbt.GetBalance(id1) == ba
+		}, defaultWaitTime, defaultWaitInterval)
+	})
+}
+
 func TestConsumerBalanceTracker_Handles_GrandTotalChanges(t *testing.T) {
 	id1 := identity.FromAddress("0x000000001")
 	accountantID := common.HexToAddress("0x000000acc")
@@ -112,7 +184,7 @@ func TestConsumerBalanceTracker_Handles_GrandTotalChanges(t *testing.T) {
 		},
 	}
 	calc := mockChannelAddressCalculator{}
-	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{grandTotalPromised})
+	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{grandTotalPromised}, &mockTransactor{})
 
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
@@ -159,7 +231,7 @@ func TestConsumerBalanceTracker_Handles_TopUp(t *testing.T) {
 		ch: make(chan *bindings.MystTokenTransfer),
 	}
 	calc := mockChannelAddressCalculator{}
-	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{grandTotalPromised})
+	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{grandTotalPromised}, &mockTransactor{})
 
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
@@ -183,6 +255,9 @@ type mockConsumerBalanceChecker struct {
 	channelToReturn client.ConsumerChannel
 	errToReturn     error
 	ch              chan *bindings.MystTokenTransfer
+
+	mystBalanceToReturn *big.Int
+	mystBalanceError    error
 }
 
 func (mcbc *mockConsumerBalanceChecker) GetConsumerChannel(addr common.Address, mystSCAddress common.Address) (client.ConsumerChannel, error) {
@@ -191,6 +266,10 @@ func (mcbc *mockConsumerBalanceChecker) GetConsumerChannel(addr common.Address, 
 
 func (mcbc *mockConsumerBalanceChecker) SubscribeToConsumerBalanceEvent(channel, mystSCAddress common.Address, timeout time.Duration) (chan *bindings.MystTokenTransfer, func(), error) {
 	return mcbc.ch, func() {}, nil
+}
+
+func (mcbc *mockConsumerBalanceChecker) GetMystBalance(mystAddress, identity common.Address) (*big.Int, error) {
+	return mcbc.mystBalanceToReturn, mcbc.mystBalanceError
 }
 
 type mockChannelAddressCalculator struct {
@@ -227,7 +306,7 @@ func TestConsumerBalanceTracker_DoesNotBlockedOnEmptyBalancesList(t *testing.T) 
 	}
 	calc := mockChannelAddressCalculator{}
 
-	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{})
+	cbt := NewConsumerBalanceTracker(bus, mockMystSCaddress, accountantID, &bc, &calc, &mcts, &mockconsumerInfoGetter{}, &mockTransactor{})
 
 	// Make sure we are not dead locked here. https://github.com/mysteriumnetwork/node/issues/2181
 	cbt.increaseBCBalance(identity.FromAddress("0x0000"), 1)

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -450,7 +450,8 @@ func (it *InvoiceTracker) handleAccountantError(err error) error {
 		stdErr.Is(err, ErrAccountantInvalidSignature),
 		stdErr.Is(err, ErrAccountantPaymentValueTooLow),
 		stdErr.Is(err, ErrAccountantPromiseValueTooLow),
-		stdErr.Is(err, ErrAccountantOverspend):
+		stdErr.Is(err, ErrAccountantOverspend),
+		stdErr.Is(err, ErrConsumerUnregistered):
 		// these are critical, return and cancel session
 		return err
 	default:

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -155,8 +155,11 @@ func (ce *ConnectionEndpoint) Create(resp http.ResponseWriter, req *http.Request
 		log.Warn().Msgf("identity %q is not registered, aborting...", cr.ConsumerID)
 		utils.SendError(resp, fmt.Errorf("identity %q is not registered. Please register the identity first", cr.ConsumerID), http.StatusExpectationFailed)
 		return
+	case registry.InProgress:
+		log.Info().Msgf("identity %q registration is in progress, continuing...", cr.ConsumerID)
+	default:
+		log.Info().Msgf("identity %q is registered, continuing...", cr.ConsumerID)
 	}
-	log.Info().Msgf("identity %q is registered, continuing...", cr.ConsumerID)
 
 	// TODO Pass proposal ID directly in request
 	proposal, err := ce.proposalRepository.Proposal(market.ProposalID{

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -151,7 +151,7 @@ func (ce *ConnectionEndpoint) Create(resp http.ResponseWriter, req *http.Request
 		return
 	}
 	switch status {
-	case registry.Unregistered, registry.InProgress, registry.RegistrationError:
+	case registry.Unregistered, registry.RegistrationError:
 		log.Warn().Msgf("identity %q is not registered, aborting...", cr.ConsumerID)
 		utils.SendError(resp, fmt.Errorf("identity %q is not registered. Please register the identity first", cr.ConsumerID), http.StatusExpectationFailed)
 		return


### PR DESCRIPTION
The registration is now quick. We no longer wait for registration confirmations on blockchain.

To accommodate this, needed to make the following changes on node side:

1) Implement calls to transactor status endpoint.
2) Change balance calculations for registrations with status of `inprogress`.
3) Bump Hermes, Transactor versions in e2e tests.



Closes #2027