### PR TITLE
Only allow a single invoice to be skipped

### DIFF
--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -120,7 +120,7 @@ func InvoiceFactoryCreator(
 			InvoiceStorage:             invoiceStorage,
 			TimeTracker:                &timeTracker,
 			ChargePeriod:               balanceSendPeriod,
-			ChargePeriodLeeway:         15 * time.Minute,
+			ChargePeriodLeeway:         2 * time.Minute,
 			ExchangeMessageChan:        exchangeChan,
 			ExchangeMessageWaitTimeout: promiseTimeout,
 			FirstInvoiceSendTimeout:    10 * time.Second,


### PR DESCRIPTION
A single invoice is allowed to be skipped, but two in a row leads to session being killed.

Closes #2177