### PR TITLE
Destroy remote WireGuard device on close

### DIFF
--- a/services/wireguard/endpoint/kernelspace/client.go
+++ b/services/wireguard/endpoint/kernelspace/client.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/jackpal/gateway"
 	wg "github.com/mysteriumnetwork/node/services/wireguard"
+	"github.com/mysteriumnetwork/node/utils"
 	"github.com/mysteriumnetwork/node/utils/cmdutil"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -167,24 +167,16 @@ func addDefaultRoute(iface string) error {
 }
 
 func (c *client) Close() (err error) {
-	var errs []error
-	defer func() {
-		for i := range errs {
-			log.Error().Err(errs[i]).Msg("Failed to close wireguard kernelspace client")
-			if err == nil {
-				err = errs[i]
-			}
-		}
-	}()
-
+	errs := utils.ErrorCollection{}
 	if err := c.DestroyDevice(c.iface); err != nil {
-		errs = append(errs, err)
+		errs.Add(err)
 	}
-
 	if err := c.wgClient.Close(); err != nil {
-		errs = append(errs, err)
+		errs.Add(err)
 	}
-
+	if err := errs.Error(); err != nil {
+		return fmt.Errorf("could not close client: %w", err)
+	}
 	return nil
 }
 

--- a/supervisor/daemon/daemon.go
+++ b/supervisor/daemon/daemon.go
@@ -58,6 +58,7 @@ func (d Daemon) dialog(conn io.ReadWriter) {
 	for scan.Scan() {
 		line := scan.Bytes()
 		line = bytes.ToLower(line)
+		log.Printf("scan line: %s", line)
 		cmd := strings.Split(string(line), " ")
 		op := cmd[0]
 		switch op {


### PR DESCRIPTION
Disconnect was not working when using supervisor since Wgctrl close doesn't know how to remove tunnel interface. 