### PR TITLE
Separate script and config dirs (important for --usermode)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ sudo tail -f /var/log/mysterium-node/*
 
 ### Debugging standalone
 ```bash
-sudo myst --data-dir=/var/lib/mysterium-node --config-dir=/etc/mysterium-node --runtime-dir=/tmp --identity=0x123456..
+sudo myst --data-dir=/var/lib/mysterium-node --config-dir=/etc/mysterium-node --script-dir=/etc/mysterium-node --runtime-dir=/tmp --identity=0x123456..
 ```
 
 ## Mysterium VPN node and client standalone binaries (.tar.gz)

--- a/bin/docker/docker-entrypoint.sh
+++ b/bin/docker/docker-entrypoint.sh
@@ -9,6 +9,7 @@ export OS_DIR_RUN="/var/run/mysterium-node"
 
 exec /usr/bin/myst \
  --config-dir=$OS_DIR_CONFIG \
+ --script-dir=$OS_DIR_CONFIG \
  --log-dir="" \
  --data-dir=$OS_DIR_DATA \
  --runtime-dir=$OS_DIR_RUN \

--- a/bin/package/installation/default
+++ b/bin/package/installation/default
@@ -1,5 +1,6 @@
 # Define additional args for `myst` service (see `myst --help` for full list)
 CONF_DIR="--config-dir=/etc/mysterium-node"
+SCRIPT_DIR="--script-dir=/etc/mysterium-node"
 RUN_DIR="--runtime-dir=/var/run/mysterium-node"
 DATA_DIR="--data-dir=/var/lib/mysterium-node"
 DAEMON_OPTS="--keystore.lightweight"

--- a/bin/package/installation/initd.sh
+++ b/bin/package/installation/initd.sh
@@ -111,6 +111,7 @@ function start() {
         --exec $DAEMON_BIN \
         -- \
         --config-dir=$OS_DIR_CONFIG \
+        --script-dir=$OS_DIR_CONFIG \
         --data-dir=$OS_DIR_DATA \
         --runtime-dir=$OS_DIR_RUN \
         $DAEMON_OPTS \

--- a/bin/package/installation/systemd.service
+++ b/bin/package/installation/systemd.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0750
 LogsDirectory=mysterium-node
 
 EnvironmentFile=-/etc/default/mysterium-node
-ExecStart=/usr/bin/myst $CONF_DIR $DATA_DIR $RUN_DIR $DAEMON_OPTS service --agreed-terms-and-conditions $SERVICE_OPTS
+ExecStart=/usr/bin/myst $CONF_DIR $SCRIPT_DIR $DATA_DIR $RUN_DIR $DAEMON_OPTS service --agreed-terms-and-conditions $SERVICE_OPTS
 KillMode=process
 TimeoutStopSec=10
 SendSIGKILL=yes

--- a/bin/package/raspberry/files/default-myst-conf
+++ b/bin/package/raspberry/files/default-myst-conf
@@ -1,5 +1,6 @@
 # Define additional args for `myst` service (see `myst --help` for full list)
 CONF_DIR="--config-dir=/etc/mysterium-node"
+SCRIPT_DIR="--script-dir=/etc/mysterium-node"
 RUN_DIR="--runtime-dir=/var/run/mysterium-node"
 DATA_DIR="--data-dir=/var/lib/mysterium-node"
 SERVICE_OPTS="openvpn,wireguard"

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -302,7 +302,7 @@ func (di *Dependencies) registerOpenvpnConnection(nodeOptions node.Options) {
 		return service_openvpn.NewClient(
 			// TODO instead of passing binary path here, Openvpn from node options could represent abstract vpn factory itself
 			nodeOptions.Openvpn.BinaryPath(),
-			nodeOptions.Directories.Config,
+			nodeOptions.Directories.Script,
 			nodeOptions.Directories.Runtime,
 			di.SignerFactory,
 			di.IPResolver,
@@ -705,7 +705,7 @@ func (di *Dependencies) bootstrapLocationComponents(options node.Options) (err e
 	case node.LocationTypeBuiltin:
 		resolver, err = location.NewBuiltInResolver(di.IPResolver)
 	case node.LocationTypeMMDB:
-		resolver, err = location.NewExternalDBResolver(filepath.Join(options.Directories.Config, options.Location.Address), di.IPResolver)
+		resolver, err = location.NewExternalDBResolver(filepath.Join(options.Directories.Script, options.Location.Address), di.IPResolver)
 	case node.LocationTypeOracle:
 		if _, err := firewall.AllowURLAccess(options.Location.Address); err != nil {
 			return err

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -281,7 +281,7 @@ func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options) {
 	}
 	connFactory := func() (connection.Connection, error) {
 		opts := wireguard_connection.Options{
-			DNSConfigDir:     nodeOptions.Directories.Config,
+			DNSScriptDir:     nodeOptions.Directories.Script,
 			HandshakeTimeout: 1 * time.Minute,
 		}
 		return wireguard_connection.NewConnection(opts, di.IPResolver, endpointFactory, dnsManager, handshakeWaiter)

--- a/config/flags_directory.go
+++ b/config/flags_directory.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// FlagConfigDir directory containing all configuration, script and helper files.
+	// FlagConfigDir directory containing all configuration files.
 	FlagConfigDir = cli.StringFlag{
 		Name:  "config-dir",
-		Usage: "Configs directory containing all configuration, script and helper files",
+		Usage: "Config directory containing all configuration files",
 	}
 	// FlagDataDir data directory for keystore and other persistent files.
 	FlagDataDir = cli.StringFlag{
@@ -45,6 +45,11 @@ var (
 		Name:  "runtime-dir",
 		Usage: "Runtime writable directory for temp files",
 	}
+	// FlagScriptDir directory containing script and helper files.
+	FlagScriptDir = cli.StringFlag{
+		Name:  "script-dir",
+		Usage: "Script directory containing all script and helper files",
+	}
 )
 
 // RegisterFlagsDirectory function register directory flags to flag list
@@ -59,26 +64,29 @@ func RegisterFlagsDirectory(flags *[]cli.Flag) error {
 		return err
 	}
 
-	FlagConfigDir.Value = filepath.Join(currentDir, "config")
 	FlagDataDir.Value = filepath.Join(userHomeDir, ".mysterium")
+	FlagConfigDir.Value = FlagDataDir.Value
 	FlagLogDir.Value = filepath.Join(FlagDataDir.Value, "logs")
 	FlagRuntimeDir.Value = currentDir
+	FlagScriptDir.Value = filepath.Join(currentDir, "config")
 
 	*flags = append(*flags,
 		&FlagConfigDir,
 		&FlagDataDir,
 		&FlagLogDir,
 		&FlagRuntimeDir,
+		&FlagScriptDir,
 	)
 	return nil
 }
 
 // ParseFlagsDirectory function fills in directory options from CLI context
 func ParseFlagsDirectory(ctx *cli.Context) {
-	Current.ParseStringFlag(ctx, FlagLogDir)
-	Current.ParseStringFlag(ctx, FlagDataDir)
 	Current.ParseStringFlag(ctx, FlagConfigDir)
+	Current.ParseStringFlag(ctx, FlagDataDir)
+	Current.ParseStringFlag(ctx, FlagLogDir)
 	Current.ParseStringFlag(ctx, FlagRuntimeDir)
+	Current.ParseStringFlag(ctx, FlagScriptDir)
 }
 
 func getExecutableDir() (string, error) {

--- a/core/node/options_directory.go
+++ b/core/node/options_directory.go
@@ -34,8 +34,8 @@ type OptionsDirectory struct {
 	Storage string
 	// Data directory stores identity keys
 	Keystore string
-	// Config directory stores all data needed for runtime (db scripts etc.)
-	Config string
+	// Script directory stores all data needed for runtime, e.g. DNS scripts.
+	Script string
 	// Runtime directory for various temp file - usually current working dir
 	Runtime string
 }
@@ -47,7 +47,7 @@ func GetOptionsDirectory() *OptionsDirectory {
 		Data:     dataDir,
 		Storage:  filepath.Join(dataDir, "db"),
 		Keystore: filepath.Join(dataDir, "keystore"),
-		Config:   config.GetString(config.FlagConfigDir),
+		Script:   config.GetString(config.FlagScriptDir),
 		Runtime:  config.GetString(config.FlagRuntimeDir),
 	}
 }

--- a/localnet/consumer.sh
+++ b/localnet/consumer.sh
@@ -4,6 +4,7 @@ set -e
 
 exec /node/build/myst/myst \
   --config-dir=/etc/mysterium-node \
+  --script-dir=/etc/mysterium-node \
   --log-dir= --data-dir=/var/lib/mysterium-node \
   --runtime-dir=/var/run/mysterium-node \
   --tequilapi.address=0.0.0.0 \

--- a/localnet/provider.sh
+++ b/localnet/provider.sh
@@ -4,6 +4,7 @@ set -e
 
 exec /node/build/myst/myst \
   --config-dir=/etc/mysterium-node \
+  --script-dir=/etc/mysterium-node \
   --log-dir= --data-dir=/var/lib/mysterium-node \
   --runtime-dir=/var/run/mysterium-node \
   --tequilapi.address=0.0.0.0 \

--- a/services/openvpn/client.go
+++ b/services/openvpn/client.go
@@ -44,15 +44,15 @@ var ErrProcessNotStarted = errors.New("process not started yet")
 type processFactory func(options connection.ConnectOptions, sessionConfig VPNConfig) (openvpn.Process, *ClientConfig, error)
 
 // NewClient creates a new openvpn connection
-func NewClient(openvpnBinary, configDirectory, runtimeDirectory string,
+func NewClient(openvpnBinary, scriptDir, runtimeDir string,
 	signerFactory identity.SignerFactory,
 	ipResolver ip.Resolver,
 ) (connection.Connection, error) {
 
 	stateCh := make(chan connection.State, 100)
 	client := &Client{
-		configDirectory:     configDirectory,
-		runtimeDirectory:    runtimeDirectory,
+		scriptDir:           scriptDir,
+		runtimeDir:          runtimeDir,
 		signerFactory:       signerFactory,
 		stateCh:             stateCh,
 		ipResolver:          ipResolver,
@@ -60,7 +60,7 @@ func NewClient(openvpnBinary, configDirectory, runtimeDirectory string,
 	}
 
 	procFactory := func(options connection.ConnectOptions, sessionConfig VPNConfig) (openvpn.Process, *ClientConfig, error) {
-		vpnClientConfig, err := NewClientConfigFromSession(sessionConfig, configDirectory, runtimeDirectory, options)
+		vpnClientConfig, err := NewClientConfigFromSession(sessionConfig, scriptDir, runtimeDir, options)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -80,8 +80,8 @@ func NewClient(openvpnBinary, configDirectory, runtimeDirectory string,
 
 // Client takes in the openvpn process and works with it
 type Client struct {
-	configDirectory     string
-	runtimeDirectory    string
+	scriptDir           string
+	runtimeDir          string
 	signerFactory       identity.SignerFactory
 	stateCh             chan connection.State
 	stats               connection.Statistics

--- a/services/openvpn/client_config.go
+++ b/services/openvpn/client_config.go
@@ -78,7 +78,7 @@ func defaultClientConfig(runtimeDir string, scriptSearchPath string) *ClientConf
 // NewClientConfigFromSession creates client configuration structure for given VPNConfig, configuration dir to store serialized file args, and
 // configuration filename to store other args
 // TODO this will become the part of openvpn service consumer separate package
-func NewClientConfigFromSession(vpnConfig VPNConfig, configDir string, runtimeDir string, options connection.ConnectOptions) (*ClientConfig, error) {
+func NewClientConfigFromSession(vpnConfig VPNConfig, scriptDir string, runtimeDir string, options connection.ConnectOptions) (*ClientConfig, error) {
 	// TODO Rename `vpnConfig` to `sessionConfig`
 	err := NewDefaultValidator().IsValid(vpnConfig)
 	if err != nil {
@@ -90,7 +90,7 @@ func NewClientConfigFromSession(vpnConfig VPNConfig, configDir string, runtimeDi
 		return nil, err
 	}
 
-	clientFileConfig := newClientConfig(runtimeDir, configDir)
+	clientFileConfig := newClientConfig(runtimeDir, scriptDir)
 	dnsIPs, err := options.DNS.ResolveIPs(vpnConfig.DNSIPs)
 	if err != nil {
 		return nil, err

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -223,7 +223,7 @@ func (m *Manager) ProvideConfig(sessionID string, sessionConfig json.RawMessage,
 func (m *Manager) startServer() error {
 	vpnServerConfig := NewServerConfig(
 		m.nodeOptions.Directories.Runtime,
-		m.nodeOptions.Directories.Config,
+		m.nodeOptions.Directories.Script,
 		m.serviceOptions.Subnet,
 		m.serviceOptions.Netmask,
 		m.tlsPrimitives,

--- a/services/openvpn/service/server_config.go
+++ b/services/openvpn/service/server_config.go
@@ -52,14 +52,14 @@ func (c *ServerConfig) SetProtocol(protocol string) {
 // NewServerConfig creates server configuration structure from given basic parameters
 func NewServerConfig(
 	runtimeDir string,
-	configDir string,
+	scriptDir string,
 	network, netmask string,
 	secPrimitives *tls.Primitives,
 	bindAddress string,
 	port int,
 	protocol string,
 ) *ServerConfig {
-	serverConfig := ServerConfig{config.NewConfig(runtimeDir, configDir)}
+	serverConfig := ServerConfig{config.NewConfig(runtimeDir, scriptDir)}
 	serverConfig.SetServerMode(port, network, netmask)
 	serverConfig.SetTLSServer()
 	serverConfig.SetProtocol(protocol)

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -35,7 +35,7 @@ import (
 
 // Options represents connection options.
 type Options struct {
-	DNSConfigDir     string
+	DNSScriptDir     string
 	HandshakeTimeout time.Duration
 }
 
@@ -154,7 +154,7 @@ func (c *Connection) Start(ctx context.Context, options connection.ConnectOption
 		return errors.Wrap(err, "could not resolve DNS IPs")
 	}
 	config.Consumer.DNSIPs = dnsIPs[0]
-	if err := c.dnsManager.Set(c.opts.DNSConfigDir, conn.InterfaceName(), config.Consumer.DNSIPs); err != nil {
+	if err := c.dnsManager.Set(c.opts.DNSScriptDir, conn.InterfaceName(), config.Consumer.DNSIPs); err != nil {
 		return errors.Wrap(err, "failed to configure DNS")
 	}
 
@@ -212,7 +212,7 @@ func (c *Connection) Stop() {
 		c.stateCh <- connection.Disconnecting
 
 		if c.connectionEndpoint != nil {
-			if err := c.dnsManager.Clean(c.opts.DNSConfigDir, c.connectionEndpoint.InterfaceName()); err != nil {
+			if err := c.dnsManager.Clean(c.opts.DNSScriptDir, c.connectionEndpoint.InterfaceName()); err != nil {
 				log.Error().Err(err).Msg("Failed to clear DNS")
 			}
 			if err := c.connectionEndpoint.Stop(); err != nil {

--- a/services/wireguard/connection/connection_test.go
+++ b/services/wireguard/connection/connection_test.go
@@ -96,7 +96,7 @@ func newConn(t *testing.T) *Connection {
 		return &mockConnectionEndpoint{}, nil
 	}
 	opts := Options{
-		DNSConfigDir: "/dns/dir",
+		DNSScriptDir: "/dns/dir",
 	}
 	conn, err := NewConnection(opts, ip.NewResolverMock("172.44.1.12"), endpointFactory, &mockDnsManager{}, &mockHandshakeWaiter{})
 	assert.NoError(t, err)
@@ -154,5 +154,5 @@ func (m *mockHandshakeWaiter) Wait(statsFetch func() (*wg.Stats, error), timeout
 
 type mockDnsManager struct{}
 
-func (m mockDnsManager) Set(configDir, dev, dns string) error { return nil }
-func (m mockDnsManager) Clean(configDir, dev string) error    { return nil }
+func (m mockDnsManager) Set(scriptDir, dev, dns string) error { return nil }
+func (m mockDnsManager) Clean(scriptDir, dev string) error    { return nil }

--- a/services/wireguard/connection/dns.go
+++ b/services/wireguard/connection/dns.go
@@ -20,7 +20,7 @@ package connection
 // DNSManager is connection DNS configuration manager.
 type DNSManager interface {
 	// Set applies DNS configuration.
-	Set(configDir, dev, dns string) error
+	Set(scriptDir, dev, dns string) error
 	// Clean removes DNS configuration.
-	Clean(configDir, dev string) error
+	Clean(scriptDir, dev string) error
 }

--- a/services/wireguard/connection/dns_default.go
+++ b/services/wireguard/connection/dns_default.go
@@ -32,15 +32,15 @@ func NewDNSManager() DNSManager {
 
 type dnsManager struct{}
 
-func (dm dnsManager) Set(configDir, dev, dns string) error {
-	cmd := exec.Command(path.Join(configDir, "update-resolv-conf"))
+func (dm dnsManager) Set(scriptDir, dev, dns string) error {
+	cmd := exec.Command(path.Join(scriptDir, "update-resolv-conf"))
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "script_type=up", "dev="+dev, "foreign_option_1=dhcp-option DNS "+dns)
 	return cmd.Run()
 }
 
-func (dm dnsManager) Clean(configDir, dev string) error {
-	cmd := exec.Command(path.Join(configDir, "update-resolv-conf"))
+func (dm dnsManager) Clean(scriptDir, dev string) error {
+	cmd := exec.Command(path.Join(scriptDir, "update-resolv-conf"))
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "script_type=down", "dev="+dev)
 	return cmd.Run()

--- a/services/wireguard/connection/dns_windows.go
+++ b/services/wireguard/connection/dns_windows.go
@@ -24,10 +24,10 @@ func NewDNSManager() DNSManager {
 
 type dnsManager struct{}
 
-func (dm dnsManager) Set(configDir, dev, dns string) error {
+func (dm dnsManager) Set(scriptDir, dev, dns string) error {
 	return nil
 }
 
-func (dm dnsManager) Clean(configDir, dev string) error {
+func (dm dnsManager) Clean(scriptDir, dev string) error {
 	return nil
 }


### PR DESCRIPTION
This allows to still use scripts such as `node/build/myst/config/update-resolv-conf` while storing `config.toml` to `~/.mysterium/config.toml`
Updated all deb package scripts and alike to set `config-dir` = `script-dir` to keep compatibility.