### PR TITLE
Revert "Create mysterium node config before starting service"

### DIFF
--- a/bin/package/installation/post-install.sh
+++ b/bin/package/installation/post-install.sh
@@ -69,31 +69,6 @@ printf "Creating directories...\n" \
 printf "Setting required capabilities...\n" \
     && setcap cap_net_admin+ep /usr/bin/myst
 
-ensure_paths
-
-# Add defaults file, if it doesn't exist
-if [[ ! -f $DAEMON_DEFAULT ]]; then
-    cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
-else
-    # TODO remove these hacks when all nodes updates
-    sed -i -e 's/SERVICE_OPTS="openvpn"/SERVICE_OPTS="openvpn,wireguard"/g' /etc/default/mysterium-node
-    sed -i -e 's/--tequilapi.address=0.0.0.0/--tequilapi.address=127.0.0.1/g' /etc/default/mysterium-node
-    # Append script-dir for existing installations only if missing
-    sed -i -e '/^\(SCRIPT_DIR=\).*/{s//\1\"--script-dir=\/etc\/mysterium-node\"/;:a;n;ba;q}' \
-           -e '$aSCRIPT_DIR="--script-dir=/etc/mysterium-node"' /etc/default/mysterium-node
-fi
-
-# TODO: remove me when all nodes updates
-printf "Ensuring that sudoers config is consistent...\n" \
-    && sed -i -e 's| /sbin/iptables/| /usr/sbin/iptables|g' /etc/sudoers.d/mysterium-node
-
-# Cleanup old log files (before log file rolling has been fixed)
-printf "Cleaning legacy log files...\n" \
-    && rm -rf /var/lib/mysterium-node/.mysterium.log*
-
-printf "\nInstallation successfully finished.\n" \
-    && printf "Usage: service mysterium-node restart\n"
-
 # Remove legacy symlink, if it exists
 if [[ -L $OS_DIR_INITD/mysterium-node ]]; then
     rm -f $OS_DIR_INITD/mysterium-node
@@ -128,3 +103,28 @@ elif [[ -f /etc/os-release ]]; then
     	install_chkconfig
     fi
 fi
+
+ensure_paths
+
+# Add defaults file, if it doesn't exist
+if [[ ! -f $DAEMON_DEFAULT ]]; then
+    cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
+else
+    # TODO remove these hacks when all nodes updates
+    sed -i -e 's/SERVICE_OPTS="openvpn"/SERVICE_OPTS="openvpn,wireguard"/g' /etc/default/mysterium-node
+    sed -i -e 's/--tequilapi.address=0.0.0.0/--tequilapi.address=127.0.0.1/g' /etc/default/mysterium-node
+    # Append script-dir for existing installations only if missing
+    sed -i -e '/^\(SCRIPT_DIR=\).*/{s//\1\"--script-dir=\/etc\/mysterium-node\"/;:a;n;ba;q}' \
+           -e '$aSCRIPT_DIR="--script-dir=/etc/mysterium-node"' /etc/default/mysterium-node
+fi
+
+# TODO: remove me when all nodes updates
+printf "Ensuring that sudoers config is consistent...\n" \
+    && sed -i -e 's| /sbin/iptables/| /usr/sbin/iptables|g' /etc/sudoers.d/mysterium-node
+
+# Cleanup old log files (before log file rolling has been fixed)
+printf "Cleaning legacy log files...\n" \
+    && rm -rf /var/lib/mysterium-node/.mysterium.log*
+
+printf "\nInstallation successfully finished.\n" \
+    && printf "Usage: service mysterium-node restart\n"

--- a/debian/postinst
+++ b/debian/postinst
@@ -69,31 +69,6 @@ printf "Creating directories...\n" \
 printf "Setting required capabilities...\n" \
     && setcap cap_net_admin+ep /usr/bin/myst
 
-ensure_paths
-
-# Add defaults file, if it doesn't exist
-if [[ ! -f $DAEMON_DEFAULT ]]; then
-    cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
-else
-    # TODO remove these hacks when all nodes updates
-    sed -i -e 's/SERVICE_OPTS="openvpn"/SERVICE_OPTS="openvpn,wireguard"/g' /etc/default/mysterium-node
-    sed -i -e 's/--tequilapi.address=0.0.0.0/--tequilapi.address=127.0.0.1/g' /etc/default/mysterium-node
-    # Append script-dir for existing installations only if missing
-    sed -i -e '/^\(SCRIPT_DIR=\).*/{s//\1\"--script-dir=\/etc\/mysterium-node\"/;:a;n;ba;q}' \
-           -e '$aSCRIPT_DIR="--script-dir=/etc/mysterium-node"' /etc/default/mysterium-node
-fi
-
-# TODO: remove me when all nodes updates
-printf "Ensuring that sudoers config is consistent...\n" \
-    && sed -i -e 's| /sbin/iptables/| /usr/sbin/iptables|g' /etc/sudoers.d/mysterium-node
-
-# Cleanup old log files (before log file rolling has been fixed)
-printf "Cleaning legacy log files...\n" \
-    && rm -rf /var/lib/mysterium-node/.mysterium.log*
-
-printf "\nInstallation successfully finished.\n" \
-    && printf "Usage: service mysterium-node restart\n"
-
 # Remove legacy symlink, if it exists
 if [[ -L $OS_DIR_INITD/mysterium-node ]]; then
     rm -f $OS_DIR_INITD/mysterium-node
@@ -128,5 +103,30 @@ elif [[ -f /etc/os-release ]]; then
     	install_chkconfig
     fi
 fi
+
+ensure_paths
+
+# Add defaults file, if it doesn't exist
+if [[ ! -f $DAEMON_DEFAULT ]]; then
+    cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
+else
+    # TODO remove these hacks when all nodes updates
+    sed -i -e 's/SERVICE_OPTS="openvpn"/SERVICE_OPTS="openvpn,wireguard"/g' /etc/default/mysterium-node
+    sed -i -e 's/--tequilapi.address=0.0.0.0/--tequilapi.address=127.0.0.1/g' /etc/default/mysterium-node
+    # Append script-dir for existing installations only if missing
+    sed -i -e '/^\(SCRIPT_DIR=\).*/{s//\1\"--script-dir=\/etc\/mysterium-node\"/;:a;n;ba;q}' \
+           -e '$aSCRIPT_DIR="--script-dir=/etc/mysterium-node"' /etc/default/mysterium-node
+fi
+
+# TODO: remove me when all nodes updates
+printf "Ensuring that sudoers config is consistent...\n" \
+    && sed -i -e 's| /sbin/iptables/| /usr/sbin/iptables|g' /etc/sudoers.d/mysterium-node
+
+# Cleanup old log files (before log file rolling has been fixed)
+printf "Cleaning legacy log files...\n" \
+    && rm -rf /var/lib/mysterium-node/.mysterium.log*
+
+printf "\nInstallation successfully finished.\n" \
+    && printf "Usage: service mysterium-node restart\n"
 
 #DEBHELPER#


### PR DESCRIPTION
Reverts mysteriumnetwork/node#2437

I suspect this one broke our RPI packaging. Do not have a way to test this job since it does work only on releases. Need to make test release.
