### PR TITLE
 Get WireGuard peer stats from supervisor

### DIFF
--- a/services/wireguard/device_config.go
+++ b/services/wireguard/device_config.go
@@ -31,9 +31,9 @@ import (
 
 // Stats represents wireguard peer statistics information.
 type Stats struct {
-	BytesSent     uint64
-	BytesReceived uint64
-	LastHandshake time.Time
+	BytesSent     uint64    `json:"bytes_sent"`
+	BytesReceived uint64    `json:"bytes_received"`
+	LastHandshake time.Time `json:"last_handshake"`
 }
 
 // DeviceConfig describes wireguard device configuration.

--- a/supervisor/client/client.go
+++ b/supervisor/client/client.go
@@ -29,7 +29,7 @@ import (
 // Command executes supervisor command.
 func Command(args ...string) (result string, err error) {
 	cmdLine := strings.Join(args, " ")
-	log.Debug().Msgf("Supervisor command invoked: %q", cmdLine)
+	log.Trace().Msgf("Supervisor command invoked: %q", cmdLine)
 	conn, err := connect()
 	if err != nil {
 		return "", err

--- a/supervisor/daemon/commands.go
+++ b/supervisor/daemon/commands.go
@@ -18,9 +18,10 @@
 package daemon
 
 const (
-	commandPing   = "ping"
-	commandKill   = "kill"
-	commandBye    = "bye"
-	commandWgUp   = "wg-up"
-	commandWgDown = "wg-down"
+	commandPing    = "ping"
+	commandKill    = "kill"
+	commandBye     = "bye"
+	commandWgUp    = "wg-up"
+	commandWgDown  = "wg-down"
+	commandWgStats = "wg-stats"
 )

--- a/supervisor/daemon/transport/transport_windows.go
+++ b/supervisor/daemon/transport/transport_windows.go
@@ -31,7 +31,7 @@ const sock = `\\.\pipe\mystpipe`
 // Start starts a listener on a unix domain socket.
 // Conversation is handled by the handlerFunc.
 func Start(handle handlerFunc) error {
-	return svc.Run("WireGuardManager", &managerService{handle: handle})
+	return svc.Run("MystSupervisor", &managerService{handle: handle})
 }
 
 type managerService struct {

--- a/supervisor/daemon/wireguard/wginterface/interface.go
+++ b/supervisor/daemon/wireguard/wginterface/interface.go
@@ -26,6 +26,6 @@ import (
 // WgInterface represents WireGuard tunnel with underlying device.
 type WgInterface struct {
 	Name   string
-	device *device.Device
+	Device *device.Device
 	uapi   net.Listener
 }

--- a/supervisor/daemon/wireguard/wginterface/interface_darwin.go
+++ b/supervisor/daemon/wireguard/wginterface/interface_darwin.go
@@ -82,7 +82,7 @@ func New(cfg wg.DeviceConfig, uid string) (*WgInterface, error) {
 
 	wgInterface := &WgInterface{
 		Name:   interfaceName,
-		device: wgDevice,
+		Device: wgDevice,
 		uapi:   uapi,
 	}
 	log.Println("Listening for UAPI requests")
@@ -111,7 +111,7 @@ func (a *WgInterface) handleUAPI() {
 			log.Println("Closing UAPI listener, err:", err)
 			return
 		}
-		go a.device.IpcHandle(conn)
+		go a.Device.IpcHandle(conn)
 	}
 }
 
@@ -134,5 +134,5 @@ func configureNetwork(cfg wg.DeviceConfig) error {
 // Down closes device and user space api socket.
 func (a *WgInterface) Down() {
 	_ = a.uapi.Close()
-	a.device.Close()
+	a.Device.Close()
 }


### PR DESCRIPTION
Remove wgctrl which was fetching peer stats from WireGuard IPC socket and add supervisor `wg-stats` command. It is similar to wireguard-windows desktop app to get stats from supervisor as using wgctrl requires root access.