### PR TITLE
Fix panic in set beneficiary CLI command

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -254,20 +254,17 @@ func (c *cliApp) settle(args []string) {
 }
 
 func (c *cliApp) setBeneficiary(actionArgs []string) {
-	const usageSetBeneficiary = "beneficiary <identity> [new beneficiary]"
+	const usageSetBeneficiary = "beneficiary <identity> <new beneficiary>"
 
-	if len(actionArgs) < 1 || len(actionArgs) > 3 {
+	if len(actionArgs) < 2 || len(actionArgs) > 3 {
 		info("Usage: " + usageSetBeneficiary)
 		return
 	}
 
-	var address = actionArgs[0]
-	var beneficiary string
-	if len(actionArgs) >= 1 {
-		beneficiary = actionArgs[1]
-	}
-
+	address := actionArgs[0]
+	beneficiary := actionArgs[1]
 	accountantID := config.GetString(config.FlagAccountantID)
+
 	err := c.tequilapi.SettleWithBeneficiary(address, beneficiary, accountantID)
 	if err != nil {
 		warn(errors.Wrap(err, "could not set beneficiary"))


### PR DESCRIPTION
```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/mysteriumnetwork/node/cmd/commands/cli.(*cliApp).setBeneficiary(0xc000641220, 0xc00020c790, 0x1, 0x1)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/cmd/commands/cli/command_identities.go:267 +0x521
github.com/mysteriumnetwork/node/cmd/commands/cli.(*cliApp).identities(0xc000641220, 0xc00067f40b, 0x36)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/cmd/commands/cli/command_identities.go:66 +0x4d2
github.com/mysteriumnetwork/node/cmd/commands/cli.(*cliApp).handleActions(0xc000641220, 0xc00067f400, 0x41)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/cmd/commands/cli/command.go:191 +0x611
github.com/mysteriumnetwork/node/cmd/commands/cli.(*cliApp).Run(0xc000641220, 0x56a07a0, 0xc00007a000, 0xc0009113e0, 0x1c)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/cmd/commands/cli/command.go:140 +0x3a0
github.com/mysteriumnetwork/node/cmd/commands/cli.NewCommand.func1(0xc000209f00, 0x0, 0x0)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/cmd/commands/cli/command.go:72 +0x1ce
github.com/urfave/cli/v2.(*Command).Run(0xc000035b00, 0xc000209e40, 0x0, 0x0)
	/Users/soffokl/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/command.go:161 +0x4e0
github.com/urfave/cli/v2.(*App).RunContext(0xc00017c480, 0x56982e0, 0xc00003c090, 0xc000032090, 0x9, 0x9, 0x0, 0x0)
	/Users/soffokl/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:302 +0x814
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/soffokl/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:211
main.main()
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/cmd/mysterium_node/mysterium_node.go:56 +0x87
```