### PR TITLE
Make iptables path consistent acrosss dists

### DIFF
--- a/bin/package/sudoers/mysterium-node
+++ b/bin/package/sudoers/mysterium-node
@@ -1,7 +1,7 @@
 # username host=(user:group) tag:commands
 # let mysterium-node run any command just as root without password
 mysterium-node    ALL=NOPASSWD: /sbin/sysctl
-mysterium-node    ALL=NOPASSWD: /sbin/iptables
+mysterium-node    ALL=NOPASSWD: /usr/sbin/iptables
 mysterium-node    ALL=NOPASSWD: /usr/sbin/ipset
 mysterium-node    ALL=NOPASSWD: /sbin/ipset
 mysterium-node    ALL=NOPASSWD: /sbin/ip

--- a/firewall/iptables/iptables.go
+++ b/firewall/iptables/iptables.go
@@ -30,7 +30,7 @@ import (
 var Exec = defaultExec
 
 func defaultExec(args ...string) ([]string, error) {
-	args = append([]string{"sudo", "/sbin/iptables"}, args...)
+	args = append([]string{"sudo", "/usr/sbin/iptables"}, args...)
 	output, err := cmdutil.ExecOutput(args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "iptables cmd error")

--- a/install.sh
+++ b/install.sh
@@ -231,6 +231,27 @@ install() {
         esac
 }
 
+ensure_paths() {
+    iptables_path=`which iptables`
+    if [[ ${iptables_path} == "" ]]; then
+       echo "required dependecy missing: iptables"
+       return
+    fi
+
+    # validate utility against valid system paths
+    basepath=${iptables_path%/*}
+    if ! [[ ${basepath} =~ (^/usr/sbin/|^/sbin|^/bin|^/usr/bin) ]]; then
+      echo "invalid path for dependecy - check if system PATH has not been altered"
+      return
+    fi
+
+    iptables_required_path="/usr/sbin/iptables"
+
+    if ! [[ -x ${iptables_required_path} ]]; then
+        ln -s ${iptables_path} ${iptables_required_path}
+    fi
+}
+
 echo "### Installing script dependencies"
 install_script_dependencies
 echo "### Installing script dependencies - done"
@@ -253,5 +274,9 @@ echo "### Detecting platform - done"
 echo "### Installing myst & dependencies"
 install
 echo "### Installing myst & dependencies - done"
+
+echo "### Ensuring sane paths for dependencies"
+ensure_paths
+echo "### Ensuring sane paths for dependencies - done"
 
 echo "### Installation complete!"

--- a/nat/service_iptables.go
+++ b/nat/service_iptables.go
@@ -165,7 +165,7 @@ func makeIPTablesRules(opts Options) (rules []iptables.Rule) {
 }
 
 func iptablesExec(args ...string) error {
-	args = append([]string{"/sbin/iptables"}, args...)
+	args = append([]string{"/usr/sbin/iptables"}, args...)
 	if err := cmdutil.SudoExec(args...); err != nil {
 		return errors.Wrap(err, "error calling IPTables")
 	}


### PR DESCRIPTION
fixes: #2146 and #2241 

`/usr/sbin/iptables` is a preferred way according recent distributions. Ensuring that this path exist.