### PR TITLE
Send invoice if threshold reached

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -225,6 +225,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 			nodeOptions.Transactor.ChannelImplementation,
 			pingpong.DefaultAccountantFailureCount,
 			uint16(nodeOptions.Payments.MaxAllowedPaymentPercentile),
+			nodeOptions.Payments.MaxUnpaidInvoiceValue,
 			di.BCHelper,
 			di.EventBus,
 			proposal,

--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -90,6 +90,12 @@ var (
 		Usage: "sets the data amount the consumer agrees to pay before establishing a session",
 		Value: 20,
 	}
+	// FlagPaymentsMaxUnpaidInvoiceValue sets the upper limit of session payment value before forcing an invoice
+	FlagPaymentsMaxUnpaidInvoiceValue = cli.Uint64Flag{
+		Name:  "payments.provider.max-unpaid-invoice-value",
+		Usage: "sets the upper limit of session payment value before forcing an invoice. If this value is exceeded before a payment interval is reached, an invoice is sent.",
+		Value: 3000000,
+	}
 )
 
 // RegisterFlagsPayments function register payments flags to flag list.
@@ -107,6 +113,7 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagPaymentsConsumerPricePerGBUpperBound,
 		&FlagPaymentsConsumerPricePerGBLowerBound,
 		&FlagPaymentsConsumerDataLeewayMegabytes,
+		&FlagPaymentsMaxUnpaidInvoiceValue,
 	)
 }
 
@@ -123,4 +130,5 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseUInt64Flag(ctx, FlagPaymentsConsumerPricePerGBUpperBound)
 	Current.ParseUInt64Flag(ctx, FlagPaymentsConsumerPricePerGBLowerBound)
 	Current.ParseUInt64Flag(ctx, FlagPaymentsConsumerDataLeewayMegabytes)
+	Current.ParseUInt64Flag(ctx, FlagPaymentsMaxUnpaidInvoiceValue)
 }

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -145,6 +145,7 @@ func GetOptions() *Options {
 			ConsumerLowerMinutePriceBound:      config.GetUInt64(config.FlagPaymentsConsumerPricePerMinuteLowerBound),
 			ConsumerDataLeewayMegabytes:        config.GetUInt64(config.FlagPaymentsConsumerDataLeewayMegabytes),
 			ProviderInvoiceFrequency:           config.GetDuration(config.FlagPaymentsProviderInvoiceFrequency),
+			MaxUnpaidInvoiceValue:              config.GetUInt64(config.FlagPaymentsMaxUnpaidInvoiceValue),
 		},
 		Accountant: OptionsAccountant{
 			AccountantID:              config.GetString(config.FlagAccountantID),

--- a/core/node/options_payments.go
+++ b/core/node/options_payments.go
@@ -32,4 +32,5 @@ type OptionsPayments struct {
 	ConsumerLowerMinutePriceBound      uint64
 	ConsumerDataLeewayMegabytes        uint64
 	ProviderInvoiceFrequency           time.Duration
+	MaxUnpaidInvoiceValue              uint64
 }

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -101,6 +101,7 @@ func InvoiceFactoryCreator(
 	channelImplementationAddress string,
 	maxAccountantFailureCount uint64,
 	maxAllowedAccountantFee uint16,
+	maxUnpaidInvoiceValue uint64,
 	blockchainHelper bcHelper,
 	eventBus eventbus.EventBus,
 	proposal market.ServiceProposal,
@@ -134,6 +135,7 @@ func InvoiceFactoryCreator(
 			SessionID:                  sessionID,
 			PromiseHandler:             promiseHandler,
 			ChannelAddressCalculator:   NewChannelAddressCalculator(accountantID.Hex(), channelImplementationAddress, registryAddress),
+			MaxNotPaidInvoice:          maxUnpaidInvoiceValue,
 		}
 		paymentEngine := NewInvoiceTracker(deps)
 		return paymentEngine, nil


### PR DESCRIPTION
Invoices will still be sent periodicly, but if a spike occurs an invoice now might be sent earlier.

Fixes #2255