### PR TITLE
Cleanup provider session events

### DIFF
--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -142,7 +142,7 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 	channelHandlers := func(ch p2p.Channel) {
 		instance.addP2PChannel(ch)
 		mng := manager.sessionManager(proposal, string(id), ch)
-		subscribeSessionCreate(mng, ch, service, manager.eventPublisher, proposal, policyRules)
+		subscribeSessionCreate(mng, ch, service, manager.eventPublisher, policyRules)
 		subscribeSessionStatus(ch, manager.statusStorage)
 		subscribeSessionAcknowledge(mng, ch)
 		subscribeSessionDestroy(mng, ch)

--- a/core/service/servicestate/status.go
+++ b/core/service/servicestate/status.go
@@ -20,9 +20,6 @@ package servicestate
 const (
 	// AppTopicServiceStatus is used in event bus to announce the service status.
 	AppTopicServiceStatus = "Service status"
-
-	// AppTopicServiceSession is used in event bus to announce the service session status.
-	AppTopicServiceSession = "Service session"
 )
 
 // AppEventServiceStatus represents the service event related information


### PR DESCRIPTION
Updates: #2488

Cleanup usage of `connection` DTOs in `service` package. Rather using existing events&DTOs from service session.