### PR TITLE
Add systemd service restart 5s delay

### DIFF
--- a/bin/package/installation/systemd.service
+++ b/bin/package/installation/systemd.service
@@ -20,6 +20,7 @@ KillMode=process
 TimeoutStopSec=10
 SendSIGKILL=yes
 Restart=on-failure
+RestartSec=5
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]


### PR DESCRIPTION
The default systemd service restart delay is 100ms and it allows only 5 attempts to start service, which is less than 1 second in total.
If the system still didn't finish initialization in 1-second service marked as broken and can be started only manually.
This change gives a node service a chance to restart correctly in a longer period of time.

Closes https://github.com/mysteriumnetwork/node/issues/2397