### PR TITLE
Start myst with specified uid and gid

### DIFF
--- a/supervisor/daemon/daemon.go
+++ b/supervisor/daemon/daemon.go
@@ -69,7 +69,7 @@ func (d Daemon) dialog(conn io.ReadWriter) {
 			answer.ok("pong")
 		case commandRun:
 			go func() {
-				err := d.RunMyst()
+				err := d.runMyst(cmd...)
 				if err != nil {
 					log.Printf("failed %s: %s", commandRun, err)
 					answer.err(err)

--- a/supervisor/daemon/myst_linux.go
+++ b/supervisor/daemon/myst_linux.go
@@ -19,8 +19,8 @@ package daemon
 
 import "errors"
 
-// RunMyst runs mysterium node daemon. Blocks.
-func (d *Daemon) RunMyst() error {
+// runMyst runs mysterium node daemon. Blocks.
+func (d *Daemon) runMyst(args ...string) error {
 	return errors.New("not implemented")
 }
 

--- a/supervisor/daemon/myst_windows.go
+++ b/supervisor/daemon/myst_windows.go
@@ -19,8 +19,8 @@ package daemon
 
 import "errors"
 
-// RunMyst runs mysterium node daemon. Blocks.
-func (d *Daemon) RunMyst() error {
+// runMyst runs mysterium node daemon. Blocks.
+func (d *Daemon) runMyst(args ...string) error {
 	return errors.New("not implemented")
 }
 


### PR DESCRIPTION
When starting myst daemon from electron pass it's user's uid and gid. If these are not passed myst will start as root user.

Previously tried to start, stop myst from electron, but it's quite unstable sometimes and myst may not stop.

Fixes https://github.com/mysteriumnetwork/node/issues/2240