### PR TITLE
Provider stores failed connects to session history

### DIFF
--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -19,7 +19,6 @@ package service
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/mysteriumnetwork/node/core/policy"
@@ -144,13 +143,9 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 		instance.addP2PChannel(ch)
 		mng := manager.sessionManager(proposal, string(id), ch)
 		subscribeSessionCreate(mng, ch, service, manager.eventPublisher, proposal, policyRules)
-		subscribeSessionStatus(mng, ch, manager.statusStorage)
+		subscribeSessionStatus(ch, manager.statusStorage)
 		subscribeSessionAcknowledge(mng, ch)
-		subscribeSessionDestroy(mng, ch, func() {
-			// Give some time for channel to finish sending last message.
-			time.Sleep(10 * time.Second)
-			instance.closeP2PChannel(ch)
-		})
+		subscribeSessionDestroy(mng, ch)
 	}
 	stopP2PListener, err := manager.p2pListener.Listen(providerID, serviceType, channelHandlers)
 	if err != nil {

--- a/core/service/session.go
+++ b/core/service/session.go
@@ -71,5 +71,10 @@ func NewSession() (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Session{ID: session.ID(uid.String())}, nil
+
+	return &Session{
+		ID:        session.ID(uid.String()),
+		CreatedAt: time.Now().UTC(),
+		done:      make(chan struct{}),
+	}, nil
 }

--- a/core/service/session.go
+++ b/core/service/session.go
@@ -39,6 +39,11 @@ type Session struct {
 	done         chan struct{}
 }
 
+// Close ends session.
+func (s *Session) Close() {
+	close(s.done)
+}
+
 // Done returns readonly done channel.
 func (s *Session) Done() <-chan struct{} {
 	return s.done

--- a/core/service/session_manager.go
+++ b/core/service/session_manager.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -156,7 +155,6 @@ type SessionManager struct {
 	natEventGetter       NATEventGetter
 	serviceId            string
 	publisher            publisher
-	creationLock         sync.Mutex
 	channel              p2p.Channel
 	config               Config
 }
@@ -164,9 +162,6 @@ type SessionManager struct {
 // Start starts a session on the provider side for the given consumer.
 // Multiple sessions per peerID is possible in case different services are used
 func (manager *SessionManager) Start(consumerID identity.Identity, accountantID common.Address, proposalID int) (*Session, error) {
-	manager.creationLock.Lock()
-	defer manager.creationLock.Unlock()
-
 	if manager.currentProposal.ID != proposalID {
 		return &Session{}, ErrorInvalidProposal
 	}
@@ -226,8 +221,6 @@ func (manager *SessionManager) Start(consumerID identity.Identity, accountantID 
 
 // Acknowledge marks the session as successfully established as far as the consumer is concerned.
 func (manager *SessionManager) Acknowledge(consumerID identity.Identity, sessionID string) error {
-	manager.creationLock.Lock()
-	defer manager.creationLock.Unlock()
 	session, found := manager.sessionStorage.Find(session.ID(sessionID))
 	if !found {
 		return ErrorSessionNotExists

--- a/core/service/session_manager.go
+++ b/core/service/session_manager.go
@@ -187,12 +187,13 @@ func (manager *SessionManager) Start(consumerID identity.Identity, accountantID 
 	log.Info().Msg("Using new payments")
 	engine, err := manager.paymentEngineFactory(identity.FromAddress(manager.currentProposal.ProviderID), consumerID, accountantID, string(session.ID))
 	if err != nil {
+		session.Close()
 		return session, err
 	}
 
 	// stop the balance tracker once the session is finished
 	go func() {
-		<-session.done
+		<-session.Done()
 		engine.Stop()
 	}()
 
@@ -200,13 +201,13 @@ func (manager *SessionManager) Start(consumerID identity.Identity, accountantID 
 		err := engine.Start()
 		if err != nil {
 			log.Error().Err(err).Msg("Payment engine error")
-			manager.destroySession(*session)
+			session.Close()
 		}
 	}()
 
 	log.Info().Msg("Waiting for a first invoice to be paid")
 	if err := engine.WaitFirstInvoice(30 * time.Second); err != nil {
-		manager.destroySession(*session)
+		session.Close()
 		return session, fmt.Errorf("first invoice was not paid: %w", err)
 	}
 
@@ -221,17 +222,14 @@ func (manager *SessionManager) Acknowledge(consumerID identity.Identity, session
 	manager.creationLock.Lock()
 	defer manager.creationLock.Unlock()
 	session, found := manager.sessionStorage.Find(session.ID(sessionID))
-
 	if !found {
 		return ErrorSessionNotExists
 	}
-
 	if session.ConsumerID != consumerID {
 		return ErrorWrongSessionOwner
 	}
 
 	manager.publisher.Publish(sevent.AppTopicSession, session.toEvent(sevent.AcknowledgedStatus))
-
 	return nil
 }
 
@@ -244,7 +242,7 @@ func (manager *SessionManager) clearStaleSession(consumerID identity.Identity, s
 	})
 	if ok {
 		log.Info().Msgf("Cleaning stale session %s for %s consumer", session.ID, consumerID.Address)
-		go manager.destroySession(session)
+		go session.Close()
 	}
 }
 
@@ -254,31 +252,15 @@ func (manager *SessionManager) Destroy(consumerID identity.Identity, sessionID s
 	if !found {
 		return ErrorSessionNotExists
 	}
-
 	if session.ConsumerID != consumerID {
 		return ErrorWrongSessionOwner
 	}
-	manager.channel.Close()
-	manager.destroySession(session)
 
+	session.Close()
 	return nil
 }
 
-func (manager *SessionManager) destroySession(session Session) {
-	manager.creationLock.Lock()
-	defer manager.creationLock.Unlock()
-
-	manager.sessionStorage.Remove(session.ID)
-
-	close(session.done)
-}
-
 func (manager *SessionManager) keepAliveLoop(sess *Session, channel p2p.Channel) {
-	// TODO: Remove this check once all provider migrates to p2p.
-	if channel == nil {
-		return
-	}
-
 	// Register handler for handling p2p keep alive pings from consumer.
 	channel.Handle(p2p.TopicKeepAlive, func(c p2p.Context) error {
 		var ping pb.P2PKeepAlivePing
@@ -294,7 +276,10 @@ func (manager *SessionManager) keepAliveLoop(sess *Session, channel p2p.Channel)
 	var errCount int
 	for {
 		select {
-		case <-sess.done:
+		case <-sess.Done():
+			// Give some time for channel to finish sending last message.
+			time.Sleep(10 * time.Second)
+			channel.Close()
 			return
 		case <-time.After(manager.config.KeepAlive.SendInterval):
 			if err := manager.sendKeepAlivePing(channel, sess.ID); err != nil {

--- a/core/service/session_manager_test.go
+++ b/core/service/session_manager_test.go
@@ -18,6 +18,8 @@
 package service
 
 import (
+	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/mocks"
 	"github.com/mysteriumnetwork/node/nat/event"
+	"github.com/mysteriumnetwork/node/p2p"
 	"github.com/mysteriumnetwork/node/session"
 	sessionEvent "github.com/mysteriumnetwork/node/session/event"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +68,21 @@ func (m mockBalanceTracker) WaitFirstInvoice(time.Duration) error {
 func mockPaymentEngineFactory(providerID, consumerID identity.Identity, accountant common.Address, sessionID string) (PaymentEngine, error) {
 	return &mockBalanceTracker{}, nil
 }
+
+type mockP2PChannel struct{}
+
+func (m *mockP2PChannel) Send(_ context.Context, _ string, _ *p2p.Message) (*p2p.Message, error) {
+	return nil, nil
+}
+
+func (m *mockP2PChannel) Handle(topic string, handler p2p.HandlerFunc) {
+}
+
+func (m *mockP2PChannel) ServiceConn() *net.UDPConn { return nil }
+
+func (m *mockP2PChannel) Conn() *net.UDPConn { return nil }
+
+func (m *mockP2PChannel) Close() error { return nil }
 
 func TestManager_Start_StoresSession(t *testing.T) {
 	expectedResult := expectedSession
@@ -166,5 +184,5 @@ func TestManager_AcknowledgeSession_PublishesEvent(t *testing.T) {
 }
 
 func newManager(proposal market.ServiceProposal, sessions *SessionPool) *SessionManager {
-	return NewSessionManager(proposal, sessions, mockPaymentEngineFactory, &MockNatEventTracker{}, "test service id", mocks.NewEventBus(), nil, DefaultConfig())
+	return NewSessionManager(proposal, sessions, mockPaymentEngineFactory, &MockNatEventTracker{}, "test service id", mocks.NewEventBus(), &mockP2PChannel{}, DefaultConfig())
 }


### PR DESCRIPTION
Closes: #2488 

This registers unsuccessful session establishments to session history too e.g. then consumer does't 1st invoice.