### PR TITLE
Reconnect on darwin after sleep

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -71,6 +71,7 @@ import (
 	service_openvpn "github.com/mysteriumnetwork/node/services/openvpn"
 	"github.com/mysteriumnetwork/node/session/connectivity"
 	"github.com/mysteriumnetwork/node/session/pingpong"
+	"github.com/mysteriumnetwork/node/sleep"
 	"github.com/mysteriumnetwork/node/tequilapi"
 	tequilapi_endpoints "github.com/mysteriumnetwork/node/tequilapi/endpoints"
 	"github.com/mysteriumnetwork/node/utils"
@@ -230,6 +231,7 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	} else {
 		di.PortMapper = mapping.NewNoopPortMapper(di.EventBus)
 	}
+
 	di.bootstrapP2P(nodeOptions.P2PPorts)
 	di.SessionConnectivityStatusStorage = connectivity.NewStatusStorage()
 
@@ -526,7 +528,9 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		return err
 	}
 
-	di.Node = NewNode(di.ConnectionManager, tequilapiHTTPServer, di.EventBus, di.NATPinger, di.UIServer)
+	sleepNotifier := sleep.NewNotifier(di.EventBus)
+
+	di.Node = NewNode(di.ConnectionManager, tequilapiHTTPServer, di.EventBus, di.NATPinger, di.UIServer, sleepNotifier)
 	return nil
 }
 

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -35,7 +35,7 @@ type Publisher interface {
 	Publish(topic string, data interface{})
 }
 
-// NATPinger allows to send nat pings as well as stop it
+// SleepNotifier notifies node about pending sleep events
 type SleepNotifier interface {
 	Start()
 	Stop()

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -18,10 +18,11 @@
 package cmd
 
 import (
+	"github.com/rs/zerolog/log"
+
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/node/event"
 	"github.com/mysteriumnetwork/node/tequilapi"
-	"github.com/rs/zerolog/log"
 )
 
 // NATPinger allows to send nat pings as well as stop it
@@ -34,20 +35,21 @@ type Publisher interface {
 	Publish(topic string, data interface{})
 }
 
+// NATPinger allows to send nat pings as well as stop it
+type SleepNotifier interface {
+	Start()
+	Stop()
+}
+
 // NewNode function creates new Mysterium node by given options
-func NewNode(
-	connectionManager connection.Manager,
-	tequilapiServer tequilapi.APIServer,
-	publisher Publisher,
-	natPinger NATPinger,
-	uiServer UIServer,
-) *Node {
+func NewNode(connectionManager connection.Manager, tequilapiServer tequilapi.APIServer, publisher Publisher, natPinger NATPinger, uiServer UIServer, notifier SleepNotifier) *Node {
 	return &Node{
 		connectionManager: connectionManager,
 		httpAPIServer:     tequilapiServer,
 		publisher:         publisher,
 		natPinger:         natPinger,
 		uiServer:          uiServer,
+		sleepNotifier:     notifier,
 	}
 }
 
@@ -58,10 +60,12 @@ type Node struct {
 	publisher         Publisher
 	natPinger         NATPinger
 	uiServer          UIServer
+	sleepNotifier     SleepNotifier
 }
 
 // Start starts Mysterium node (Tequilapi service, fetches location)
 func (node *Node) Start() error {
+	go node.sleepNotifier.Start()
 	node.httpAPIServer.StartServing()
 
 	go func() {
@@ -104,6 +108,9 @@ func (node *Node) Kill() error {
 
 	node.natPinger.Stop()
 	log.Info().Msg("NAT pinger stopped")
+
+	node.sleepNotifier.Stop()
+	log.Info().Msg("Sleep notifier stopped")
 
 	return nil
 }

--- a/communication/nats/connection_wrap.go
+++ b/communication/nats/connection_wrap.go
@@ -93,7 +93,7 @@ func (c *ConnectionWrap) connectOptions() nats_lib.Options {
 func (c *ConnectionWrap) Open() (err error) {
 	c.Conn, err = c.connectOptions().Connect()
 	if err != nil {
-		return errors.Wrapf(err, `failed to connect to NATS servers "%v"`, c.servers)
+		return fmt.Errorf("failed to connect to NATS servers %v: %w", c.connectOptions().Servers, err)
 	}
 
 	return nil

--- a/communication/nats/connection_wrap_test.go
+++ b/communication/nats/connection_wrap_test.go
@@ -72,7 +72,7 @@ func TestConnectionWrap_NewConnection(t *testing.T) {
 
 func TestConnectionWrap_Close_AfterFailedOpen(t *testing.T) {
 	connection, _ := newConnection("nats://far-server:1234")
-	assert.EqualError(t, connection.Open(), `failed to connect to NATS servers "[nats://far-server:1234]": nats: no servers available for connection`)
+	assert.Equal(t, "failed to connect to NATS servers [nats://far-server:1234]: nats: no servers available for connection", connection.Open().Error())
 	connection.Close()
 }
 

--- a/core/connection/connect_options.go
+++ b/core/connection/connect_options.go
@@ -20,6 +20,8 @@ package connection
 import (
 	"net"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/session"
@@ -39,8 +41,9 @@ type ConnectOptions struct {
 	ProviderID      identity.Identity
 	Proposal        market.ServiceProposal
 	SessionID       session.ID
-	DNS             DNSOption
+	Params          ConnectParams
 	SessionConfig   []byte
 	ProviderNATConn *net.UDPConn
 	ChannelConn     *net.UDPConn
+	AccountantID    common.Address
 }

--- a/core/connection/interface.go
+++ b/core/connection/interface.go
@@ -41,13 +41,6 @@ type Connection interface {
 // StateChannel is the channel we receive state change events on
 type StateChannel chan State
 
-// PromiseIssuer issues promises from consumer to provider.
-// Consumer signs those promises.
-type PromiseIssuer interface {
-	Start(proposal market.ServiceProposal) error
-	Stop() error
-}
-
 // Manager interface provides methods to manage connection
 type Manager interface {
 	// Connect creates new connection from given consumer to provider, reports error if connection already exists

--- a/core/connection/interface.go
+++ b/core/connection/interface.go
@@ -50,5 +50,5 @@ type Manager interface {
 	// Disconnect closes established connection, reports error if no connection
 	Disconnect() error
 	// CheckChannel checks if current session channel is alive, returns error on failed keep-alive ping
-	CheckChannel() error
+	CheckChannel(context.Context) error
 }

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -27,8 +27,13 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/mysteriumnetwork/node/communication/nats"
 	"github.com/mysteriumnetwork/node/core/ip"
+	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/money"
@@ -36,8 +41,8 @@ import (
 	"github.com/mysteriumnetwork/node/pb"
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/mysteriumnetwork/node/session/connectivity"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
+	"github.com/mysteriumnetwork/node/sleep"
+
 	"google.golang.org/protobuf/proto"
 )
 
@@ -180,6 +185,57 @@ func (tc *testContext) TestWhenManagerMadeConnectionStatusReturnsConnectedStateA
 		},
 		tc.connManager.Status(),
 	)
+}
+
+func (tc *testContext) TestSessionDoesFullReconnectOnWakeupEvent() {
+	tc.connManager.eventBus = eventbus.New()
+
+	err := tc.connManager.Connect(consumerID, accountantID, activeProposal, ConnectParams{})
+	assert.NoError(tc.T(), err)
+	assert.Equal(
+		tc.T(),
+		Status{
+			StartedAt:    tc.mockTime,
+			ConsumerID:   consumerID,
+			AccountantID: accountantID,
+			State:        Connected,
+			SessionID:    establishedSessionID,
+			Proposal:     activeProposal,
+		},
+		tc.connManager.Status(),
+	)
+
+	connecting := State("not defined")
+	connected := State("not defined")
+	tc.connManager.eventBus.SubscribeAsync(AppTopicConnectionState, func(e AppEventConnectionState) {
+		fmt.Println("got state: ", e)
+
+		if e.State == Connecting {
+			fmt.Println("got connecting state")
+			connecting = Connecting
+		}
+		if e.State == Connected {
+			fmt.Println("got connected state")
+			connected = Connected
+		}
+	})
+
+	fmt.Println("sending wakeup event")
+	tc.connManager.eventBus.Publish(sleep.AppTopicSleepNotification, sleep.EventWakeup)
+
+	assert.Eventually(tc.T(), func() bool {
+		if connecting == Connecting {
+			return true
+		}
+		return false
+	}, 200*time.Second, 10*time.Millisecond)
+
+	assert.Eventually(tc.T(), func() bool {
+		if connected == Connected {
+			return true
+		}
+		return false
+	}, 200*time.Second, 10*time.Millisecond)
 }
 
 func (tc *testContext) TestStatusReportsConnectingWhenConnectionIsInProgress() {

--- a/core/connection/stubs_test.go
+++ b/core/connection/stubs_test.go
@@ -19,6 +19,7 @@ package connection
 
 import (
 	"context"
+	"errors"
 	"sync"
 )
 
@@ -32,6 +33,18 @@ type StubPublisherEvent struct {
 type StubPublisher struct {
 	publishHistory []StubPublisherEvent
 	lock           sync.Mutex
+}
+
+func (sp *StubPublisher) Subscribe(topic string, fn interface{}) error {
+	return errors.New("subscribe not implemented")
+}
+
+func (sp *StubPublisher) SubscribeAsync(topic string, fn interface{}) error {
+	return errors.New("subscribe async not implemented")
+}
+
+func (sp *StubPublisher) Unsubscribe(topic string, fn interface{}) error {
+	return errors.New("unsubscribe not implemented")
 }
 
 // NewStubPublisher returns a stub publisher

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -18,6 +18,7 @@
 package mysterium
 
 import (
+	"context"
 	"path/filepath"
 	"time"
 
@@ -390,10 +391,15 @@ func (mb *MobileNode) Reconnect(req *ConnectRequest) *ConnectResponse {
 	if req.ForceReconnect {
 		log.Info().Msg("Forcing immediate reconnect")
 		return reconnect()
-	} else if err := mb.connectionManager.CheckChannel(); err != nil {
-		log.Info().Msg("Forcing reconnect after failed channel")
-		return reconnect()
+	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		if err := mb.connectionManager.CheckChannel(ctx); err != nil {
+			log.Info().Msgf("Forcing reconnect after failed channel: %s", err)
+			return reconnect()
+		}
 	}
+
 	log.Info().Msg("Reconnect is not needed - p2p channel is alive")
 	return &ConnectResponse{}
 }

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -391,13 +391,13 @@ func (mb *MobileNode) Reconnect(req *ConnectRequest) *ConnectResponse {
 	if req.ForceReconnect {
 		log.Info().Msg("Forcing immediate reconnect")
 		return reconnect()
-	} else {
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-		if err := mb.connectionManager.CheckChannel(ctx); err != nil {
-			log.Info().Msgf("Forcing reconnect after failed channel: %s", err)
-			return reconnect()
-		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if err := mb.connectionManager.CheckChannel(ctx); err != nil {
+		log.Info().Msgf("Forcing reconnect after failed channel: %s", err)
+		return reconnect()
 	}
 
 	log.Info().Msg("Reconnect is not needed - p2p channel is alive")

--- a/mobile/mysterium/wireguard_connection_setup_test.go
+++ b/mobile/mysterium/wireguard_connection_setup_test.go
@@ -38,7 +38,7 @@ func TestConnectionStartStop(t *testing.T) {
 	// Start connection.
 	sessionConfig, _ := json.Marshal(newServiceConfig())
 	err := conn.Start(context.Background(), connection.ConnectOptions{
-		DNS:           "1.2.3.4",
+		Params:        connection.ConnectParams{DNS: "1.2.3.4"},
 		SessionConfig: sessionConfig,
 	})
 

--- a/services/openvpn/client_config.go
+++ b/services/openvpn/client_config.go
@@ -91,7 +91,7 @@ func NewClientConfigFromSession(vpnConfig VPNConfig, scriptDir string, runtimeDi
 	}
 
 	clientFileConfig := newClientConfig(runtimeDir, scriptDir)
-	dnsIPs, err := options.DNS.ResolveIPs(vpnConfig.DNSIPs)
+	dnsIPs, err := options.Params.DNS.ResolveIPs(vpnConfig.DNSIPs)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -122,7 +122,7 @@ func (c *Connection) Start(ctx context.Context, options connection.ConnectOption
 		config.Provider.Endpoint.Port = options.ProviderNATConn.RemoteAddr().(*net.UDPAddr).Port
 	}
 
-	dnsIPs, err := options.DNS.ResolveIPs(config.Consumer.DNSIPs)
+	dnsIPs, err := options.Params.DNS.ResolveIPs(config.Consumer.DNSIPs)
 	if err != nil {
 		return errors.Wrap(err, "could not resolve DNS IPs")
 	}

--- a/services/wireguard/connection/connection_test.go
+++ b/services/wireguard/connection/connection_test.go
@@ -38,7 +38,7 @@ func TestConnectionStartStop(t *testing.T) {
 	// Start connection.
 	sessionConfig, _ := json.Marshal(newServiceConfig())
 	err := conn.Start(context.Background(), connection.ConnectOptions{
-		DNS:           "1.2.3.4",
+		Params:        connection.ConnectParams{DNS: "1.2.3.4"},
 		SessionConfig: sessionConfig,
 	})
 

--- a/sleep/darwin.h
+++ b/sleep/darwin.h
@@ -1,0 +1,67 @@
+#include <ctype.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <mach/mach_port.h>
+#include <mach/mach_interface.h>
+#include <mach/mach_init.h>
+
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#include <IOKit/IOMessage.h>
+
+io_connect_t root_port; // a reference to the Root Power Domain IOService
+// notification port allocated by IORegisterForSystemPower
+IONotificationPortRef notifyPortRef;
+// notifier object, used to deregister later
+io_object_t notifierObject;
+// this parameter is passed to the callback
+void *refCon;
+CFRunLoopRef runLoop;
+
+void SleepCallBack(void *refCon, io_service_t service, natural_t messageType, void *messageArgument)
+{
+    switch (messageType)
+    {
+    case kIOMessageSystemWillSleep:
+        NotifySleep();
+        IOAllowPowerChange(root_port, (long)messageArgument);
+        break;
+    case kIOMessageSystemWillPowerOn:
+        NotifyWake();
+        break;
+    case kIOMessageSystemHasPoweredOn:
+        break;
+    default:
+        break;
+    }
+}
+
+void registerNotifications()
+{
+    root_port = IORegisterForSystemPower(refCon, &notifyPortRef, SleepCallBack, &notifierObject);
+    if (root_port == 0)
+    {
+        printf("IORegisterForSystemPower failed\n");
+    }
+
+    CFRunLoopAddSource(CFRunLoopGetCurrent(),
+                       IONotificationPortGetRunLoopSource(notifyPortRef), kCFRunLoopCommonModes);
+
+    runLoop = CFRunLoopGetCurrent();
+    CFRunLoopRun();
+}
+
+void unregisterNotifications()
+{
+    CFRunLoopRemoveSource(runLoop,
+                          IONotificationPortGetRunLoopSource(notifyPortRef),
+                          kCFRunLoopCommonModes);
+
+    IODeregisterForSystemPower(&notifierObject);
+
+    IOServiceClose(root_port);
+
+    IONotificationPortDestroy(notifyPortRef);
+
+    CFRunLoopStop(runLoop);
+}

--- a/sleep/sleep.go
+++ b/sleep/sleep.go
@@ -1,24 +1,46 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package sleep
 
 import "github.com/mysteriumnetwork/node/eventbus"
 
+// Event represents sleep event triggered by underlying OS
 type Event int
 
 const (
 	// AppTopicSleepNotification represents sleep management Event notification
 	AppTopicSleepNotification = "sleep_notification"
 
+	// EventWakeup event sent to node after OS wakes up from sleep
 	EventWakeup Event = iota
+	// EventSleep event sent to node after OS goes to sleep
 	EventSleep
 )
 
 var eventChannel chan Event
 
+// Notifier represents sleep event notifier structure
 type Notifier struct {
 	eventbus eventbus.Publisher
 	stop     chan struct{}
 }
 
+// NewNotifier create sleep events notifier
 func NewNotifier(eventbus eventbus.Publisher) *Notifier {
 	eventChannel = make(chan Event)
 	return &Notifier{

--- a/sleep/sleep.go
+++ b/sleep/sleep.go
@@ -1,0 +1,28 @@
+package sleep
+
+import "github.com/mysteriumnetwork/node/eventbus"
+
+type Event int
+
+const (
+	// AppTopicSleepNotification represents sleep management Event notification
+	AppTopicSleepNotification = "sleep_notification"
+
+	EventWakeup Event = iota
+	EventSleep
+)
+
+var eventChannel chan Event
+
+type Notifier struct {
+	eventbus eventbus.Publisher
+	stop     chan struct{}
+}
+
+func NewNotifier(eventbus eventbus.Publisher) *Notifier {
+	eventChannel = make(chan Event)
+	return &Notifier{
+		eventbus: eventbus,
+		stop:     make(chan struct{}),
+	}
+}

--- a/sleep/sleep_darwin.go
+++ b/sleep/sleep_darwin.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package sleep
 
 // #cgo LDFLAGS: -framework CoreFoundation -framework IOKit

--- a/sleep/sleep_darwin.go
+++ b/sleep/sleep_darwin.go
@@ -1,0 +1,28 @@
+package sleep
+
+// #cgo LDFLAGS: -framework CoreFoundation -framework IOKit
+// void NotifyWake();
+// void NotifySleep();
+// #include "darwin.h"
+import "C"
+import (
+	"github.com/rs/zerolog/log"
+)
+
+func (n Notifier) Start() {
+	log.Debug().Msg("Register for sleep events")
+	go C.registerNotifications()
+	go func() {
+		for {
+			e := <-eventChannel
+			n.eventbus.Publish(AppTopicSleepNotification, e)
+		}
+	}()
+	<-n.stop
+}
+
+func (n Notifier) Stop() {
+	log.Debug().Msg("Unregister sleep events")
+	C.unregisterNotifications()
+	close(n.stop)
+}

--- a/sleep/sleep_export.go
+++ b/sleep/sleep_export.go
@@ -1,12 +1,31 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package sleep
 
 import "C"
 
+//NotifySleep sends EventSleep to event channel
 //export NotifySleep
 func NotifySleep() {
 	eventChannel <- EventSleep
 }
 
+//NotifyWake sends EventWakeup to event channel
 //export NotifyWake
 func NotifyWake() {
 	eventChannel <- EventWakeup

--- a/sleep/sleep_export.go
+++ b/sleep/sleep_export.go
@@ -1,0 +1,13 @@
+package sleep
+
+import "C"
+
+//export NotifySleep
+func NotifySleep() {
+	eventChannel <- EventSleep
+}
+
+//export NotifyWake
+func NotifyWake() {
+	eventChannel <- EventWakeup
+}

--- a/sleep/sleep_noop.go
+++ b/sleep/sleep_noop.go
@@ -1,15 +1,34 @@
 // +build !darwin
 
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package sleep
 
 import (
 	"github.com/rs/zerolog/log"
 )
 
+// Start noop function
 func (n Notifier) Start() {
 	log.Debug().Msg("Register for noop sleep events")
 }
 
+// Stop noop function
 func (n Notifier) Stop() {
 	log.Debug().Msg("Unregister noop sleep events")
 }

--- a/sleep/sleep_noop.go
+++ b/sleep/sleep_noop.go
@@ -3,17 +3,8 @@
 package sleep
 
 import (
-	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/rs/zerolog/log"
 )
-
-type Notifier struct {
-	eventbus eventbus.Publisher
-}
-
-func NewNotifier(eventbus eventbus.Publisher) *Notifier {
-	return &Notifier{eventbus: eventbus}
-}
 
 func (n Notifier) Start() {
 	log.Debug().Msg("Register for noop sleep events")

--- a/sleep/sleep_noop.go
+++ b/sleep/sleep_noop.go
@@ -1,0 +1,24 @@
+// +build !darwin
+
+package sleep
+
+import (
+	"github.com/mysteriumnetwork/node/eventbus"
+	"github.com/rs/zerolog/log"
+)
+
+type Notifier struct {
+	eventbus eventbus.Publisher
+}
+
+func NewNotifier(eventbus eventbus.Publisher) *Notifier {
+	return &Notifier{eventbus: eventbus}
+}
+
+func (n Notifier) Start() {
+	log.Debug().Msg("Register for noop sleep events")
+}
+
+func (n Notifier) Stop() {
+	log.Debug().Msg("Unregister noop sleep events")
+}

--- a/tequilapi/endpoints/connection_test.go
+++ b/tequilapi/endpoints/connection_test.go
@@ -18,6 +18,7 @@
 package endpoints
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -66,7 +67,7 @@ func (cm *mockConnectionManager) Disconnect() error {
 	return cm.onDisconnectReturn
 }
 
-func (cm *mockConnectionManager) CheckChannel() error {
+func (cm *mockConnectionManager) CheckChannel(context.Context) error {
 	return cm.onCheckChannelReturn
 }
 


### PR DESCRIPTION
Partially covers #2447, does reconnect on MacOS after wake-up from sleep. It does full reconnect using connect parameters from last session. Checks whether reconnect is required by checking if p2p channel is alive.
