### PR TITLE
Do not publish session trace for failed stages

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -104,8 +104,8 @@ func (t *Tracer) Finish(eventPublisher eventbus.Publisher, id string) string {
 
 	var strs []string
 	for _, s := range stages {
-		t.publishStageEvent(eventPublisher, id, *s)
 		if s.end.After(time.Time{}) {
+			t.publishStageEvent(eventPublisher, id, *s)
 			strs = append(strs, fmt.Sprintf("%q took %s", s.key, s.end.Sub(s.start).String()))
 		} else {
 			strs = append(strs, fmt.Sprintf("%q did not start", s.key))


### PR DESCRIPTION
It fixes sending events with invalid timing. 
![image](https://user-images.githubusercontent.com/8612618/86311270-cefffb00-bc41-11ea-9629-b2e5b8e807df.png)
