### PR TITLE
Revert "Start only user enabled services"

### DIFF
--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -106,9 +106,10 @@ type serviceCommand struct {
 
 // Run runs a command
 func (sc *serviceCommand) Run(ctx *cli.Context) (err error) {
+	arg := ctx.Args().Get(0)
 	serviceTypes := services.Types()
-	if ctx.NArg() > 0 {
-		serviceTypes = strings.Split(ctx.Args().Get(0), ",")
+	if arg != "" {
+		serviceTypes = strings.Split(arg, ",")
 	}
 
 	providerID := sc.unlockIdentity(

--- a/services/options_type.go
+++ b/services/options_type.go
@@ -20,7 +20,6 @@ package services
 import (
 	"encoding/json"
 
-	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/services/noop"
 	"github.com/mysteriumnetwork/node/services/openvpn"
@@ -44,19 +43,7 @@ type ServiceOptionsParser func(*json.RawMessage) (service.Options, error)
 
 // Types returns all possible service types.
 func Types() []string {
-	userConfig := config.Current.GetUserConfig()
-
-	var enabledServices []string
-	if _, enabled := userConfig[openvpn.ServiceType]; enabled {
-		enabledServices = append(enabledServices, openvpn.ServiceType)
-	}
-	if _, enabled := userConfig[wireguard.ServiceType]; enabled {
-		enabledServices = append(enabledServices, wireguard.ServiceType)
-	}
-	if _, enabled := userConfig[noop.ServiceType]; enabled {
-		enabledServices = append(enabledServices, noop.ServiceType)
-	}
-	return enabledServices
+	return []string{openvpn.ServiceType, wireguard.ServiceType, noop.ServiceType}
 }
 
 // TypeConfiguredOptions returns specific service options.


### PR DESCRIPTION
Reverts mysteriumnetwork/node#2424

Agreed with @Waldz that we need look for a more fluent migration process towards node onboarding. 
Since current change would effectively disable all services in a network, just reverting it.

Point of having configurable services was that service for a new node provider should not start until provider agrees with ToS. Still, we have a lot of old providers and we need to migrate them. My suggestion is to send email / mmn notifications to node runners requesting existing nodes to agree with updated ToS and set node password at least. Only then, after 2 weeks or so, check how many nodes still did not agree with updated ToS and only then decide whether  we should disable node services. 
