### PR TITLE
Shorter keepalive interval on provider

### DIFF
--- a/core/service/session_manager.go
+++ b/core/service/session_manager.go
@@ -78,7 +78,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		KeepAlive: KeepAliveConfig{
-			SendInterval:    3 * time.Minute,
+			SendInterval:    14 * time.Second,
 			SendTimeout:     5 * time.Second,
 			MaxSendErrCount: 5,
 		},


### PR DESCRIPTION
3 min interval is way too long. For certain NAT setups to be able to keep datagram tunnel you need to do more frequent requests from behind the NAT device. Make it 14 sec for now by default. 
