### PR TITLE
Remove warning message since we are using a random port

### DIFF
--- a/services/openvpn/service/factory.go
+++ b/services/openvpn/service/factory.go
@@ -57,8 +57,7 @@ func NewManager(nodeOptions node.Options,
 	}
 }
 
-func vpnServerIP(port int, outboundIP, publicIP string, isLocalnet bool) string {
-	//TODO public ip could be overridden by arg nodeOptions if needed
+func vpnServerIP(outboundIP, publicIP string, isLocalnet bool) string {
 	if publicIP == outboundIP {
 		return publicIP
 	}
@@ -72,16 +71,6 @@ Since it's localnet, will use %v for openvpn service`, publicIP,
 		return outboundIP
 	}
 
-	log.Warn().Msgf(
-		`WARNING: It seems that publicly visible ip: [%s] does not match your local machines ip: [%s].
-You should probably need to do port forwarding on your router: %s:%v -> %s:%v.`,
-		publicIP,
-		outboundIP,
-		publicIP,
-		port,
-		outboundIP,
-		port,
-	)
 	return publicIP
 }
 

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -190,7 +190,7 @@ func (m *Manager) ProvideConfig(sessionID string, sessionConfig json.RawMessage,
 		return nil, fmt.Errorf("could not get public IP: %w", err)
 	}
 
-	serverIP := vpnServerIP(m.serviceOptions.Port, m.outboundIP, publicIP, m.nodeOptions.OptionsNetwork.Localnet)
+	serverIP := vpnServerIP(m.outboundIP, publicIP, m.nodeOptions.OptionsNetwork.Localnet)
 	vpnConfig := &openvpn_service.VPNConfig{
 		RemoteIP:        serverIP,
 		RemotePort:      m.vpnServerPort,


### PR DESCRIPTION
There is no point to ask users about manual port forwarding since we are using random ports and NAT hole punching by default.
If the user doing manual port forwarding he is aware of needs to forward it manually.
Closes https://github.com/mysteriumnetwork/node/issues/1673