### PR TITLE
Skip services bootstrap for user mode

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -54,7 +54,8 @@ import (
 
 // bootstrapServices loads all the components required for running services
 func (di *Dependencies) bootstrapServices(nodeOptions node.Options) error {
-	if nodeOptions.MobileConsumer {
+	if nodeOptions.Consumer {
+		log.Debug().Msg("Skipping services bootstrap for consumer mode")
 		return nil
 	}
 
@@ -159,7 +160,8 @@ func (di *Dependencies) bootstrapServiceNoop(nodeOptions node.Options) {
 }
 
 func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) error {
-	if nodeOptions.MobileConsumer {
+	if nodeOptions.Consumer {
+		log.Debug().Msg("Skipping provider registrar for consumer mode")
 		return nil
 	}
 
@@ -175,7 +177,8 @@ func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) err
 }
 
 func (di *Dependencies) bootstrapAccountantPromiseSettler(nodeOptions node.Options) error {
-	if nodeOptions.MobileConsumer {
+	if nodeOptions.Consumer {
+		log.Debug().Msg("Skipping accountant promise settler for consumer mode")
 		di.AccountantPromiseSettler = &pingpong_noop.NoopAccountantPromiseSettler{}
 		return nil
 	}
@@ -264,7 +267,8 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 }
 
 func (di *Dependencies) registerConnections(nodeOptions node.Options) {
-	if nodeOptions.MobileConsumer {
+	if nodeOptions.Consumer {
+		log.Debug().Msg("Skipping connections registration for consumer mode")
 		di.registerNoopConnection()
 		return
 	}

--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -188,6 +188,13 @@ var (
 		Usage: "Range of P2P listen ports (e.g. 51820:52075), value of 0:0 means disabled",
 		Value: "0:0",
 	}
+
+	//FlagConsumer sets to run as consumer only which allows to skip bootstrap for some of the dependencies.
+	FlagConsumer = cli.BoolFlag{
+		Name:  "consumer",
+		Usage: "Run in consumer mode only.",
+		Value: false,
+	}
 )
 
 // RegisterFlagsNode function register node flags to flag list
@@ -228,6 +235,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		&FlagUserMode,
 		&FlagVendorID,
 		&FlagP2PListenPorts,
+		&FlagConsumer,
 	)
 
 	return nil
@@ -268,6 +276,7 @@ func ParseFlagsNode(ctx *cli.Context) {
 	Current.ParseBoolFlag(ctx, FlagUserMode)
 	Current.ParseStringFlag(ctx, FlagVendorID)
 	Current.ParseStringFlag(ctx, FlagP2PListenPorts)
+	Current.ParseBoolFlag(ctx, FlagConsumer)
 
 	ValidateAddressFlags(FlagTequilapiAddress)
 }

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -78,7 +78,7 @@ type Options struct {
 
 	Payments OptionsPayments
 
-	MobileConsumer bool
+	Consumer bool
 
 	P2PPorts *port.Range
 }
@@ -158,6 +158,7 @@ func GetOptions() *Options {
 			BlockAlways: config.GetBool(config.FlagFirewallKillSwitch),
 		},
 		P2PPorts: getP2PListenPorts(),
+		Consumer: config.GetBool(config.FlagConsumer),
 	}
 }
 

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -196,8 +196,8 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 			ConsumerLowerGBPriceBound:          0,
 			ConsumerUpperGBPriceBound:          11000000,
 		},
-		MobileConsumer: true,
-		P2PPorts:       port.UnspecifiedRange(),
+		Consumer: true,
+		P2PPorts: port.UnspecifiedRange(),
 	}
 
 	err := di.Bootstrap(nodeOptions)


### PR DESCRIPTION
We do not need to bootstrap services when `-usermode` flag is specified as it will work only for consumer mode.