### PR TITLE
Supervisor logs

### DIFF
--- a/cmd/supervisor/README.md
+++ b/cmd/supervisor/README.md
@@ -3,7 +3,7 @@
 Supervisor is a system background service that allows seamless installation/running of [Mysterium node](https://github.com/mysteriumnetwork/node) under elevated permissions.
 Clients (e.g. desktop applications) can ask the supervisor to RUN or KILL the node instance via OS dependent mechanism.
 
-Currently, only macOS is supported and it is using unix domain sockets for communication.
+Currently, only macOS and Windows are supported and it is using unix domain sockets or named pipes for communication.
 
 For usage see:
 
@@ -15,13 +15,16 @@ myst_supervisor -help
 
 | Command                           | OS           | Args | Output | Implemented | Notes |
 | --------------------------------- | ------------ | ---- | ------ | ----------- | ----- |
-| isWgSupported (kernel)            | linux        |      | ok     | -           | |
-| NAT ipForward                     | linux, macOS |      | ok     | -           | | `/sbin/sysctl -w net.ipv4.ip_forward=1` |
-| NAT/firewall rules                | ALL          | vpnNetwork <br> dnsIP <br> dnsPort <br> protectedNetworks <br> providerExternalIP <br> enableDNSRedirect | ok | - | |
-| NAT/firewall allowIP              | linux        | IP   | ok     | -           | |
-| NAT/firewall allowURL             | linux        | URL  | ok     | -           | |
-| Create tun (wg userspace)         | ALL          | iface name | `windows.GUID / FD int` | - | FD to be used in `wg/tun.CreateTUNFromFile(*os.File, int) (Device, error)` see `tun_linux.go/tun_darwin.go` <br> windows: `CreateTUNWithRequestedGUID` |
-| Destroy device (wg userspace)     | ALL          | iface name | ok | 
-| assignIP                          | ALL          | iface name, subnet | ok |
-| excludeRoute                      | ALL          | IP | ok |
-| defaultRoute                      | ALL          | iface name | ok |
+| ping                              | macOS, Win   |      | ok     | ✅           | Ping supervisor |
+| kill                              | macOS, Win   |      | ok     | ✅          | Kill myst process gracefully |
+| bye                               | macOS   |      | ok     | ✅            | Kill supervisor |
+| wg-up                             | macOS, Win   | -uid, -config    | ok     | ✅           | Setup WireGuard device with given configuration in JSON string format |
+| wg-down                           | macOS, Win   | -iface     | ok     | ✅           | Destroy WireGuard device |
+| wg-stats                          | macOS, Win   | -iface     | `{"bytes_send": 100, "bytes_received": 200, "last_handshake": "2020-06-02T13:42:55.786Z"}`     | ✅           | Get WireGuard device peer statistics |
+
+
+## Logs
+
+On Windows logs could be found at `C:\Windows\system32\myst_supervisor.log`
+
+On macOS logs could be found at `/var/log/myst_supervisor.log`

--- a/cmd/supervisor/supervisor.go
+++ b/cmd/supervisor/supervisor.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/rs/zerolog/log"
 
@@ -53,12 +52,7 @@ func main() {
 		}
 		log.Info().Msg("Supervisor installed")
 	} else {
-		logPath := *logFilePath
-		if logPath == "" {
-			logPath = defaultLogPath()
-		}
-
-		if err := logconfig.Configure(logPath); err != nil {
+		if err := logconfig.Configure(*logFilePath); err != nil {
 			log.Fatal().Err(err).Msg("Failed to configure logging")
 		}
 
@@ -68,15 +62,6 @@ func main() {
 			log.Fatal().Err(err).Msg("Error running supervisor")
 		}
 	}
-}
-
-func defaultLogPath() string {
-	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
-		return "/var/log/myst_supervisor"
-	}
-
-	// On Windows default log file location will be under C:\Windows\system32\myst_supervisor.log
-	return "./myst_supervisor"
 }
 
 func thisPath() (string, error) {

--- a/cmd/supervisor/supervisor.go
+++ b/cmd/supervisor/supervisor.go
@@ -51,6 +51,7 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to install supervisor")
 		}
+		log.Info().Msg("Supervisor installed")
 	} else {
 		logPath := *logFilePath
 		if logPath == "" {

--- a/logconfig/rollingwriter/rollingwriter.go
+++ b/logconfig/rollingwriter/rollingwriter.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package logconfig
+package rollingwriter
 
 import (
 	"io"
@@ -26,35 +26,41 @@ import (
 	"strings"
 
 	"github.com/arthurkiller/rollingwriter"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
-type rollingWriter struct {
+// RollingWriter represents logs writer with logs rolling and cleanup support.
+type RollingWriter struct {
 	config rollingwriter.Config
-	fw     io.Writer
+	Writer io.Writer
 }
 
-func newRollingWriter(opts *LogOptions) (writer *rollingWriter, err error) {
-	writer = &rollingWriter{}
+// NewRollingWriter creates new rolling writer.
+func NewRollingWriter(filepath string) (writer *RollingWriter, err error) {
+	writer = &RollingWriter{}
 	writer.config = rollingwriter.Config{
 		TimeTagFormat:     "20060102T150405",
-		LogPath:           path.Dir(opts.Filepath),
-		FileName:          path.Base(opts.Filepath),
+		LogPath:           path.Dir(filepath),
+		FileName:          path.Base(filepath),
 		RollingPolicy:     rollingwriter.VolumeRolling,
 		RollingVolumeSize: "50MB",
 		Compress:          true,
 		WriterMode:        "lock",
 		MaxRemain:         5,
 	}
-	writer.fw, err = rollingwriter.NewWriterFromConfig(&writer.config)
+	writer.Writer, err = rollingwriter.NewWriterFromConfig(&writer.config)
 	return writer, err
 }
 
-// cleanObsoleteLogs cleans obsolete logs so that the count of remaining log files is equal to w.config.MaxRemain.
+// Write writes to underlying rolling writer.
+func (w *RollingWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+// CleanObsoleteLogs cleans obsolete logs so that the count of remaining log files is equal to w.config.MaxRemain.
 // rollingWriter only handles file rolling at runtime, but if the node is restarted, the count is lost thus we have
 // to do this manually.
-func (w *rollingWriter) cleanObsoleteLogs() error {
+func (w *RollingWriter) CleanObsoleteLogs() error {
 	files, err := ioutil.ReadDir(w.config.LogPath)
 	if err != nil {
 		return err
@@ -81,12 +87,4 @@ func (w *rollingWriter) cleanObsoleteLogs() error {
 		}
 	}
 	return nil
-}
-
-func (w *rollingWriter) zeroLogger() io.Writer {
-	return zerolog.ConsoleWriter{
-		Out:        w.fw,
-		NoColor:    true,
-		TimeFormat: timestampFmt,
-	}
 }

--- a/supervisor/daemon/daemon.go
+++ b/supervisor/daemon/daemon.go
@@ -24,12 +24,13 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/mysteriumnetwork/node/core/storage/boltdb"
 	"github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
+	"github.com/rs/zerolog/log"
+
 	"github.com/mysteriumnetwork/node/supervisor/config"
 	"github.com/mysteriumnetwork/node/supervisor/daemon/transport"
 	"github.com/mysteriumnetwork/node/supervisor/daemon/wireguard"

--- a/supervisor/daemon/myst.go
+++ b/supervisor/daemon/myst.go
@@ -21,16 +21,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 const tequilapiHost = "http://localhost:4050"
 
 func (d *Daemon) killMyst() error {
-	log.Println("Trying to stop node process gracefully")
+	log.Info().Msg("Trying to stop node process gracefully")
 	err := gracefulStop(3 * time.Second)
 	if err == nil {
 		return nil

--- a/supervisor/daemon/transport/transport_darwin.go
+++ b/supervisor/daemon/transport/transport_darwin.go
@@ -19,9 +19,10 @@ package transport
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"os"
+
+	"github.com/rs/zerolog/log"
 )
 
 const sock = "/var/run/myst.sock"
@@ -42,23 +43,23 @@ func Start(handle handlerFunc) error {
 	}
 	defer func() {
 		if err := l.Close(); err != nil {
-			log.Println("Error closing listener:", err)
+			log.Printf("Error closing listener: %v", err)
 		}
 	}()
 	for {
-		log.Println("Waiting for connections...")
+		log.Print("Waiting for connections...")
 		conn, err := l.Accept()
 		if err != nil {
 			return fmt.Errorf("accept error: %w", err)
 		}
 		go func() {
 			peer := conn.RemoteAddr().Network()
-			log.Println("Client connected:", peer)
+			log.Printf("Client connected: %s", peer)
 			handle(conn)
 			if err := conn.Close(); err != nil {
 				log.Printf("Error closing connection for: %v error: %v", peer, err)
 			}
-			log.Println("Client disconnected:", peer)
+			log.Print("Client disconnected:", peer)
 		}()
 	}
 }

--- a/supervisor/daemon/transport/transport_windows.go
+++ b/supervisor/daemon/transport/transport_windows.go
@@ -19,8 +19,9 @@ package transport
 
 import (
 	"fmt"
-	"log"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/Microsoft/go-winio"
 	"golang.org/x/sys/windows/svc"
@@ -90,23 +91,23 @@ func (m *managerService) listenPipe() error {
 	}
 	defer func() {
 		if err := l.Close(); err != nil {
-			log.Println("Error closing listener:", err)
+			log.Printf("Error closing listener:", err)
 		}
 	}()
 	for {
-		log.Println("Waiting for connections...")
+		log.Print("Waiting for connections...")
 		conn, err := l.Accept()
 		if err != nil {
 			return fmt.Errorf("accept error: %w", err)
 		}
 		go func() {
 			peer := conn.RemoteAddr().Network()
-			log.Println("Client connected:", peer)
+			log.Printf("Client connected: %s", peer)
 			m.handle(conn)
 			if err := conn.Close(); err != nil {
-				log.Printf("Error closing connection for: %v error: %v", peer, err)
+				log.Printf("Error closing connection for: %s error: %v", peer, err)
 			}
-			log.Println("Client disconnected:", peer)
+			log.Printf("Client disconnected: %s", peer)
 		}()
 	}
 }

--- a/supervisor/install/install_darwin.go
+++ b/supervisor/install/install_darwin.go
@@ -20,11 +20,12 @@ package install
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
 	"text/template"
+
+	"github.com/rs/zerolog/log"
 )
 
 const daemonID = "network.mysterium.myst_supervisor"
@@ -42,10 +43,6 @@ const plistTpl = `
 	</array>
 	<key>KeepAlive</key>
 	<true/>
-	<key>StandardOutPath</key>
-	<string>{{.LogPath}}</string>
-	<key>StandardErrorPath</key>
-	<string>{{.LogPath}}</string>
 </dict>
 </plist>
 `
@@ -55,7 +52,7 @@ func Install(options Options) error {
 	if !options.valid() {
 		return errors.New("invalid options")
 	}
-	log.Println("Installing launchd daemon")
+	log.Info().Msg("Installing launchd daemon")
 	clean()
 	tpl, err := template.New("plistTpl").Parse(plistTpl)
 	if err != nil {
@@ -67,7 +64,6 @@ func Install(options Options) error {
 	}
 	err = tpl.Execute(fd, map[string]string{
 		"DaemonID":       daemonID,
-		"LogPath":        "/var/log/myst_supervisor.log",
 		"SupervisorPath": options.SupervisorPath,
 	})
 	if err != nil {
@@ -84,7 +80,7 @@ func Install(options Options) error {
 }
 
 func clean() {
-	log.Println("Cleaning up previous installation")
+	log.Info().Msg("Cleaning up previous installation")
 	_, _ = runV("launchctl", "unload", plistPath)
 	_ = os.RemoveAll(plistPath)
 }

--- a/supervisor/install/install_windows.go
+++ b/supervisor/install/install_windows.go
@@ -19,7 +19,8 @@ package install
 
 import (
 	"fmt"
-	"log"
+
+	"github.com/rs/zerolog/log"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
@@ -85,7 +86,7 @@ func uninstallService(m *mgr.Mgr, name string) error {
 		return fmt.Errorf("service %s is not installed", name)
 	}
 	defer s.Close()
-	log.Println("Detected previously installed service, uninstalling...")
+	log.Info().Msg("Detected previously installed service, uninstalling...")
 
 	s.Control(svc.Stop)
 	err = s.Delete()

--- a/supervisor/logconfig/default_log_path_unix.go
+++ b/supervisor/logconfig/default_log_path_unix.go
@@ -1,0 +1,24 @@
+// +build !windows
+
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package logconfig
+
+func defaultLogPath() (string, error) {
+	return "/var/log/myst_supervisor", nil
+}

--- a/supervisor/logconfig/default_log_path_windows.go
+++ b/supervisor/logconfig/default_log_path_windows.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package logconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// On Windows default log file location will be under C:\Windows\system32\config\systemprofile\AppData\Local\MystSupervisor\myst_supervisor.log
+func defaultLogPath() (string, error) {
+	root, err := rootWinDirectory()
+	if err != nil {
+		return "", fmt.Errorf("could not get root win directory for logs: %w", err)
+	}
+	return filepath.Join(root, "myst_supervisor"), nil
+}
+
+func rootWinDirectory() (string, error) {
+	root, err := windows.KnownFolderPath(windows.FOLDERID_LocalAppData, windows.KF_FLAG_CREATE)
+	if err != nil {
+		return "", fmt.Errorf("could not get known local app data folder: %w", err)
+	}
+	c := filepath.Join(root, "MystSupervisor")
+	err = os.MkdirAll(c, os.ModeDir|0700)
+	if err != nil {
+		return "", fmt.Errorf("could not create logs directory: %w", err)
+	}
+	return c, nil
+}

--- a/supervisor/logconfig/logconfig.go
+++ b/supervisor/logconfig/logconfig.go
@@ -32,6 +32,13 @@ const (
 
 // Configure configures supervisor global logger instance.
 func Configure(logPath string) error {
+	if logPath == "" {
+		var err error
+		logPath, err = defaultLogPath()
+		if err != nil {
+			return fmt.Errorf("could not get default log path: %w", err)
+		}
+	}
 	rw, err := rollingwriter.NewRollingWriter(logPath)
 	if err != nil {
 		return fmt.Errorf("could not to create rolling logs writer: %w", err)

--- a/supervisor/logconfig/logconfig.go
+++ b/supervisor/logconfig/logconfig.go
@@ -26,6 +26,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	timestampFmt = "2006-01-02T15:04:05.000"
+)
+
 // Configure configures supervisor global logger instance.
 func Configure(logPath string) error {
 	rw, err := rollingwriter.NewRollingWriter(logPath)
@@ -36,7 +40,7 @@ func Configure(logPath string) error {
 		log.Printf("Failed to cleanup obsolete logs: %v", err)
 	}
 
-	logger := log.Output(zerolog.ConsoleWriter{Out: rw, NoColor: true}).
+	logger := log.Output(zerolog.ConsoleWriter{Out: rw, NoColor: true, TimeFormat: timestampFmt}).
 		Level(zerolog.DebugLevel).
 		With().
 		Timestamp().


### PR DESCRIPTION
Use zerolog in supervisor which allows to extend WireGuard default logger and pass zerolog global instance which is configured to log to file.

Closes https://github.com/mysteriumnetwork/node/issues/2317