### PR TITLE
Wait supervisor uninstall fix

### DIFF
--- a/logconfig/rollingwriter/rollingwriter.go
+++ b/logconfig/rollingwriter/rollingwriter.go
@@ -76,7 +76,7 @@ func (w *RollingWriter) CleanObsoleteLogs() error {
 		log.Debug().Msgf("Found %d old log files in log directory, skipping cleanup", len(oldLogFiles))
 		return nil
 	}
-	log.Info().Msgf("Found %d old log files in log directory, proceeding to cleanup", len(oldLogFiles))
+	log.Debug().Msgf("Found %d old log files in log directory, proceeding to cleanup", len(oldLogFiles))
 	sort.Slice(oldLogFiles, func(i, j int) bool {
 		return oldLogFiles[i].ModTime().After(oldLogFiles[j].ModTime())
 	})

--- a/supervisor/daemon/daemon.go
+++ b/supervisor/daemon/daemon.go
@@ -52,7 +52,7 @@ func New(cfg *config.Config) Daemon {
 func (d *Daemon) Start() error {
 	db, err := boltdb.NewStorage(os.TempDir())
 	if err != nil {
-		log.Printf("failed to init routes storage: %s", err)
+		log.Err(err).Msg("Failed to init routes storage")
 	} else {
 		netutil.SetRouteManagerStorage(db)
 		netutil.ClearStaleRoutes()
@@ -67,7 +67,7 @@ func (d *Daemon) dialog(conn io.ReadWriter) {
 	answer := responder{conn}
 	for scan.Scan() {
 		line := scan.Bytes()
-		log.Printf("> %s", line)
+		log.Debug().Msgf("> %s", line)
 		cmd := strings.Split(string(line), " ")
 		op := strings.ToLower(cmd[0])
 		switch op {
@@ -79,7 +79,7 @@ func (d *Daemon) dialog(conn io.ReadWriter) {
 		case commandWgUp:
 			up, err := d.wgUp(cmd...)
 			if err != nil {
-				log.Printf("failed %s: %s", commandWgUp, err)
+				log.Err(err).Msgf("%s failed", commandWgUp)
 				answer.err(err)
 			} else {
 				answer.ok(up)
@@ -87,7 +87,7 @@ func (d *Daemon) dialog(conn io.ReadWriter) {
 		case commandWgDown:
 			err := d.wgDown(cmd...)
 			if err != nil {
-				log.Printf("failed %s: %s", commandWgDown, err)
+				log.Err(err).Msgf("%s failed", commandWgDown)
 				answer.err(err)
 			} else {
 				answer.ok()
@@ -95,14 +95,14 @@ func (d *Daemon) dialog(conn io.ReadWriter) {
 		case commandWgStats:
 			stats, err := d.wgStats(cmd...)
 			if err != nil {
-				log.Printf("failed %s: %s", commandWgStats, err)
+				log.Err(err).Msgf("%s failed", commandWgStats)
 				answer.err(err)
 			} else {
 				answer.ok(stats)
 			}
 		case commandKill:
 			if err := d.killMyst(); err != nil {
-				log.Printf("failed %s: %s", commandKill, err)
+				log.Err(err).Msgf("%s failed", commandKill)
 				answer.err(err)
 			} else {
 				answer.ok()

--- a/supervisor/daemon/transport/transport_darwin.go
+++ b/supervisor/daemon/transport/transport_darwin.go
@@ -43,7 +43,7 @@ func Start(handle handlerFunc) error {
 	}
 	defer func() {
 		if err := l.Close(); err != nil {
-			log.Printf("Error closing listener: %v", err)
+			log.Err(err).Msg("Error closing listener")
 		}
 	}()
 	for {
@@ -54,12 +54,12 @@ func Start(handle handlerFunc) error {
 		}
 		go func() {
 			peer := conn.RemoteAddr().Network()
-			log.Printf("Client connected: %s", peer)
+			log.Debug().Msgf("Client connected: %s", peer)
 			handle(conn)
 			if err := conn.Close(); err != nil {
-				log.Printf("Error closing connection for: %v error: %v", peer, err)
+				log.Err(err).Msgf("Error closing connection for: %v", peer)
 			}
-			log.Print("Client disconnected:", peer)
+			log.Debug().Msgf("Client disconnected: %s", peer)
 		}()
 	}
 }

--- a/supervisor/daemon/transport/transport_windows.go
+++ b/supervisor/daemon/transport/transport_windows.go
@@ -60,7 +60,7 @@ func (m *managerService) Execute(args []string, r <-chan svc.ChangeRequest, s ch
 		case svc.Continue:
 			s <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 		default:
-			log.Error().Msgf("unexpected control request #%d", c)
+			log.Error().Msgf("Unexpected control request #%d", c)
 		}
 	}
 	return

--- a/supervisor/daemon/transport/transport_windows.go
+++ b/supervisor/daemon/transport/transport_windows.go
@@ -45,7 +45,7 @@ func (m *managerService) Execute(args []string, r <-chan svc.ChangeRequest, s ch
 	s <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 	go func() {
 		if err := m.listenPipe(); err != nil {
-			log.Printf("could not listen pipe: %v", err)
+			log.Err(err).Msgf("Could not listen pipe on %s", sock)
 		}
 	}()
 
@@ -60,7 +60,7 @@ func (m *managerService) Execute(args []string, r <-chan svc.ChangeRequest, s ch
 		case svc.Continue:
 			s <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 		default:
-			log.Printf("unexpected control request #%d", c)
+			log.Error().Msgf("unexpected control request #%d", c)
 		}
 	}
 	return
@@ -91,23 +91,23 @@ func (m *managerService) listenPipe() error {
 	}
 	defer func() {
 		if err := l.Close(); err != nil {
-			log.Printf("Error closing listener:", err)
+			log.Err(err).Msg("Error closing listener")
 		}
 	}()
 	for {
-		log.Print("Waiting for connections...")
+		log.Debug().Msg("Waiting for connections...")
 		conn, err := l.Accept()
 		if err != nil {
 			return fmt.Errorf("accept error: %w", err)
 		}
 		go func() {
 			peer := conn.RemoteAddr().Network()
-			log.Printf("Client connected: %s", peer)
+			log.Debug().Msgf("Client connected: %s", peer)
 			m.handle(conn)
 			if err := conn.Close(); err != nil {
-				log.Printf("Error closing connection for: %s error: %v", peer, err)
+				log.Err(err).Msgf("Error closing connection for: %s", peer)
 			}
-			log.Printf("Client disconnected: %s", peer)
+			log.Debug().Msgf("Client disconnected: %s", peer)
 		}()
 	}
 }

--- a/supervisor/daemon/wireguard/wginterface/interface_darwin.go
+++ b/supervisor/daemon/wireguard/wginterface/interface_darwin.go
@@ -20,11 +20,12 @@ package wginterface
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
 	"github.com/mysteriumnetwork/node/utils/netutil"
@@ -50,7 +51,7 @@ func New(cfg wgcfg.DeviceConfig, uid string) (*WgInterface, error) {
 	wgDevice := device.NewDevice(tunnel, logger)
 	logger.Info.Println("Device started")
 
-	log.Println("Setting interface configuration")
+	log.Info().Msg("Setting interface configuration")
 	fileUAPI, err := ipc.UAPIOpen(interfaceName)
 	if err != nil {
 		return nil, fmt.Errorf("UAPI listen error: %w", err)
@@ -63,10 +64,10 @@ func New(cfg wgcfg.DeviceConfig, uid string) (*WgInterface, error) {
 		return nil, fmt.Errorf("could not set device uapi config: %w", err)
 	}
 
-	log.Println("Bringing peers up")
+	log.Info().Msg("Bringing peers up")
 	wgDevice.Up()
 
-	log.Println("Configuring network")
+	log.Info().Msg("Configuring network")
 	if err := configureNetwork(cfg); err != nil {
 		return nil, fmt.Errorf("could not setup network: %w", err)
 	}
@@ -85,7 +86,7 @@ func New(cfg wgcfg.DeviceConfig, uid string) (*WgInterface, error) {
 		Device: wgDevice,
 		uapi:   uapi,
 	}
-	log.Println("Listening for UAPI requests")
+	log.Info().Msg("Listening for UAPI requests")
 	go wgInterface.handleUAPI()
 
 	return wgInterface, nil
@@ -108,7 +109,7 @@ func (a *WgInterface) handleUAPI() {
 	for {
 		conn, err := a.uapi.Accept()
 		if err != nil {
-			log.Println("Closing UAPI listener, err:", err)
+			log.Err(err).Msg("Failed to close UAPI listener")
 			return
 		}
 		go a.Device.IpcHandle(conn)


### PR DESCRIPTION
Some refactoring for supervisor logging. Added log level and checked all log statements to properly log by level.

When installing new supervisor version we first need to stop and uninstall previous service before installing new version, but previously we didn't waited for service deletion as this operation is async. Using OpenService method allows to handle this case.