### PR TITLE
Support alternative iptables path

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -39,6 +39,24 @@ function install_chkconfig {
         && chkconfig --add mysterium-node
 }
 
+function ensure_paths {
+    iptables_path=`which iptables`
+
+    # validate utility against valid system paths
+    basepath=${iptables_path%/*}
+    echo "iptables basepath detected: ${basepath}"
+    if ! [[ ${basepath} =~ (^/usr/sbin|^/sbin|^/bin|^/usr/bin) ]]; then
+      echo "invalid basepath for dependency - check if system PATH has not been altered"
+      exit 1
+    fi
+
+    iptables_required_path="/usr/sbin/iptables"
+
+    if ! [[ -x ${iptables_required_path} ]]; then
+        ln -s ${iptables_path} ${iptables_required_path}
+    fi
+}
+
 printf "Creating user '$DAEMON_USER:$DAEMON_GROUP'...\n" \
     && useradd --system -U $DAEMON_USER -G root -s /bin/false -m -d $OS_DIR_DATA \
     && usermod -a -G root $DAEMON_USER \
@@ -61,36 +79,38 @@ if [[ -f /etc/redhat-release ]]; then
     # RHEL-variant logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-	install_systemd
+    	install_systemd
     else
-	# Assuming sysv
-	install_initd
-	install_chkconfig
+	    # Assuming sysv
+	    install_initd
+	    install_chkconfig
     fi
 elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-	install_systemd
+    	install_systemd
     else
-	# Assuming sysv
-	install_initd
-	install_update_rcd
+	    # Assuming sysv
+    	install_initd
+    	install_update_rcd
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
     if [[ $ID = "amzn" ]]; then
-	# Amazon Linux logic
-	install_initd
-	install_chkconfig
+    	# Amazon Linux logic
+    	install_initd
+    	install_chkconfig
     fi
 fi
+
+ensure_paths
 
 # Add defaults file, if it doesn't exist
 if [[ ! -f $DAEMON_DEFAULT ]]; then
     cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
 else
-    # TODO remove this hack when all nodes updated to both services.
+    # TODO remove these hacks when all nodes updates
     sed -i -e 's/SERVICE_OPTS="openvpn"/SERVICE_OPTS="openvpn,wireguard"/g' /etc/default/mysterium-node
     sed -i -e 's/--tequilapi.address=0.0.0.0/--tequilapi.address=127.0.0.1/g' /etc/default/mysterium-node
     # Append script-dir for existing installations only if missing


### PR DESCRIPTION
Some distributives still have a different path to the `iptables` utility. This prevents normal service work.
This PR allows an alternative path to the `iptables` utility. 

```
root@monitoring:~# cat  /etc/issue
Ubuntu 18.04.4 LTS \n \l
root@monitoring:~# ls -l /usr/sbin/iptables
ls: cannot access '/usr/sbin/iptables': No such file or directory
root@monitoring:~# which iptables
/sbin/iptables
root@monitoring:~#
```

![image](https://user-images.githubusercontent.com/8612618/84985245-415ede80-b15e-11ea-974c-2db2a9cd28e7.png)
