### PR TITLE
Merge DTOs for Tequilapi server & client

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -440,7 +440,7 @@ func (c *cliApp) status() {
 	if err != nil {
 		warn(err)
 	} else {
-		info("IP:", ip)
+		info("IP:", ip.IP)
 	}
 
 	location, err := c.tequilapi.ConnectionLocation()

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -35,7 +35,7 @@ const AppTopicState = "State change"
 
 // State represents the node state at the current moment. It's a read only object, used only to display data.
 type State struct {
-	NATStatus  NATStatus
+	NATStatus  contract.NATStatusDTO
 	Services   []contract.ServiceInfoDTO
 	Sessions   []contract.ServiceSessionDTO
 	Connection Connection
@@ -72,11 +72,4 @@ func (c Connection) String() string {
 		c.Throughput.Up,
 		money.NewMoney(c.Invoice.AgreementTotal, money.CurrencyMyst),
 	)
-}
-
-// NATStatus stores the nat status related information
-// swagger:model NATStatusDTO
-type NATStatus struct {
-	Status string `json:"status"`
-	Error  string `json:"error"`
 }

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/identity/registry"
-	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/payments/crypto"
@@ -37,7 +36,7 @@ const AppTopicState = "State change"
 // State represents the node state at the current moment. It's a read only object, used only to display data.
 type State struct {
 	NATStatus  NATStatus
-	Services   []ServiceInfo
+	Services   []contract.ServiceInfoDTO
 	Sessions   []contract.ServiceSessionDTO
 	Connection Connection
 	Identities []Identity
@@ -80,21 +79,4 @@ func (c Connection) String() string {
 type NATStatus struct {
 	Status string `json:"status"`
 	Error  string `json:"error"`
-}
-
-// ConnectionStatistics shows the successful and attempted connection count
-type ConnectionStatistics struct {
-	Attempted  int `json:"attempted"`
-	Successful int `json:"successful"`
-}
-
-// ServiceInfo stores the information about a service
-type ServiceInfo struct {
-	ID                   string                 `json:"id"`
-	ProviderID           string                 `json:"provider_id"`
-	Type                 string                 `json:"type"`
-	Options              interface{}            `json:"options"`
-	Status               string                 `json:"status"`
-	Proposal             market.ServiceProposal `json:"proposal"`
-	ConnectionStatistics ConnectionStatistics   `json:"connection_statistics"`
 }

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -19,7 +19,6 @@ package event
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/consumer/bandwidth"
@@ -28,6 +27,7 @@ import (
 	"github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/payments/crypto"
 )
 
@@ -38,7 +38,7 @@ const AppTopicState = "State change"
 type State struct {
 	NATStatus  NATStatus
 	Services   []ServiceInfo
-	Sessions   []ServiceSession
+	Sessions   []contract.ServiceSessionDTO
 	Connection Connection
 	Identities []Identity
 }
@@ -96,28 +96,5 @@ type ServiceInfo struct {
 	Options              interface{}            `json:"options"`
 	Status               string                 `json:"status"`
 	Proposal             market.ServiceProposal `json:"proposal"`
-	AccessPolicies       *[]market.AccessPolicy `json:"access_policies,omitempty"`
-	Sessions             []ServiceSession       `json:"service_session,omitempty"`
 	ConnectionStatistics ConnectionStatistics   `json:"connection_statistics"`
-}
-
-// ServiceSession represents the session object
-// swagger:model ServiceSessionDTO
-type ServiceSession struct {
-	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
-	ID string `json:"id"`
-	// example: 0x0000000000000000000000000000000000000001
-	ConsumerID string `json:"consumer_id"`
-	// example: 2019-06-06T11:04:43.910035Z
-	CreatedAt time.Time `json:"created_at"`
-	// example: 12345
-	BytesOut uint64 `json:"bytes_out"`
-	// example: 23451
-	BytesIn uint64 `json:"bytes_in"`
-	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
-	ServiceID string `json:"service_id"`
-	// example: wireguard
-	ServiceType string `json:"service_type"`
-	// example: 500000
-	TokensEarned uint64 `json:"tokens_earned"`
 }

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -35,6 +35,7 @@ import (
 	natEvent "github.com/mysteriumnetwork/node/nat/event"
 	sevent "github.com/mysteriumnetwork/node/session/event"
 	pingpongEvent "github.com/mysteriumnetwork/node/session/pingpong/event"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/rs/zerolog/log"
 )
 
@@ -110,7 +111,7 @@ func NewKeeper(deps KeeperDeps, debounceDuration time.Duration) *Keeper {
 			NATStatus: stateEvent.NATStatus{
 				Status: "not_finished",
 			},
-			Sessions: make([]stateEvent.ServiceSession, 0),
+			Sessions: make([]contract.ServiceSessionDTO, 0),
 			Connection: stateEvent.Connection{
 				Session: connection.Status{
 					State: connection.NotConnected,
@@ -299,7 +300,7 @@ func (k *Keeper) consumeServiceSessionEvent(e sevent.AppEventSession) {
 }
 
 func (k *Keeper) addSession(e sevent.AppEventSession) {
-	k.state.Sessions = append(k.state.Sessions, stateEvent.ServiceSession{
+	k.state.Sessions = append(k.state.Sessions, contract.ServiceSessionDTO{
 		ID:          e.Session.ID,
 		ConsumerID:  e.Session.ConsumerID.Address,
 		CreatedAt:   e.Session.StartedAt,
@@ -333,7 +334,7 @@ func (k *Keeper) updateSessionStats(e interface{}) {
 		return
 	}
 
-	var session *stateEvent.ServiceSession
+	var session *contract.ServiceSessionDTO
 	for i := range k.state.Sessions {
 		if k.state.Sessions[i].ID == evt.ID {
 			session = &k.state.Sessions[i]
@@ -363,7 +364,7 @@ func (k *Keeper) updateSessionEarnings(e interface{}) {
 		return
 	}
 
-	var session *stateEvent.ServiceSession
+	var session *contract.ServiceSessionDTO
 	for i := range k.state.Sessions {
 		if k.state.Sessions[i].ID == evt.SessionID {
 			session = &k.state.Sessions[i]

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -107,7 +107,7 @@ type KeeperDeps struct {
 func NewKeeper(deps KeeperDeps, debounceDuration time.Duration) *Keeper {
 	k := &Keeper{
 		state: &stateEvent.State{
-			NATStatus: stateEvent.NATStatus{
+			NATStatus: contract.NATStatusDTO{
 				Status: "not_finished",
 			},
 			Sessions: make([]contract.ServiceSessionDTO, 0),
@@ -271,7 +271,7 @@ func (k *Keeper) updateNatStatus(e interface{}) {
 
 	k.deps.NATStatusProvider.ConsumeNATEvent(event)
 	status := k.deps.NATStatusProvider.Status()
-	k.state.NATStatus = stateEvent.NATStatus{Status: status.Status}
+	k.state.NATStatus = contract.NATStatusDTO{Status: status.Status}
 	if status.Error != nil {
 		k.state.NATStatus.Error = status.Error.Error()
 	}

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/service/servicestate"
-	"github.com/mysteriumnetwork/node/core/state/event"
-	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
@@ -228,7 +226,7 @@ func Test_ConsumesSessionAcknowledgeEvents(t *testing.T) {
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	keeper.Subscribe(eventBus)
-	keeper.state.Services = []event.ServiceInfo{
+	keeper.state.Services = []contract.ServiceInfoDTO{
 		{ID: myID},
 	}
 	keeper.state.Sessions = []contract.ServiceSessionDTO{
@@ -353,7 +351,7 @@ func Test_ConsumesServiceEvents(t *testing.T) {
 	assert.Equal(t, expected.Proposal().ProviderID, actual.ProviderID)
 	assert.Equal(t, expected.Options(), actual.Options)
 	assert.Equal(t, string(expected.State()), actual.Status)
-	assert.EqualValues(t, expected.Proposal(), actual.Proposal)
+	assert.EqualValues(t, contract.NewProposalDTO(expected.Proposal()), actual.Proposal)
 }
 
 func Test_ConsumesConnectionStateEvents(t *testing.T) {
@@ -567,7 +565,7 @@ func Test_getServiceByID(t *testing.T) {
 	}
 	keeper := NewKeeper(deps, duration)
 	myID := "test"
-	keeper.state.Services = []event.ServiceInfo{
+	keeper.state.Services = []contract.ServiceInfoDTO{
 		{ID: myID},
 		{ID: "mock"},
 	}
@@ -604,7 +602,7 @@ func Test_incrementConnectionCount(t *testing.T) {
 	}
 	keeper := NewKeeper(deps, duration)
 	myID := "test"
-	keeper.state.Services = []event.ServiceInfo{
+	keeper.state.Services = []contract.ServiceInfoDTO{
 		{ID: myID},
 		{ID: "mock"},
 	}
@@ -648,7 +646,7 @@ func (mep *mockEarningsProvider) GetEarnings(_ identity.Identity) pingpongEvent.
 	return mep.Earnings
 }
 
-func serviceByID(services []stateEvent.ServiceInfo, id string) (se stateEvent.ServiceInfo, found bool) {
+func serviceByID(services []contract.ServiceInfoDTO, id string) (se contract.ServiceInfoDTO, found bool) {
 	for i := range services {
 		if services[i].ID == id {
 			se = services[i]

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -38,6 +38,7 @@ import (
 	sessionEvent "github.com/mysteriumnetwork/node/session/event"
 	"github.com/mysteriumnetwork/node/session/pingpong"
 	pingpongEvent "github.com/mysteriumnetwork/node/session/pingpong/event"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/stretchr/testify/assert"
 )
@@ -190,7 +191,7 @@ func Test_ConsumesSessionEvents(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(
 		t,
-		[]stateEvent.ServiceSession{
+		[]contract.ServiceSessionDTO{
 			{
 				ID:         expected.ID,
 				ConsumerID: expected.ConsumerID.Address,
@@ -215,7 +216,7 @@ func Test_ConsumesSessionEvents(t *testing.T) {
 func Test_ConsumesSessionAcknowledgeEvents(t *testing.T) {
 	// given
 	myID := "test"
-	expected := event.ServiceSession{
+	expected := contract.ServiceSessionDTO{
 		ID:        myID,
 		ServiceID: myID,
 	}
@@ -230,7 +231,7 @@ func Test_ConsumesSessionAcknowledgeEvents(t *testing.T) {
 	keeper.state.Services = []event.ServiceInfo{
 		{ID: myID},
 	}
-	keeper.state.Sessions = []event.ServiceSession{
+	keeper.state.Sessions = []contract.ServiceSessionDTO{
 		expected,
 	}
 
@@ -260,7 +261,7 @@ func Test_consumeServiceSessionEarningsEvent(t *testing.T) {
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	keeper.Subscribe(eventBus)
-	keeper.state.Sessions = []event.ServiceSession{
+	keeper.state.Sessions = []contract.ServiceSessionDTO{
 		{ID: "1"},
 	}
 
@@ -276,7 +277,7 @@ func Test_consumeServiceSessionEarningsEvent(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(
 		t,
-		[]stateEvent.ServiceSession{
+		[]contract.ServiceSessionDTO{
 			{ID: "1", TokensEarned: 500},
 		},
 		keeper.GetState().Sessions,
@@ -292,7 +293,7 @@ func Test_consumeServiceSessionStatisticsEvent(t *testing.T) {
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	keeper.Subscribe(eventBus)
-	keeper.state.Sessions = []event.ServiceSession{
+	keeper.state.Sessions = []contract.ServiceSessionDTO{
 		{ID: "1"},
 	}
 
@@ -309,7 +310,7 @@ func Test_consumeServiceSessionStatisticsEvent(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(
 		t,
-		[]stateEvent.ServiceSession{
+		[]contract.ServiceSessionDTO{
 			{ID: "1", BytesOut: 2, BytesIn: 1},
 		},
 		keeper.GetState().Sessions,

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -222,7 +222,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 
 	nonVpnIP, err := tequilapi.ConnectionIP()
 	assert.NoError(t, err)
-	log.Info().Msg("Original consumer IP: " + nonVpnIP)
+	log.Info().Msg("Original consumer IP: " + nonVpnIP.IP)
 
 	err = waitForCondition(func() (bool, error) {
 		status, err := tequilapi.ConnectionStatus()
@@ -244,7 +244,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 
 	vpnIP, err := tequilapi.ConnectionIP()
 	assert.NoError(t, err)
-	log.Info().Msg("Changed consumer IP: " + vpnIP)
+	log.Info().Msg("Changed consumer IP: " + vpnIP.IP)
 
 	// sessions history should be created after connect
 	sessionsDTO, err := tequilapi.ConnectionSessionsByType(serviceType)

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -323,20 +323,20 @@ func sessionStatsReceived(tequilapi *tequilapi_client.Client, serviceType string
 	}
 }
 
-type sessionAsserter func(t *testing.T, session tequilapi_client.ConnectionSessionDTO)
+type sessionAsserter func(t *testing.T, session contract.ConnectionSessionDTO)
 
 var serviceTypeAssertionMap = map[string]sessionAsserter{
-	"openvpn": func(t *testing.T, session tequilapi_client.ConnectionSessionDTO) {
+	"openvpn": func(t *testing.T, session contract.ConnectionSessionDTO) {
 		assert.NotZero(t, session.Duration)
 		assert.NotZero(t, session.BytesSent)
 		assert.NotZero(t, session.BytesReceived)
 	},
-	"noop": func(t *testing.T, session tequilapi_client.ConnectionSessionDTO) {
+	"noop": func(t *testing.T, session contract.ConnectionSessionDTO) {
 		assert.NotZero(t, session.Duration)
 		assert.Zero(t, session.BytesSent)
 		assert.Zero(t, session.BytesReceived)
 	},
-	"wireguard": func(t *testing.T, session tequilapi_client.ConnectionSessionDTO) {
+	"wireguard": func(t *testing.T, session contract.ConnectionSessionDTO) {
 		assert.NotZero(t, session.Duration)
 		assert.NotZero(t, session.BytesSent)
 		assert.NotZero(t, session.BytesReceived)

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -243,7 +243,7 @@ func (client *Client) ConnectionLocation() (location contract.LocationDTO, err e
 }
 
 // Healthcheck returns a healthcheck info
-func (client *Client) Healthcheck() (healthcheck HealthcheckDTO, err error) {
+func (client *Client) Healthcheck() (healthcheck contract.HealthCheckDTO, err error) {
 	response, err := client.http.Get("healthcheck", url.Values{})
 	if err != nil {
 		return

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -418,9 +418,7 @@ func (client *Client) ServiceStop(id string) error {
 }
 
 // NATStatus returns status of NAT traversal
-func (client *Client) NATStatus() (NATStatusDTO, error) {
-	status := NATStatusDTO{}
-
+func (client *Client) NATStatus() (status contract.NATStatusDTO, err error) {
 	response, err := client.http.Get("nat/status", nil)
 	if err != nil {
 		return status, err

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -85,18 +85,17 @@ func (client *Client) CurrentIdentity(identity, passphrase string) (id contract.
 }
 
 // Identity returns identity status with current balance
-func (client *Client) Identity(identityAddress string) (contract.IdentityDTO, error) {
+func (client *Client) Identity(identityAddress string) (id contract.IdentityDTO, err error) {
 	path := fmt.Sprintf("identities/%s", identityAddress)
 
 	response, err := client.http.Get(path, nil)
 	if err != nil {
-		return contract.IdentityDTO{}, err
+		return id, err
 	}
 	defer response.Body.Close()
 
-	res := contract.IdentityDTO{}
-	err = parseResponseJSON(response, &res)
-	return res, err
+	err = parseResponseJSON(response, &id)
+	return id, err
 }
 
 // IdentityRegistrationStatus returns information of identity needed to register it on blockchain
@@ -196,27 +195,25 @@ func (client *Client) ConnectionDestroy() (err error) {
 }
 
 // ConnectionStatistics returns statistics about current connection
-func (client *Client) ConnectionStatistics() (contract.ConnectionStatisticsDTO, error) {
+func (client *Client) ConnectionStatistics() (statistics contract.ConnectionStatisticsDTO, err error) {
 	response, err := client.http.Get("connection/statistics", url.Values{})
 	if err != nil {
-		return contract.ConnectionStatisticsDTO{}, err
+		return statistics, err
 	}
 	defer response.Body.Close()
 
-	var statistics contract.ConnectionStatisticsDTO
 	err = parseResponseJSON(response, &statistics)
 	return statistics, err
 }
 
 // ConnectionStatus returns connection status
-func (client *Client) ConnectionStatus() (contract.ConnectionStatusDTO, error) {
+func (client *Client) ConnectionStatus() (status contract.ConnectionStatusDTO, err error) {
 	response, err := client.http.Get("connection", url.Values{})
 	if err != nil {
-		return contract.ConnectionStatusDTO{}, err
+		return status, err
 	}
 	defer response.Body.Close()
 
-	var status contract.ConnectionStatusDTO
 	err = parseResponseJSON(response, &status)
 	return status, err
 }
@@ -350,8 +347,7 @@ func (client *Client) Stop() error {
 }
 
 // ConnectionSessions returns all sessions from history
-func (client *Client) ConnectionSessions() (ConnectionSessionListDTO, error) {
-	sessions := ConnectionSessionListDTO{}
+func (client *Client) ConnectionSessions() (sessions contract.ListConnectionSessionsResponse, err error) {
 	response, err := client.http.Get("connection-sessions", url.Values{})
 	if err != nil {
 		return sessions, err
@@ -363,14 +359,14 @@ func (client *Client) ConnectionSessions() (ConnectionSessionListDTO, error) {
 }
 
 // ConnectionSessionsByType returns sessions from history filtered by type
-func (client *Client) ConnectionSessionsByType(serviceType string) (ConnectionSessionListDTO, error) {
+func (client *Client) ConnectionSessionsByType(serviceType string) (contract.ListConnectionSessionsResponse, error) {
 	sessions, err := client.ConnectionSessions()
 	sessions = filterSessionsByType(serviceType, sessions)
 	return sessions, err
 }
 
 // ConnectionSessionsByStatus returns sessions from history filtered by their status
-func (client *Client) ConnectionSessionsByStatus(status string) (ConnectionSessionListDTO, error) {
+func (client *Client) ConnectionSessionsByStatus(status string) (contract.ListConnectionSessionsResponse, error) {
 	sessions, err := client.ConnectionSessions()
 	sessions = filterSessionsByStatus(status, sessions)
 	return sessions, err
@@ -439,8 +435,7 @@ func (client *Client) NATStatus() (NATStatusDTO, error) {
 }
 
 // ServiceSessions returns all currently running sessions
-func (client *Client) ServiceSessions() (ServiceSessionListDTO, error) {
-	sessions := ServiceSessionListDTO{}
+func (client *Client) ServiceSessions() (sessions contract.ListServiceSessionsResponse, err error) {
 	response, err := client.http.Get("service-sessions", url.Values{})
 	if err != nil {
 		return sessions, err
@@ -452,7 +447,7 @@ func (client *Client) ServiceSessions() (ServiceSessionListDTO, error) {
 }
 
 // filterSessionsByType removes all sessions of irrelevant types
-func filterSessionsByType(serviceType string, sessions ConnectionSessionListDTO) ConnectionSessionListDTO {
+func filterSessionsByType(serviceType string, sessions contract.ListConnectionSessionsResponse) contract.ListConnectionSessionsResponse {
 	matches := 0
 	for _, s := range sessions.Sessions {
 		if s.ServiceType == serviceType {
@@ -465,7 +460,7 @@ func filterSessionsByType(serviceType string, sessions ConnectionSessionListDTO)
 }
 
 // filterSessionsByStatus removes all sessions with non matching status
-func filterSessionsByStatus(status string, sessions ConnectionSessionListDTO) ConnectionSessionListDTO {
+func filterSessionsByStatus(status string, sessions contract.ListConnectionSessionsResponse) contract.ListConnectionSessionsResponse {
 	matches := 0
 	for _, s := range sessions.Sessions {
 		if s.Status == status {

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -219,22 +219,19 @@ func (client *Client) ConnectionStatus() (status contract.ConnectionStatusDTO, e
 }
 
 // ConnectionIP returns public ip
-func (client *Client) ConnectionIP() (string, error) {
+func (client *Client) ConnectionIP() (ip contract.IPDTO, err error) {
 	response, err := client.http.Get("connection/ip", url.Values{})
 	if err != nil {
-		return "", err
+		return ip, err
 	}
 	defer response.Body.Close()
 
-	var ipData struct {
-		IP string `json:"ip"`
-	}
-	err = parseResponseJSON(response, &ipData)
-	return ipData.IP, err
+	err = parseResponseJSON(response, &ip)
+	return ip, err
 }
 
 // ConnectionLocation returns current location
-func (client *Client) ConnectionLocation() (location LocationDTO, err error) {
+func (client *Client) ConnectionLocation() (location contract.LocationDTO, err error) {
 	response, err := client.http.Get("connection/location", url.Values{})
 	if err != nil {
 		return location, err
@@ -258,7 +255,7 @@ func (client *Client) Healthcheck() (healthcheck HealthcheckDTO, err error) {
 }
 
 // OriginLocation returns original location
-func (client *Client) OriginLocation() (location LocationDTO, err error) {
+func (client *Client) OriginLocation() (location contract.LocationDTO, err error) {
 	response, err := client.http.Get("location", url.Values{})
 	if err != nil {
 		return location, err

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -370,7 +370,7 @@ func (client *Client) ConnectionSessionsByStatus(status string) (contract.ListCo
 }
 
 // Services returns all running services
-func (client *Client) Services() (services ServiceListDTO, err error) {
+func (client *Client) Services() (services contract.ListServicesResponse, err error) {
 	response, err := client.http.Get("services", url.Values{})
 	if err != nil {
 		return services, err
@@ -382,7 +382,7 @@ func (client *Client) Services() (services ServiceListDTO, err error) {
 }
 
 // Service returns a service information by the requested id
-func (client *Client) Service(id string) (service ServiceInfoDTO, err error) {
+func (client *Client) Service(id string) (service contract.ServiceInfoDTO, err error) {
 	response, err := client.http.Get("services/"+id, url.Values{})
 	if err != nil {
 		return service, err
@@ -394,7 +394,7 @@ func (client *Client) Service(id string) (service ServiceInfoDTO, err error) {
 }
 
 // ServiceStart starts an instance of the service.
-func (client *Client) ServiceStart(request contract.ServiceStartRequest) (service ServiceInfoDTO, err error) {
+func (client *Client) ServiceStart(request contract.ServiceStartRequest) (service contract.ServiceInfoDTO, err error) {
 	response, err := client.http.Post("services", request)
 	if err != nil {
 		return service, err

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -30,12 +30,6 @@ type RegistrationDataDTO struct {
 	Registered bool   `json:"registered"`
 }
 
-// NATStatusDTO gives information about NAT traversal success or failure
-type NATStatusDTO struct {
-	Status string `json:"status"`
-	Error  string `json:"error,omitempty"`
-}
-
 // SettleRequest represents the request to settle accountant promises
 type SettleRequest struct {
 	AccountantID string `json:"accountant_id"`

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -30,21 +30,6 @@ type Fees struct {
 	Accountant   uint16 `json:"accountant"`
 }
 
-// HealthcheckDTO holds returned healthcheck response
-type HealthcheckDTO struct {
-	Uptime    string       `json:"uptime"`
-	Process   int          `json:"process"`
-	Version   string       `json:"version"`
-	BuildInfo BuildInfoDTO `json:"build_info"`
-}
-
-// BuildInfoDTO holds info about build
-type BuildInfoDTO struct {
-	Commit      string `json:"commit"`
-	Branch      string `json:"branch"`
-	BuildNumber string `json:"build_number"`
-}
-
 // RegistrationDataDTO holds input data required to register new myst identity on blockchain smart contract
 type RegistrationDataDTO struct {
 	Status     string `json:"status"`

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -45,19 +45,6 @@ type BuildInfoDTO struct {
 	BuildNumber string `json:"build_number"`
 }
 
-// LocationDTO describes location metadata
-type LocationDTO struct {
-	IP  string `json:"ip"`
-	ASN int    `json:"asn"`
-	ISP string `json:"isp"`
-
-	Continent string `json:"continent"`
-	Country   string `json:"country"`
-	City      string `json:"city"`
-
-	UserType string `json:"user_type"`
-}
-
 // RegistrationDataDTO holds input data required to register new myst identity on blockchain smart contract
 type RegistrationDataDTO struct {
 	Status     string `json:"status"`

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -64,25 +64,6 @@ type RegistrationDataDTO struct {
 	Registered bool   `json:"registered"`
 }
 
-// ConnectionSessionListDTO copied from tequilapi endpoint
-type ConnectionSessionListDTO struct {
-	Sessions []ConnectionSessionDTO `json:"sessions"`
-}
-
-// ConnectionSessionDTO copied from tequilapi endpoint
-type ConnectionSessionDTO struct {
-	SessionID       string `json:"session_id"`
-	ProviderID      string `json:"provider_id"`
-	ServiceType     string `json:"service_type"`
-	ProviderCountry string `json:"provider_country"`
-	DateStarted     string `json:"date_started"`
-	BytesSent       uint64 `json:"bytes_sent"`
-	BytesReceived   uint64 `json:"bytes_received"`
-	TokensSpent     uint64 `json:"tokens_spent"`
-	Duration        uint64 `json:"duration"`
-	Status          string `json:"status"`
-}
-
 // ServiceListDTO represents a list of running services on the node
 type ServiceListDTO []ServiceInfoDTO
 
@@ -94,17 +75,6 @@ type ServiceInfoDTO struct {
 	Options     json.RawMessage      `json:"options"`
 	Status      string               `json:"status"`
 	Proposal    contract.ProposalDTO `json:"proposal"`
-}
-
-// ServiceSessionListDTO copied from tequilapi endpoint
-type ServiceSessionListDTO struct {
-	Sessions []ServiceSessionDTO `json:"sessions"`
-}
-
-// ServiceSessionDTO copied from tequilapi endpoint
-type ServiceSessionDTO struct {
-	ID         string `json:"id"`
-	ConsumerID string `json:"consumer_id"`
 }
 
 // NATStatusDTO gives information about NAT traversal success or failure

--- a/tequilapi/client/dto.go
+++ b/tequilapi/client/dto.go
@@ -17,12 +17,6 @@
 
 package client
 
-import (
-	"encoding/json"
-
-	"github.com/mysteriumnetwork/node/tequilapi/contract"
-)
-
 // Fees represents the transactor fee
 type Fees struct {
 	Registration uint64 `json:"registration"`
@@ -34,19 +28,6 @@ type Fees struct {
 type RegistrationDataDTO struct {
 	Status     string `json:"status"`
 	Registered bool   `json:"registered"`
-}
-
-// ServiceListDTO represents a list of running services on the node
-type ServiceListDTO []ServiceInfoDTO
-
-// ServiceInfoDTO represents running service information
-type ServiceInfoDTO struct {
-	ID          string               `json:"id"`
-	ProviderID  string               `json:"provider_id"`
-	ServiceType string               `json:"type"`
-	Options     json.RawMessage      `json:"options"`
-	Status      string               `json:"status"`
-	Proposal    contract.ProposalDTO `json:"proposal"`
 }
 
 // NATStatusDTO gives information about NAT traversal success or failure

--- a/tequilapi/contract/auth.go
+++ b/tequilapi/contract/auth.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+// LoginRequest request used to login to API.
+// swagger:model LoginRequest
+type LoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// ChangePasswordRequest request used to change API password.
+// swagger:model ChangePasswordRequest
+type ChangePasswordRequest struct {
+	Username    string `json:"username"`
+	OldPassword string `json:"old_password"`
+	NewPassword string `json:"new_password"`
+}

--- a/tequilapi/contract/healthcheck.go
+++ b/tequilapi/contract/healthcheck.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+// HealthCheckDTO holds API healthcheck.
+// swagger:model HealthCheckDTO
+type HealthCheckDTO struct {
+	// example: 25h53m33.540493171s
+	Uptime string `json:"uptime"`
+
+	// example: 10449
+	Process int `json:"process"`
+
+	// example: 0.0.6
+	Version   string       `json:"version"`
+	BuildInfo BuildInfoDTO `json:"build_info"`
+}
+
+// BuildInfoDTO holds info about build.
+// swagger:model BuildInfoDTO
+type BuildInfoDTO struct {
+	// example: <unknown>
+	Commit string `json:"commit"`
+
+	// example: <unknown>
+	Branch string `json:"branch"`
+
+	// example: dev-build
+	BuildNumber string `json:"build_number"`
+}

--- a/tequilapi/contract/location.go
+++ b/tequilapi/contract/location.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+// IPDTO describes IP metadata.
+// swagger:model IPDTO
+type IPDTO struct {
+	// public IP address
+	// example: 127.0.0.1
+	IP string `json:"ip"`
+}
+
+// LocationDTO describes IP location metadata.
+// swagger:model LocationDTO
+type LocationDTO struct {
+	// IP address
+	// example: 1.2.3.4
+	IP string `json:"ip"`
+	// Autonomous system number
+	// example: 62179
+	ASN int `json:"asn"`
+	// Internet Service Provider name
+	// example: Telia Lietuva, AB
+	ISP string `json:"isp"`
+
+	// Continent
+	// example: EU
+	Continent string `json:"continent"`
+	// Node Country
+	// example: LT
+	Country string `json:"country"`
+	// Node City
+	// example: Vilnius
+	City string `json:"city"`
+
+	// User type (data_center, residential, etc.)
+	// example: residential
+	UserType string `json:"user_type"`
+	// User type (DEPRECATED)
+	// example: residential
+	NodeType string `json:"node_type"`
+}

--- a/tequilapi/contract/nat.go
+++ b/tequilapi/contract/nat.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+// NATStatusDTO gives information about NAT traversal success or failure
+// swagger:model NATStatusDTO
+type NATStatusDTO struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}

--- a/tequilapi/contract/proposal.go
+++ b/tequilapi/contract/proposal.go
@@ -28,27 +28,20 @@ import (
 // NewProposalDTO maps to API service proposal.
 func NewProposalDTO(p market.ServiceProposal) ProposalDTO {
 	return ProposalDTO{
-		ID:          p.ID,
-		ProviderID:  p.ProviderID,
-		ServiceType: p.ServiceType,
-		ServiceDefinition: ServiceDefinitionDTO{
-			LocationOriginate: ServiceLocationDTO{
-				Continent: p.ServiceDefinition.GetLocation().Continent,
-				Country:   p.ServiceDefinition.GetLocation().Country,
-				City:      p.ServiceDefinition.GetLocation().City,
-
-				ASN:      p.ServiceDefinition.GetLocation().ASN,
-				ISP:      p.ServiceDefinition.GetLocation().ISP,
-				NodeType: p.ServiceDefinition.GetLocation().NodeType,
-			},
-		},
-		AccessPolicies: p.AccessPolicies,
-		PaymentMethod:  NewPaymentMethodDTO(p.PaymentMethod),
+		ID:                p.ID,
+		ProviderID:        p.ProviderID,
+		ServiceType:       p.ServiceType,
+		ServiceDefinition: NewServiceDefinitionDTO(p.ServiceDefinition),
+		AccessPolicies:    p.AccessPolicies,
+		PaymentMethod:     NewPaymentMethodDTO(p.PaymentMethod),
 	}
 }
 
 // NewPaymentMethodDTO maps to API payment method.
 func NewPaymentMethodDTO(m market.PaymentMethod) PaymentMethodDTO {
+	if m == nil {
+		return PaymentMethodDTO{}
+	}
 	return PaymentMethodDTO{
 		Type:  m.GetType(),
 		Price: m.GetPrice(),
@@ -56,6 +49,29 @@ func NewPaymentMethodDTO(m market.PaymentMethod) PaymentMethodDTO {
 			PerSeconds: uint64(m.GetRate().PerTime.Seconds()),
 			PerBytes:   m.GetRate().PerByte,
 		},
+	}
+}
+
+// NewServiceDefinitionDTO maps to API service definition.
+func NewServiceDefinitionDTO(s market.ServiceDefinition) ServiceDefinitionDTO {
+	if s == nil {
+		return ServiceDefinitionDTO{}
+	}
+	return ServiceDefinitionDTO{
+		LocationOriginate: NewLocationsDTO(s.GetLocation()),
+	}
+}
+
+// NewLocationsDTO maps to API service location.
+func NewLocationsDTO(l market.Location) ServiceLocationDTO {
+	return ServiceLocationDTO{
+		Continent: l.Continent,
+		Country:   l.Country,
+		City:      l.City,
+
+		ASN:      l.ASN,
+		ISP:      l.ISP,
+		NodeType: l.NodeType,
 	}
 }
 

--- a/tequilapi/contract/service.go
+++ b/tequilapi/contract/service.go
@@ -56,3 +56,39 @@ type ServicePaymentMethod struct {
 type ServiceAccessPolicies struct {
 	IDs []string `json:"ids"`
 }
+
+// ListServicesResponse represents a list of running services on the node.
+// swagger:model ListServicesResponse
+type ListServicesResponse []ServiceInfoDTO
+
+// ServiceInfoDTO represents running service information.
+// swagger:model ServiceInfoDTO
+type ServiceInfoDTO struct {
+	// example: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+	ID string `json:"id"`
+
+	// provider identity
+	// example: 0x0000000000000000000000000000000000000002
+	ProviderID string `json:"provider_id"`
+
+	// service type. Possible values are "openvpn", "wireguard" and "noop"
+	// example: openvpn
+	Type string `json:"type"`
+
+	// options with which service was started. Every service has a unique list of allowed options.
+	// example: {"port": 1123, "protocol": "udp"}
+	Options interface{} `json:"options"`
+
+	// example: Running
+	Status string `json:"status"`
+
+	Proposal ProposalDTO `json:"proposal"`
+
+	ConnectionStatistics ServiceStatisticsDTO `json:"connection_statistics"`
+}
+
+// ServiceStatisticsDTO shows the successful and attempted connection count
+type ServiceStatisticsDTO struct {
+	Attempted  int `json:"attempted"`
+	Successful int `json:"successful"`
+}

--- a/tequilapi/contract/session.go
+++ b/tequilapi/contract/session.go
@@ -47,3 +47,50 @@ type ServiceSessionDTO struct {
 	// example: 500000
 	TokensEarned uint64 `json:"tokens_earned"`
 }
+
+// ListConnectionSessionsResponse defines session list representable as json
+// swagger:model ListConnectionSessionsResponse
+type ListConnectionSessionsResponse struct {
+	Sessions []ConnectionSessionDTO `json:"sessions"`
+}
+
+// ConnectionSessionDTO represents the session object
+// swagger:model ConnectionSessionDTO
+type ConnectionSessionDTO struct {
+	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
+	SessionID string `json:"session_id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	ConsumerID string `json:"consumer_id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	AccountantID string `json:"accountant_id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	ProviderID string `json:"provider_id"`
+
+	// example: openvpn
+	ServiceType string `json:"service_type"`
+
+	// example: NL
+	ProviderCountry string `json:"provider_country"`
+
+	// example: 2018-10-29 16:22:05
+	DateStarted string `json:"date_started"`
+
+	// example: 1024
+	BytesSent uint64 `json:"bytes_sent"`
+
+	// example: 1024
+	BytesReceived uint64 `json:"bytes_received"`
+
+	// duration in seconds
+	// example: 120
+	Duration uint64 `json:"duration"`
+
+	// example: 500000
+	TokensSpent uint64 `json:"tokens_spent"`
+
+	// example: Completed
+	Status string `json:"status"`
+}

--- a/tequilapi/contract/session.go
+++ b/tequilapi/contract/session.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+import (
+	"time"
+)
+
+// ListServiceSessionsResponse defines session list representable as json
+// swagger:model ListServiceSessionsResponse
+type ListServiceSessionsResponse struct {
+	Sessions []ServiceSessionDTO `json:"sessions"`
+}
+
+// ServiceSessionDTO represents the session object
+// swagger:model ServiceSessionDTO
+type ServiceSessionDTO struct {
+	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
+	ID string `json:"id"`
+	// example: 0x0000000000000000000000000000000000000001
+	ConsumerID string `json:"consumer_id"`
+	// example: 2019-06-06T11:04:43.910035Z
+	CreatedAt time.Time `json:"created_at"`
+	// example: 12345
+	BytesOut uint64 `json:"bytes_out"`
+	// example: 23451
+	BytesIn uint64 `json:"bytes_in"`
+	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
+	ServiceID string `json:"service_id"`
+	// example: wireguard
+	ServiceType string `json:"service_type"`
+	// example: 500000
+	TokensEarned uint64 `json:"tokens_earned"`
+}

--- a/tequilapi/endpoints/auth.go
+++ b/tequilapi/endpoints/auth.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 
 	"github.com/mysteriumnetwork/node/core/auth"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
@@ -39,19 +40,6 @@ type jwtAuthenticator interface {
 type authenticator interface {
 	CheckCredentials(username, password string) error
 	ChangePassword(username, oldPassword, newPassword string) error
-}
-
-// swagger:model LoginRequest
-type loginRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-}
-
-// swagger:model ChangePasswordRequest
-type changePasswordRequest struct {
-	Username    string `json:"username"`
-	OldPassword string `json:"old_password"`
-	NewPassword string `json:"new_password"`
 }
 
 // swagger:operation POST /auth/login Authentication Login
@@ -75,7 +63,7 @@ type changePasswordRequest struct {
 //     schema:
 //       "$ref": "#/definitions/ErrorMessageDTO"
 func (api *authenticationAPI) Login(httpRes http.ResponseWriter, httpReq *http.Request, _ httprouter.Params) {
-	var req *loginRequest
+	var req *contract.LoginRequest
 	var err error
 
 	req, err = toLoginRequest(httpReq)
@@ -126,7 +114,7 @@ func (api *authenticationAPI) Login(httpRes http.ResponseWriter, httpReq *http.R
 //     schema:
 //       "$ref": "#/definitions/ErrorMessageDTO"
 func (api *authenticationAPI) ChangePassword(httpRes http.ResponseWriter, httpReq *http.Request, _ httprouter.Params) {
-	var req *changePasswordRequest
+	var req *contract.ChangePasswordRequest
 	var err error
 	req, err = toChangePasswordRequest(httpReq)
 	if err != nil {
@@ -140,16 +128,16 @@ func (api *authenticationAPI) ChangePassword(httpRes http.ResponseWriter, httpRe
 	}
 }
 
-func toLoginRequest(req *http.Request) (*loginRequest, error) {
-	var loginReq = loginRequest{}
+func toLoginRequest(req *http.Request) (*contract.LoginRequest, error) {
+	var loginReq = contract.LoginRequest{}
 	if err := json.NewDecoder(req.Body).Decode(&loginReq); err != nil {
 		return nil, err
 	}
 	return &loginReq, nil
 }
 
-func toChangePasswordRequest(req *http.Request) (*changePasswordRequest, error) {
-	var cpReq = changePasswordRequest{}
+func toChangePasswordRequest(req *http.Request) (*contract.ChangePasswordRequest, error) {
+	var cpReq = contract.ChangePasswordRequest{}
 	if err := json.NewDecoder(req.Body).Decode(&cpReq); err != nil {
 		return nil, err
 	}

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -39,13 +39,6 @@ import (
 // operations, custom client error code is defined. Maybe in later times a better idea will come how to handle these situations
 const statusConnectCancelled = 499
 
-// swagger:model IPDTO
-type ipResponse struct {
-	// public IP address
-	// example: 127.0.0.1
-	IP string `json:"ip"`
-}
-
 // ProposalGetter defines interface to fetch currently active service proposal by id
 type ProposalGetter interface {
 	GetProposal(id market.ProposalID) (*market.ServiceProposal, error)

--- a/tequilapi/endpoints/connection_location.go
+++ b/tequilapi/endpoints/connection_location.go
@@ -23,41 +23,12 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/core/location"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 )
 
-// swagger:model LocationDTO
-type locationResponse struct {
-	// IP address
-	// example: 1.2.3.4
-	IP string `json:"ip"`
-	// Autonomous system number
-	// example: 62179
-	ASN int `json:"asn"`
-	// Internet Service Provider name
-	// example: Telia Lietuva, AB
-	ISP string `json:"isp"`
-
-	// Continent
-	// example: EU
-	Continent string `json:"continent"`
-	// Node Country
-	// example: LT
-	Country string `json:"country"`
-	// Node City
-	// example: Vilnius
-	City string `json:"city"`
-
-	// User type (data_center, residential, etc.)
-	// example: residential
-	UserType string `json:"user_type"`
-	// User type (DEPRECATED)
-	// example: residential
-	NodeType string `json:"node_type"`
-}
-
-func locationToRes(l location.Location) locationResponse {
-	return locationResponse{
+func locationToRes(l location.Location) contract.LocationDTO {
+	return contract.LocationDTO{
 		IP:        l.IP,
 		ASN:       l.ASN,
 		ISP:       l.ISP,
@@ -114,7 +85,7 @@ func (le *ConnectionLocationEndpoint) GetConnectionIP(writer http.ResponseWriter
 		return
 	}
 
-	response := ipResponse{
+	response := contract.IPDTO{
 		IP: ipAddress,
 	}
 	utils.WriteAsJSON(response, writer)

--- a/tequilapi/endpoints/connection_sessions.go
+++ b/tequilapi/endpoints/connection_sessions.go
@@ -23,55 +23,9 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/mysteriumnetwork/node/consumer/session"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 )
-
-// connectionSessionsList defines session list representable as json
-// swagger:model ConnectionSessionListDTO
-type connectionSessionsList struct {
-	Sessions []connectionSession `json:"sessions"`
-}
-
-// connectionSession represents the session object
-// swagger:model ConnectionSessionDTO
-type connectionSession struct {
-	// example: 4cfb0324-daf6-4ad8-448b-e61fe0a1f918
-	SessionID string `json:"session_id"`
-
-	// example: 0x0000000000000000000000000000000000000001
-	ConsumerID string `json:"consumer_id"`
-
-	// example: 0x0000000000000000000000000000000000000001
-	AccountantID string `json:"accountant_id"`
-
-	// example: 0x0000000000000000000000000000000000000001
-	ProviderID string `json:"provider_id"`
-
-	// example: openvpn
-	ServiceType string `json:"service_type"`
-
-	// example: NL
-	ProviderCountry string `json:"provider_country"`
-
-	// example: 2018-10-29 16:22:05
-	DateStarted string `json:"date_started"`
-
-	// example: 1024
-	BytesSent uint64 `json:"bytes_sent"`
-
-	// example: 1024
-	BytesReceived uint64 `json:"bytes_received"`
-
-	// duration in seconds
-	// example: 120
-	Duration uint64 `json:"duration"`
-
-	// example: 500000
-	TokensSpent uint64 `json:"tokens_spent"`
-
-	// example: Completed
-	Status string `json:"status"`
-}
 
 type connectionSessionStorage interface {
 	GetAll() ([]session.History, error)
@@ -96,7 +50,7 @@ func NewConnectionSessionsEndpoint(sessionStorage connectionSessionStorage) *con
 //   200:
 //     description: List of sessions
 //     schema:
-//       "$ref": "#/definitions/ConnectionSessionListDTO"
+//       "$ref": "#/definitions/ListConnectionSessionsResponse"
 //   500:
 //     description: Internal server error
 //     schema:
@@ -108,7 +62,7 @@ func (endpoint *connectionSessionsEndpoint) List(resp http.ResponseWriter, reque
 		return
 	}
 
-	sessionsSerializable := connectionSessionsList{Sessions: mapConnectionSessions(sessions, connectionSessionToDto)}
+	sessionsSerializable := contract.ListConnectionSessionsResponse{Sessions: mapConnectionSessions(sessions, connectionSessionToDto)}
 	utils.WriteAsJSON(sessionsSerializable, resp)
 }
 
@@ -118,8 +72,8 @@ func AddRoutesForConnectionSessions(router *httprouter.Router, sessionStorage co
 	router.GET("/connection-sessions", sessionsEndpoint.List)
 }
 
-func connectionSessionToDto(se session.History) connectionSession {
-	return connectionSession{
+func connectionSessionToDto(se session.History) contract.ConnectionSessionDTO {
+	return contract.ConnectionSessionDTO{
 		SessionID:       string(se.SessionID),
 		ConsumerID:      se.ConsumerID.Address,
 		AccountantID:    se.AccountantID,
@@ -135,8 +89,8 @@ func connectionSessionToDto(se session.History) connectionSession {
 	}
 }
 
-func mapConnectionSessions(sessions []session.History, f func(session.History) connectionSession) []connectionSession {
-	dtoArray := make([]connectionSession, len(sessions))
+func mapConnectionSessions(sessions []session.History, f func(session.History) contract.ConnectionSessionDTO) []contract.ConnectionSessionDTO {
+	dtoArray := make([]contract.ConnectionSessionDTO, len(sessions))
 	for i, se := range sessions {
 		dtoArray[i] = f(se)
 	}

--- a/tequilapi/endpoints/connection_sessions_test.go
+++ b/tequilapi/endpoints/connection_sessions_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mysteriumnetwork/node/consumer/session"
@@ -82,7 +83,7 @@ func Test_ConnectionSessionsEndpoint_List(t *testing.T) {
 	handlerFunc := NewConnectionSessionsEndpoint(ssm).List
 	handlerFunc(resp, req, nil)
 
-	parsedResponse := &connectionSessionsList{}
+	parsedResponse := &contract.ListConnectionSessionsResponse{}
 	err = json.Unmarshal(resp.Body.Bytes(), parsedResponse)
 	assert.Nil(t, err)
 	assert.EqualValues(t, connectionSessionToDto(connectionSessionMock), parsedResponse.Sessions[0])

--- a/tequilapi/endpoints/health_check.go
+++ b/tequilapi/endpoints/health_check.go
@@ -23,33 +23,9 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/mysteriumnetwork/node/metadata"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 )
-
-// swagger:model HealthCheckDTO
-type healthCheckData struct {
-	// example: 25h53m33.540493171s
-	Uptime string `json:"uptime"`
-
-	// example: 10449
-	Process int `json:"process"`
-
-	// example: 0.0.6
-	Version   string    `json:"version"`
-	BuildInfo buildInfo `json:"build_info"`
-}
-
-// swagger:model BuildInfoDTO
-type buildInfo struct {
-	// example: <unknown>
-	Commit string `json:"commit"`
-
-	// example: <unknown>
-	Branch string `json:"branch"`
-
-	// example: dev-build
-	BuildNumber string `json:"build_number"`
-}
 
 type healthCheckEndpoint struct {
 	startTime       time.Time
@@ -84,14 +60,14 @@ func HealthCheckEndpointFactory(currentTimeFunc func() time.Time, procID func() 
 //     schema:
 //       "$ref": "#/definitions/ErrorMessageDTO"
 func (hce *healthCheckEndpoint) HealthCheck(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
-	status := healthCheckData{
+	status := contract.HealthCheckDTO{
 		Uptime:  hce.currentTimeFunc().Sub(hce.startTime).String(),
 		Process: hce.processNumber,
 		Version: metadata.VersionAsString(),
-		BuildInfo: buildInfo{
-			metadata.BuildCommit,
-			metadata.BuildBranch,
-			metadata.BuildNumber,
+		BuildInfo: contract.BuildInfoDTO{
+			Commit:      metadata.BuildCommit,
+			Branch:      metadata.BuildBranch,
+			BuildNumber: metadata.BuildNumber,
 		},
 	}
 	utils.WriteAsJSON(status, writer)

--- a/tequilapi/endpoints/nat_test.go
+++ b/tequilapi/endpoints/nat_test.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_NATStatus_ReturnsStatusSuccessful_WithSuccessfulEvent(t *testing.T) {
 	provider := &mockStateProvider{stateToReturn: stateEvent.State{
-		NATStatus: stateEvent.NATStatus{
+		NATStatus: contract.NATStatusDTO{
 			Status: "something",
 			Error:  "maybe",
 		},

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -33,34 +33,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// swagger:model ServiceListDTO
-type serviceList []serviceInfo
-
-// swagger:model ServiceInfoDTO
-type serviceInfo struct {
-	// example: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
-	ID string `json:"id"`
-
-	// provider identity
-	// example: 0x0000000000000000000000000000000000000002
-	ProviderID string `json:"provider_id"`
-
-	// service type. Possible values are "openvpn", "wireguard" and "noop"
-	// example: openvpn
-	Type string `json:"type"`
-
-	// options with which service was started. Every service has a unique list of allowed options.
-	// example: {"port": 1123, "protocol": "udp"}
-	Options interface{} `json:"options"`
-
-	// example: Running
-	Status string `json:"status"`
-
-	Proposal contract.ProposalDTO `json:"proposal"`
-
-	AccessPolicies *[]market.AccessPolicy `json:"access_policies,omitempty"`
-}
-
 // ServiceEndpoint struct represents management of service resource and it's sub-resources
 type ServiceEndpoint struct {
 	serviceManager ServiceManager
@@ -83,7 +55,7 @@ func NewServiceEndpoint(serviceManager ServiceManager, optionsParser map[string]
 }
 
 // ServiceList provides a list of running services on the node.
-// swagger:operation GET /services Service serviceList
+// swagger:operation GET /services Service ListServicesResponse
 // ---
 // summary: List of services
 // description: ServiceList provides a list of running services on the node.
@@ -91,7 +63,7 @@ func NewServiceEndpoint(serviceManager ServiceManager, optionsParser map[string]
 //   200:
 //     description: List of running services
 //     schema:
-//       "$ref": "#/definitions/ServiceListDTO"
+//       "$ref": "#/definitions/ListServicesResponse"
 func (se *ServiceEndpoint) ServiceList(resp http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	instances := se.serviceManager.List()
 
@@ -315,9 +287,9 @@ func (se *ServiceEndpoint) toServiceOptions(serviceType string, value *json.RawM
 	return options
 }
 
-func toServiceInfoResponse(id service.ID, instance *service.Instance) serviceInfo {
+func toServiceInfoResponse(id service.ID, instance *service.Instance) contract.ServiceInfoDTO {
 	proposal := instance.Proposal()
-	return serviceInfo{
+	return contract.ServiceInfoDTO{
 		ID:         string(id),
 		ProviderID: proposal.ProviderID,
 		Type:       proposal.ServiceType,
@@ -327,8 +299,8 @@ func toServiceInfoResponse(id service.ID, instance *service.Instance) serviceInf
 	}
 }
 
-func toServiceListResponse(instances map[service.ID]*service.Instance) serviceList {
-	res := make([]serviceInfo, 0)
+func toServiceListResponse(instances map[service.ID]*service.Instance) contract.ListServicesResponse {
+	res := make([]contract.ServiceInfoDTO, 0)
 	for id, instance := range instances {
 		res = append(res, toServiceInfoResponse(id, instance))
 	}

--- a/tequilapi/endpoints/service_sessions.go
+++ b/tequilapi/endpoints/service_sessions.go
@@ -23,14 +23,9 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
 )
-
-// serviceSessionsList defines session list representable as json
-// swagger:model ServiceSessionListDTO
-type serviceSessionsList struct {
-	Sessions []stateEvent.ServiceSession `json:"sessions"`
-}
 
 type stateStorage interface {
 	GetState() stateEvent.State
@@ -55,13 +50,13 @@ func NewServiceSessionsEndpoint(stateStorage stateStorage) *serviceSessionsEndpo
 //   200:
 //     description: List of sessions
 //     schema:
-//       "$ref": "#/definitions/ServiceSessionListDTO"
+//       "$ref": "#/definitions/ListServiceSessionsResponse"
 func (endpoint *serviceSessionsEndpoint) List(resp http.ResponseWriter, request *http.Request, params httprouter.Params) {
 	sessions := endpoint.stateStorage.GetState().Sessions
 
 	sort.Slice(sessions, func(i, j int) bool { return sessions[i].CreatedAt.Before(sessions[j].CreatedAt) })
 
-	sessionsSerializable := serviceSessionsList{
+	sessionsSerializable := contract.ListServiceSessionsResponse{
 		Sessions: sessions,
 	}
 	utils.WriteAsJSON(sessionsSerializable, resp)

--- a/tequilapi/endpoints/service_sessions_test.go
+++ b/tequilapi/endpoints/service_sessions_test.go
@@ -25,11 +25,12 @@ import (
 	"time"
 
 	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	serviceSessionMock = stateEvent.ServiceSession{
+	serviceSessionMock = contract.ServiceSessionDTO{
 		ID:         "session1",
 		ConsumerID: "consumer1",
 		CreatedAt:  time.Now(),
@@ -44,7 +45,7 @@ func Test_ServiceSessionsEndpoint_List(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	anotherSession := stateEvent.ServiceSession{
+	anotherSession := contract.ServiceSessionDTO{
 		ID:         "session2",
 		ConsumerID: "consumer1",
 		CreatedAt:  time.Now(),
@@ -52,7 +53,7 @@ func Test_ServiceSessionsEndpoint_List(t *testing.T) {
 
 	ssm := &stateProviderMock{
 		stateToReturn: stateEvent.State{
-			Sessions: []stateEvent.ServiceSession{
+			Sessions: []contract.ServiceSessionDTO{
 				serviceSessionMock,
 				anotherSession,
 			},
@@ -63,7 +64,7 @@ func Test_ServiceSessionsEndpoint_List(t *testing.T) {
 	handlerFunc := NewServiceSessionsEndpoint(ssm).List
 	handlerFunc(resp, req, nil)
 
-	parsedResponse := &serviceSessionsList{}
+	parsedResponse := &contract.ListServiceSessionsResponse{}
 	err = json.Unmarshal(resp.Body.Bytes(), parsedResponse)
 	assert.Nil(t, err)
 	assert.Equal(t, serviceSessionMock.ConsumerID, parsedResponse.Sessions[0].ConsumerID)

--- a/tequilapi/endpoints/service_test.go
+++ b/tequilapi/endpoints/service_test.go
@@ -165,7 +165,8 @@ func Test_AddRoutesForServiceAddsRoutes(t *testing.T) {
 							"per_bytes":7669584
 						}
 					}
-				}
+				},
+				"connection_statistics": {"attempted":0, "successful":0}
 			}]`,
 		},
 		{
@@ -197,7 +198,8 @@ func Test_AddRoutesForServiceAddsRoutes(t *testing.T) {
 							"per_bytes":7669584
 						}
 					}
-				}
+				},
+				"connection_statistics": {"attempted":0, "successful":0}
 			}`,
 		},
 		{
@@ -229,7 +231,8 @@ func Test_AddRoutesForServiceAddsRoutes(t *testing.T) {
 							"per_bytes":7669584
 						}
 					}
-				}
+				},
+				"connection_statistics": {"attempted":0, "successful":0}
 			}`,
 		},
 		{
@@ -417,7 +420,8 @@ func Test_ServiceGetReturnsServiceInfo(t *testing.T) {
 						"per_bytes":7669584
 					}
 				}
-			}
+			},
+			"connection_statistics": {"attempted":0, "successful":0}
 		}`,
 		resp.Body.String(),
 	)
@@ -524,7 +528,8 @@ func Test_ServiceStart_WithAccessPolicy(t *testing.T) {
 						"source": "https://some.domain/api/v1/lists/12312312332132"
 					}
 				]
-			}
+			},
+			"connection_statistics": {"attempted":0, "successful":0}
 		}`,
 		resp.Body.String(),
 	)

--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -205,7 +205,7 @@ func (h *Handler) ConsumeNodeEvent(e nodeEvent.Payload) {
 }
 
 type stateRes struct {
-	NATStatus  stateEvent.NATStatus         `json:"nat_status"`
+	NATStatus  contract.NATStatusDTO        `json:"nat_status"`
 	Services   []contract.ServiceInfoDTO    `json:"service_info"`
 	Sessions   []contract.ServiceSessionDTO `json:"sessions"`
 	Consumer   consumerStateRes             `json:"consumer"`

--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -205,11 +205,11 @@ func (h *Handler) ConsumeNodeEvent(e nodeEvent.Payload) {
 }
 
 type stateRes struct {
-	NATStatus  stateEvent.NATStatus        `json:"nat_status"`
-	Services   []stateEvent.ServiceInfo    `json:"service_info"`
-	Sessions   []stateEvent.ServiceSession `json:"sessions"`
-	Consumer   consumerStateRes            `json:"consumer"`
-	Identities []contract.IdentityDTO      `json:"identities"`
+	NATStatus  stateEvent.NATStatus         `json:"nat_status"`
+	Services   []stateEvent.ServiceInfo     `json:"service_info"`
+	Sessions   []contract.ServiceSessionDTO `json:"sessions"`
+	Consumer   consumerStateRes             `json:"consumer"`
+	Identities []contract.IdentityDTO       `json:"identities"`
 }
 
 type consumerStateRes struct {

--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -206,7 +206,7 @@ func (h *Handler) ConsumeNodeEvent(e nodeEvent.Payload) {
 
 type stateRes struct {
 	NATStatus  stateEvent.NATStatus         `json:"nat_status"`
-	Services   []stateEvent.ServiceInfo     `json:"service_info"`
+	Services   []contract.ServiceInfoDTO    `json:"service_info"`
 	Sessions   []contract.ServiceSessionDTO `json:"sessions"`
 	Consumer   consumerStateRes             `json:"consumer"`
 	Identities []contract.IdentityDTO       `json:"identities"`

--- a/tequilapi/endpoints/sse_handler_test.go
+++ b/tequilapi/endpoints/sse_handler_test.go
@@ -33,6 +33,7 @@ import (
 	nodeEvent "github.com/mysteriumnetwork/node/core/node/event"
 	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
 	"github.com/mysteriumnetwork/node/identity/registry"
+	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -148,7 +149,7 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
 	assert.JSONEq(t, expectJSON, msgJSON)
 
 	changedState := msp.GetState()
-	changedState.NATStatus = stateEvent.NATStatus{
+	changedState.NATStatus = contract.NATStatusDTO{
 		Status: "mass panic",
 		Error:  "cookie prices rise drastically",
 	}


### PR DESCRIPTION
Updates: #2374

Merged all leftover DTOs for Tequilapi server & client. Lets create new ones in `tequilapi/contract` from now on.

Intentionally left transactor DTOs untouched in `tequilapi/client/dto.go` as per big refactoring there (@vkuznecovas, @soffokl)