### PR TITLE
Ignore systemd error on rpi build

### DIFF
--- a/bin/package/installation/post-install.sh
+++ b/bin/package/installation/post-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -v
 
 . /usr/share/debconf/confmodule
 
@@ -104,7 +104,7 @@ if [[ -f /etc/redhat-release ]]; then
     # RHEL-variant logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-    	install_systemd
+    	install_systemd || echo "got an error, ignoring - probably systemd-spawn issue"
     else
 	    # Assuming sysv
 	    install_initd
@@ -114,7 +114,7 @@ elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-    	install_systemd
+    	install_systemd || echo "got an error, ignoring - probably systemd-spawn issue"
     else
 	    # Assuming sysv
     	install_initd

--- a/bin/package/raspberry/files/1-setup-node.sh
+++ b/bin/package/raspberry/files/1-setup-node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ev
+#!/bin/bash -v
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 export DEBIAN_FRONTEND="noninteractive"

--- a/ci/packages/raspberry.go
+++ b/ci/packages/raspberry.go
@@ -18,6 +18,7 @@
 package packages
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -169,7 +170,7 @@ func fetchRaspbianImage() (filename string, err error) {
 		return strings.Contains(aws.StringValue(object.Key), "-raspbian-buster-lite")
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to fetch raspbian image: %w", err)
 	}
 
 	localRaspbianZipDir, localRaspbianZipFilename := filepath.Split(localRaspbianZip)

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -v
 
 . /usr/share/debconf/confmodule
 
@@ -104,7 +104,7 @@ if [[ -f /etc/redhat-release ]]; then
     # RHEL-variant logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-    	install_systemd
+    	install_systemd || echo "got an error, ignoring - probably systemd-spawn issue"
     else
 	    # Assuming sysv
 	    install_initd
@@ -114,7 +114,7 @@ elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-    	install_systemd
+    	install_systemd || echo "got an error, ignoring - probably systemd-spawn issue"
     else
 	    # Assuming sysv
     	install_initd


### PR DESCRIPTION
Should fix currently failing CI release.

Systemd actually does not work when running inside systemd-spawn virtual environment. This consistently returns failure on attempt to restart a service producing error: 
```
System has not been booted with systemd as init system (PID 1). Can't operate.
```
 Just ignore it. Not sure if there exists a proper workaround for this, was not able to find one. Actual post install in real env works ok.

