### PR TITLE
Print stack trace on feedback error

### DIFF
--- a/logconfig/config.go
+++ b/logconfig/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mysteriumnetwork/node/logconfig/rollingwriter"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog/pkgerrors"
 )
 
 const (
@@ -43,6 +44,7 @@ func Bootstrap() {
 		"/vendor",
 		"/go/pkg/mod",
 	}
+	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	zerolog.CallerMarshalFunc = func(file string, line int) string {
 		var ok bool

--- a/tequilapi/endpoints/feedback.go
+++ b/tequilapi/endpoints/feedback.go
@@ -95,13 +95,13 @@ func (api *feedbackAPI) ReportIssue(httpRes http.ResponseWriter, httpReq *http.R
 
 	result, err := api.reporter.NewIssue(req)
 	if err != nil {
-		log.Error().Err(err).Stack().Msg("Could not create an issue for feedback")
+		log.Error().Stack().Err(err).Msg("Could not create an issue for feedback")
 		utils.SendError(httpRes, err, http.StatusInternalServerError)
 		return
 	}
 
 	if !result.Success {
-		log.Error().Err(err).Stack().Msg("Submitting an issue failed")
+		log.Error().Stack().Err(err).Msg("Submitting an issue failed")
 		utils.SendErrorBody(httpRes, result.Errors, result.HTTPResponse.StatusCode)
 		return
 	}


### PR DESCRIPTION
No actual error was being printed when feedback fails. Fixed.
