### PR TITLE
Cleanup IPResolver cache on disconnect

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -98,7 +98,11 @@ func (t *Tracer) Finish() string {
 
 	var strs []string
 	for _, s := range stages {
-		strs = append(strs, fmt.Sprintf("%q took %s", s.key, s.end.Sub(s.start).String()))
+		if s.end.After(time.Time{}) {
+			strs = append(strs, fmt.Sprintf("%q took %s", s.key, s.end.Sub(s.start).String()))
+		} else {
+			strs = append(strs, fmt.Sprintf("%q did not start", s.key))
+		}
 	}
 	return strings.Join(strs, ", ")
 }


### PR DESCRIPTION
After changing network on mobile connection would fail if previous connect would not complete. This fixes that.