### PR TITLE
Register handlers before working with channel

### DIFF
--- a/p2p/channel.go
+++ b/p2p/channel.go
@@ -225,12 +225,14 @@ func newChannel(remoteConn *net.UDPConn, privateKey PrivateKey, peerPubKey Publi
 		remoteAlive:      make(chan struct{}, 1),
 	}
 
+	return &c, nil
+}
+
+func (c *channel) launchReadSendLoops() {
 	go c.remoteReadLoop()
 	go c.remoteSendLoop()
 	go c.localReadLoop()
 	go c.localSendLoop()
-
-	return &c, nil
 }
 
 // remoteReadLoop reads from remote conn and writes to local KCP UDP conn.

--- a/p2p/channel_test.go
+++ b/p2p/channel_test.go
@@ -225,6 +225,7 @@ func TestChannel_Send_To_When_Peer_Starts_Later(t *testing.T) {
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		provider, err := reopenChannel(provider.(*channel))
+
 		require.NoError(t, err)
 		provider.Handle("timeout", func(c Context) error {
 			return c.OK()
@@ -281,7 +282,12 @@ func reopenChannel(c *channel) (*channel, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newChannel(punchedConn, c.privateKey, c.peer.publicKey)
+	ch, err := newChannel(punchedConn, c.privateKey, c.peer.publicKey)
+	if err != nil {
+		return nil, err
+	}
+	ch.launchReadSendLoops()
+	return ch, err
 }
 
 func reopenChannelWithNewLocalAddr(c *channel) (*channel, error) {
@@ -289,7 +295,12 @@ func reopenChannelWithNewLocalAddr(c *channel) (*channel, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newChannel(punchedConn, c.privateKey, c.peer.publicKey)
+	ch, err := newChannel(punchedConn, c.privateKey, c.peer.publicKey)
+	if err != nil {
+		return nil, err
+	}
+	ch.launchReadSendLoops()
+	return ch, err
 }
 
 func createTestChannels() (Channel, Channel, error) {
@@ -323,11 +334,13 @@ func createTestChannels() (Channel, Channel, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	provider.launchReadSendLoops()
 
 	consumer, err := newChannel(consumerConn, consumerPrivateKey, providerPublicKey)
 	if err != nil {
 		return nil, nil, err
 	}
+	consumer.launchReadSendLoops()
 
 	return provider, consumer, nil
 }

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -128,6 +128,8 @@ func (m *dialer) Dial(ctx context.Context, consumerID, providerID identity.Ident
 		return nil, fmt.Errorf("could not create p2p channel: %w", err)
 	}
 	channel.setServiceConn(conn2)
+	channel.launchReadSendLoops()
+
 	return channel, nil
 }
 

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -174,10 +174,13 @@ func (m *listener) Listen(providerID identity.Identity, serviceType string, chan
 			log.Err(err).Msg("Could not create channel")
 			return
 		}
+
 		channel.setServiceConn(conn2)
 		channel.setUpnpPortsRelease(config.upnpPortsRelease)
 
 		channelHandlers(channel)
+
+		channel.launchReadSendLoops()
 
 		// Send handlers ready to consumer.
 		if err := m.providerChannelHandlersReady(providerID, serviceType); err != nil {


### PR DESCRIPTION
This PR separates channel creation from actual its usage. This should fix race conditions when "p2p peer handler not found" error was being generated in some edge cases, when RPI providers gets super slow in registering channel handlers, but already processes incoming session creation requests.


