### PR TITLE
By default, bind Web UI to outbound IP only

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -285,13 +285,21 @@ func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options) {
 	di.ConnectionRegistry.Register(wireguard.ServiceType, connFactory)
 }
 
-func (di *Dependencies) bootstrapUIServer(options node.Options) {
-	if options.UI.UIEnabled {
-		di.UIServer = ui.NewServer(options.UI.UIBindAddress, options.UI.UIPort, options.TequilapiAddress, options.TequilapiPort, di.JWTAuthenticator, di.HTTPClient)
-		return
+func (di *Dependencies) bootstrapUIServer(options node.Options) (err error) {
+	if !options.UI.UIEnabled {
+		di.UIServer = uinoop.NewServer()
+		return nil
 	}
 
-	di.UIServer = uinoop.NewServer()
+	bindAddress := options.UI.UIBindAddress
+	if bindAddress == "" {
+		bindAddress, err = di.IPResolver.GetOutboundIP()
+		if err != nil {
+			return err
+		}
+	}
+	di.UIServer = ui.NewServer(bindAddress, options.UI.UIPort, options.TequilapiAddress, options.TequilapiPort, di.JWTAuthenticator, di.HTTPClient)
+	return nil
 }
 
 func (di *Dependencies) bootstrapMMN(options node.Options) {

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -287,7 +287,7 @@ func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options) {
 
 func (di *Dependencies) bootstrapUIServer(options node.Options) {
 	if options.UI.UIEnabled {
-		di.UIServer = ui.NewServer(options.BindAddress, options.UI.UIPort, options.TequilapiPort, di.JWTAuthenticator, di.HTTPClient)
+		di.UIServer = ui.NewServer(options.UI.UIBindAddress, options.UI.UIPort, options.TequilapiAddress, options.TequilapiPort, di.JWTAuthenticator, di.HTTPClient)
 		return
 	}
 

--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -167,8 +167,8 @@ var (
 	// FlagUIAddress IP address of interface to listen for incoming connections.
 	FlagUIAddress = cli.StringFlag{
 		Name:  "ui.address",
-		Usage: "IP address to bind Web UI to",
-		Value: "0.0.0.0",
+		Usage: "IP address to bind Web UI to (by default, local LAN IP)",
+		Value: "",
 	}
 	// FlagUIPort runs web UI on the specified port.
 	FlagUIPort = cli.IntFlag{

--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -54,7 +54,7 @@ var (
 	// FlagBindAddress IP address to bind to.
 	FlagBindAddress = cli.StringFlag{
 		Name:  "bind.address",
-		Usage: "IP address to bind to",
+		Usage: "IP address to bind provided services to",
 		Value: "0.0.0.0",
 	}
 	// FlagFeedbackURL URL of Feedback API.
@@ -143,7 +143,7 @@ var (
 	// FlagTequilapiAddress IP address of interface to listen for incoming connections.
 	FlagTequilapiAddress = cli.StringFlag{
 		Name:  "tequilapi.address",
-		Usage: "IP address of interface to listen for incoming connections",
+		Usage: "IP address to bind Tequilapi to",
 		Value: "127.0.0.1",
 	}
 	// FlagTequilapiPort port for listening for incoming API requests.
@@ -164,10 +164,16 @@ var (
 		Usage: "Enables the Web UI",
 		Value: true,
 	}
+	// FlagUIAddress IP address of interface to listen for incoming connections.
+	FlagUIAddress = cli.StringFlag{
+		Name:  "ui.address",
+		Usage: "IP address to bind Web UI to",
+		Value: "0.0.0.0",
+	}
 	// FlagUIPort runs web UI on the specified port.
 	FlagUIPort = cli.IntFlag{
 		Name:  "ui.port",
-		Usage: "the port to run ui on",
+		Usage: "The port to run Web UI on",
 		Value: 4449,
 	}
 	// FlagUserMode allows to run node under current user without sudo.
@@ -231,6 +237,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		&FlagTequilapiPort,
 		&FlagPProfEnable,
 		&FlagUIEnable,
+		&FlagUIAddress,
 		&FlagUIPort,
 		&FlagUserMode,
 		&FlagVendorID,
@@ -272,6 +279,7 @@ func ParseFlagsNode(ctx *cli.Context) {
 	Current.ParseIntFlag(ctx, FlagTequilapiPort)
 	Current.ParseBoolFlag(ctx, FlagPProfEnable)
 	Current.ParseBoolFlag(ctx, FlagUIEnable)
+	Current.ParseStringFlag(ctx, FlagUIAddress)
 	Current.ParseIntFlag(ctx, FlagUIPort)
 	Current.ParseBoolFlag(ctx, FlagUserMode)
 	Current.ParseStringFlag(ctx, FlagVendorID)

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -92,8 +92,9 @@ func GetOptions() *Options {
 		TequilapiEnabled: true,
 		BindAddress:      config.GetString(config.FlagBindAddress),
 		UI: OptionsUI{
-			UIEnabled: config.GetBool(config.FlagUIEnable),
-			UIPort:    config.GetInt(config.FlagUIPort),
+			UIEnabled:     config.GetBool(config.FlagUIEnable),
+			UIBindAddress: config.GetString(config.FlagUIAddress),
+			UIPort:        config.GetInt(config.FlagUIPort),
 		},
 		FeedbackURL: config.GetString(config.FlagFeedbackURL),
 		Keystore: OptionsKeystore{

--- a/core/node/options_ui.go
+++ b/core/node/options_ui.go
@@ -19,6 +19,7 @@ package node
 
 // OptionsUI describes possible parameters of ui configuration
 type OptionsUI struct {
-	UIEnabled bool
-	UIPort    int
+	UIEnabled     bool
+	UIBindAddress string
+	UIPort        int
 }

--- a/ui/reverse_proxy.go
+++ b/ui/reverse_proxy.go
@@ -43,11 +43,11 @@ func buildTransport() *http.Transport {
 	}
 }
 
-func buildReverseProxy(bindAddress string, transport *http.Transport, tequilapiPort int) *httputil.ReverseProxy {
+func buildReverseProxy(tequilapiAddress string, tequilapiPort int) *httputil.ReverseProxy {
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = "http"
-			req.URL.Host = bindAddress + ":" + strconv.Itoa(tequilapiPort)
+			req.URL.Host = tequilapiAddress + ":" + strconv.Itoa(tequilapiPort)
 			req.URL.Path = strings.Replace(req.URL.Path, tequilapiUrlPrefix, "", 1)
 			req.URL.Path = strings.TrimRight(req.URL.Path, "/")
 		},
@@ -59,7 +59,7 @@ func buildReverseProxy(bindAddress string, transport *http.Transport, tequilapiP
 			res.Header.Del("Access-Control-Allow-Methods")
 			return nil
 		},
-		Transport: transport,
+		Transport: buildTransport(),
 	}
 
 	proxy.FlushInterval = 10 * time.Millisecond
@@ -68,8 +68,8 @@ func buildReverseProxy(bindAddress string, transport *http.Transport, tequilapiP
 }
 
 // ReverseTequilapiProxy proxies UIServer requests to the TequilAPI server
-func ReverseTequilapiProxy(bindAddress string, tequilapiPort int, authenticator jwtAuthenticator) gin.HandlerFunc {
-	proxy := buildReverseProxy(bindAddress, buildTransport(), tequilapiPort)
+func ReverseTequilapiProxy(tequilapiAddress string, tequilapiPort int, authenticator jwtAuthenticator) gin.HandlerFunc {
+	proxy := buildReverseProxy(tequilapiAddress, tequilapiPort)
 
 	return func(c *gin.Context) {
 		// skip non Tequilapi routes

--- a/ui/server.go
+++ b/ui/server.go
@@ -93,8 +93,6 @@ func NewServer(bindAddress string, port int, tequilapiAddress string, tequilapiP
 
 // Serve starts the server
 func (s *Server) Serve() error {
-	log.Info().Msg("Server starting on: " + s.srv.Addr)
-
 	go func() {
 		err := s.discovery.Start()
 		if err != nil {
@@ -104,8 +102,10 @@ func (s *Server) Serve() error {
 
 	err := s.srv.ListenAndServe()
 	if err != http.ErrServerClosed {
-		return errors.Wrap(err, "dvpn web server crashed")
+		return errors.Wrap(err, "UI server crashed")
 	}
+
+	log.Info().Msgf("UI started on: %s", s.srv.Addr)
 	return nil
 }
 

--- a/ui/server.go
+++ b/ui/server.go
@@ -71,11 +71,11 @@ var corsConfig = cors.Config{
 }
 
 // NewServer creates a new instance of the server for the given port
-func NewServer(bindAddress string, port int, tequilapiPort int, authenticator jwtAuthenticator, httpClient *requests.HTTPClient) *Server {
+func NewServer(bindAddress string, port int, tequilapiAddress string, tequilapiPort int, authenticator jwtAuthenticator, httpClient *requests.HTTPClient) *Server {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.NoRoute(ReverseTequilapiProxy(bindAddress, tequilapiPort, authenticator))
+	r.NoRoute(ReverseTequilapiProxy(tequilapiAddress, tequilapiPort, authenticator))
 	r.Use(cors.New(corsConfig))
 
 	r.StaticFS("/", godvpnweb.Assets)

--- a/ui/server_test.go
+++ b/ui/server_test.go
@@ -35,7 +35,7 @@ func (j *jwtAuth) ValidateToken(token string) (bool, error) {
 }
 
 func Test_Server_ServesHTML(t *testing.T) {
-	s := NewServer("localhost", 55555, 55554, &jwtAuth{}, requests.NewHTTPClient("0.0.0.0", requests.DefaultTimeout))
+	s := NewServer("localhost", 55555, "localhost", 55554, &jwtAuth{}, requests.NewHTTPClient("0.0.0.0", requests.DefaultTimeout))
 	s.discovery = &mockDiscovery{}
 	serverError := make(chan error)
 	go func() {


### PR DESCRIPTION
Minimising NodeUI binding address from `0.0.0.0:4449` -> to `192.168.0.132:4449` - by default, configure node in LAN only)
User may also configure it with separate cli flag `--ui.address`