### PR TITLE
Update peer reply address on the fly

### DIFF
--- a/core/ip/cached_resolver_test.go
+++ b/core/ip/cached_resolver_test.go
@@ -34,7 +34,7 @@ func TestCachedResolverCachesPublicIP(t *testing.T) {
 	}{
 		{
 			name:              "Test ip is fetch and cache",
-			cacheDuration:     time.Millisecond,
+			cacheDuration:     50 * time.Millisecond,
 			sleepAfterCall:    time.Microsecond,
 			expectedIP:        "1.1.1.1",
 			expectedIPFetches: 1,

--- a/p2p/channel.go
+++ b/p2p/channel.go
@@ -260,14 +260,12 @@ func (c *channel) remoteReadLoop() {
 			close(c.remoteAlive)
 		})
 
-		// Check if peer port changed.
+		// Check if peer address changed.
 		if addr, ok := addr.(*net.UDPAddr); ok {
-			if addr.IP.Equal(latestPeerAddr.IP) {
-				if addr.Port != latestPeerAddr.Port {
-					log.Debug().Msgf("Peer port changed from %d to %d", latestPeerAddr.Port, addr.Port)
-					c.peer.updateAddr(addr)
-					latestPeerAddr = addr
-				}
+			if !addr.IP.Equal(latestPeerAddr.IP) || addr.Port != latestPeerAddr.Port {
+				log.Debug().Msgf("Peer address changed from %v to %v", latestPeerAddr, addr)
+				c.peer.updateAddr(addr)
+				latestPeerAddr = addr
 			}
 		}
 


### PR DESCRIPTION
This solves issues when both consumer and provider are on the same ISP network (such as TELE2) which uses infrastructure NAT and routes packets inside ISP network using internal IP addressing. Our IP reference using ipify shows wrong peer IP.

UPDATE: Issue is solved only when upnp or direct public IP is used. For nat-hole-punching case this cannot be used, since in majority of cases receiving ping from unknown IP is considered a DDOS and is blocked on NAT router.  I see no point in covering  very narrow case when such DDOS does not happen. 