### PR TITLE
Make go buildable crossplatform with `mage build`

### DIFF
--- a/ci/dev/build.go
+++ b/ci/dev/build.go
@@ -18,17 +18,113 @@
 package dev
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
+	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	"github.com/mysteriumnetwork/go-ci/env"
+	"github.com/mysteriumnetwork/node/logconfig"
+	"github.com/mysteriumnetwork/node/utils/fileutil"
+	"github.com/rs/zerolog/log"
 )
+
+// Build builds the project. Like go tool, it supports cross-platform build with env vars: GOOS, GOARCH.
+func Build() error {
+	logconfig.Bootstrap()
+	if err := buildBinary(path.Join("cmd", "mysterium_node", "mysterium_node.go"), "myst"); err != nil {
+		return err
+	}
+	if err := copyConfig("myst"); err != nil {
+		return err
+	}
+	if err := buildBinary(path.Join("cmd", "supervisor", "supervisor.go"), "myst_supervisor"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func linkerFlags() (flags []string) {
+	if env.Str(env.BuildBranch) != "" {
+		flags = append(flags, "-X", fmt.Sprintf("'github.com/mysteriumnetwork/node/metadata.BuildBranch=%s'", env.Str(env.BuildBranch)))
+	}
+	if env.Str("BUILD_COMMIT") != "" {
+		flags = append(flags, "-X", fmt.Sprintf("'github.com/mysteriumnetwork/node/metadata.BuildCommit=%s'", env.Str("BUILD_COMMIT")))
+	}
+	if env.Str(env.BuildNumber) != "" {
+		flags = append(flags, "-X", fmt.Sprintf("'github.com/mysteriumnetwork/node/metadata.BuildNumber=%s'", env.Str(env.BuildNumber)))
+	}
+	if env.Str(env.BuildVersion) != "" {
+		flags = append(flags, "-X", fmt.Sprintf("'github.com/mysteriumnetwork/node/metadata.Version=%s'", env.Str(env.BuildVersion)))
+	}
+	return flags
+}
+
+func buildBinary(source, target string) error {
+	targetOS, ok := os.LookupEnv("GOOS")
+	if !ok {
+		targetOS = runtime.GOOS
+	}
+	targetArch, ok := os.LookupEnv("GOARCH")
+	if !ok {
+		targetArch = runtime.GOARCH
+	}
+	log.Info().Msgf("Building %s -> %s %s/%s", source, target, targetOS, targetArch)
+
+	buildDir, err := filepath.Abs(path.Join("build", target))
+	if err != nil {
+		return err
+	}
+
+	var flags = []string{"build"}
+	if env.Bool("FLAG_RACE") {
+		flags = append(flags, "-race")
+	}
+
+	ldFlags := linkerFlags()
+	flags = append(flags, fmt.Sprintf(`-ldflags=-w -s %s`, strings.Join(ldFlags, " ")))
+
+	if os.Getenv("GOOS") == "windows" {
+		target += ".exe"
+	}
+	flags = append(flags, "-o", path.Join(buildDir, target), source)
+	return sh.Run("go", flags...)
+}
+
+func copyConfig(target string) error {
+	dest, err := filepath.Abs(path.Join("build", target, "config"))
+	if err != nil {
+		return err
+	}
+
+	common, err := filepath.Abs(path.Join("bin", "package", "config", "common"))
+	if err != nil {
+		return err
+	}
+	if err := fileutil.CopyDirs(common, dest); err != nil {
+		return err
+	}
+
+	targetOS, ok := os.LookupEnv("GOOS")
+	if !ok {
+		targetOS = runtime.GOOS
+	}
+	osSpecific, err := filepath.Abs(path.Join("bin", "package", "config", targetOS))
+	if err := fileutil.CopyDirs(osSpecific, dest); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 // Daemon builds and runs myst daemon
 func Daemon() error {
-	if err := sh.RunV("bin/build"); err != nil {
-		return err
-	}
+	mg.Deps(Build)
+
 	cmd := "build/myst/myst daemon"
 	if runtime.GOOS == "darwin" {
 		cmd = "sudo " + cmd
@@ -39,9 +135,8 @@ func Daemon() error {
 
 // Openvpn builds and starts openvpn service with terms accepted
 func Openvpn() error {
-	if err := sh.RunV("bin/build"); err != nil {
-		return err
-	}
+	mg.Deps(Build)
+
 	cmd := "build/myst/myst service --agreed-terms-and-conditions openvpn"
 	if runtime.GOOS == "darwin" {
 		cmd = "sudo " + cmd
@@ -52,9 +147,8 @@ func Openvpn() error {
 
 // Wireguard builds and starts wireguard service with terms accepted
 func Wireguard() error {
-	if err := sh.RunV("bin/build"); err != nil {
-		return err
-	}
+	mg.Deps(Build)
+
 	cmd := "build/myst/myst service --agreed-terms-and-conditions wireguard"
 	if runtime.GOOS == "darwin" {
 		cmd = "sudo " + cmd
@@ -65,8 +159,7 @@ func Wireguard() error {
 
 // CLI builds and runs myst CLI
 func CLI() error {
-	if err := sh.RunV("bin/build"); err != nil {
-		return err
-	}
+	mg.Deps(Build)
+
 	return sh.RunV("build/myst/myst", "cli")
 }

--- a/go.sum
+++ b/go.sum
@@ -89,12 +89,15 @@ github.com/corbym/gocrest v1.0.3/go.mod h1:maVFL5lbdS2PgfOQgGRWDYTeunSWQeiEgoNdT
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.15+incompatible h1:+9RjdC18gMxNQVvSiXvObLu29mOFmkgdsB4cRTlV+EE=
 github.com/coreos/etcd v3.3.15+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/utils/fileutil/fileutil.go
+++ b/utils/fileutil/fileutil.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fileutil provides utility methods used when dealing with the filesystem in tsdb.
+// It is largely copied from github.com/coreos/etcd/pkg/fileutil to avoid the
+// dependency chain it brings with it.
+// Please check github.com/coreos/etcd for licensing information.
+
+package fileutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CopyDirs copies all directories, subdirectories and files recursively including the empty folders.
+// Source and destination must be full paths.
+func CopyDirs(src, dest string) error {
+	if err := os.MkdirAll(dest, 0777); err != nil {
+		return err
+	}
+	files, err := readDirs(src)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		dp := filepath.Join(dest, f)
+		sp := filepath.Join(src, f)
+
+		stat, err := os.Stat(sp)
+		if err != nil {
+			return err
+		}
+
+		// Empty directories are also created.
+		if stat.IsDir() {
+			if err := os.MkdirAll(dp, 0777); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := copyFile(sp, dp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dest string) error {
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(dest, data, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// readDirs reads the source directory recursively and
+// returns relative paths to all files and empty directories.
+func readDirs(src string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(src, func(path string, f os.FileInfo, err error) error {
+		relativePath := strings.TrimPrefix(path, src)
+		if len(relativePath) > 0 {
+			files = append(files, relativePath)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// ReadDir returns the filenames in the given directory in sorted order.
+func ReadDir(dirpath string) ([]string, error) {
+	dir, err := os.Open(dirpath)
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}


### PR DESCRIPTION
This is mostly for making dev life easier under windows, as well as one more step away from shell scripts to mage.