### PR TITLE
Use user independent dir for app data

### DIFF
--- a/cmd/supervisor/README.md
+++ b/cmd/supervisor/README.md
@@ -25,6 +25,6 @@ myst_supervisor -help
 
 ## Logs
 
-On Windows logs could be found at `C:\Windows\System32\config\systemprofile\AppData\Local\MystSupervisor\myst_supervisor.log`
+On Windows logs could be found at `C:\ProgramData\MystSupervisor\myst_supervisor.log`
 
 On macOS logs could be found at `/var/log/myst_supervisor.log`

--- a/supervisor/util/winutil/appdata_windows.go
+++ b/supervisor/util/winutil/appdata_windows.go
@@ -26,8 +26,8 @@ import (
 )
 
 func AppDataDir() (string, error) {
-	// On Windows default log file location will be under C:\Windows\system32\config\systemprofile\AppData\Local\MystSupervisor\myst_supervisor.log
-	root, err := windows.KnownFolderPath(windows.FOLDERID_LocalAppData, windows.KF_FLAG_CREATE)
+	// Default: C:\ProgramData\MystSupervisor
+	root, err := windows.KnownFolderPath(windows.FOLDERID_ProgramData, windows.KF_FLAG_CREATE)
 	if err != nil {
 		return "", fmt.Errorf("could not get known local app data folder: %w", err)
 	}


### PR DESCRIPTION
During install, app dir is set to current user.
While running service, it is set to systemprofile.
So when running as a service, supervisor couldn't access the config.

Fixes: #2411 