### PR TITLE
Fix order of provider session events

### DIFF
--- a/core/connection/stubs_test.go
+++ b/core/connection/stubs_test.go
@@ -19,65 +19,8 @@ package connection
 
 import (
 	"context"
-	"errors"
 	"sync"
 )
-
-// StubPublisherEvent represents the event in publishers history
-type StubPublisherEvent struct {
-	calledWithTopic string
-	calledWithData  interface{}
-}
-
-// StubPublisher acts as a publisher
-type StubPublisher struct {
-	publishHistory []StubPublisherEvent
-	lock           sync.Mutex
-}
-
-func (sp *StubPublisher) Subscribe(topic string, fn interface{}) error {
-	return errors.New("subscribe not implemented")
-}
-
-func (sp *StubPublisher) SubscribeAsync(topic string, fn interface{}) error {
-	return errors.New("subscribe async not implemented")
-}
-
-func (sp *StubPublisher) Unsubscribe(topic string, fn interface{}) error {
-	return errors.New("unsubscribe not implemented")
-}
-
-// NewStubPublisher returns a stub publisher
-func NewStubPublisher() *StubPublisher {
-	return &StubPublisher{
-		publishHistory: make([]StubPublisherEvent, 0),
-	}
-}
-
-// Publish adds the given event to the publish history
-func (sp *StubPublisher) Publish(topic string, data interface{}) {
-	sp.lock.Lock()
-	defer sp.lock.Unlock()
-	event := StubPublisherEvent{
-		calledWithTopic: topic,
-		calledWithData:  data,
-	}
-	sp.publishHistory = append(sp.publishHistory, event)
-}
-
-// Clear clears the event history
-func (sp *StubPublisher) Clear() {
-	sp.lock.Lock()
-	defer sp.lock.Unlock()
-	sp.publishHistory = make([]StubPublisherEvent, 0)
-}
-
-// GetEventHistory fetches the event history
-func (sp *StubPublisher) GetEventHistory() []StubPublisherEvent {
-	sp.lock.Lock()
-	defer sp.lock.Unlock()
-	return sp.publishHistory
-}
 
 type fakeState string
 

--- a/core/service/session.go
+++ b/core/service/session.go
@@ -53,7 +53,7 @@ func (s *Session) Done() <-chan struct{} {
 	return s.done
 }
 
-func (s Session) toEvent(status event.Status) event.AppEventSession {
+func (s *Session) toEvent(status event.Status) event.AppEventSession {
 	return event.AppEventSession{
 		Status: status,
 		Service: event.ServiceContext{

--- a/core/service/session_manager_test.go
+++ b/core/service/session_manager_test.go
@@ -188,7 +188,7 @@ func TestManager_AcknowledgeSession_RejectsBadClient(t *testing.T) {
 
 func TestManager_AcknowledgeSession_PublishesEvent(t *testing.T) {
 	sessionStore := NewSessionPool(mocks.NewEventBus())
-	session := Session{ID: "1", ConsumerID: consumerID}
+	session := &Session{ID: "1", ConsumerID: consumerID}
 	sessionStore.Add(session)
 
 	mp := mocks.NewEventBus()

--- a/core/service/session_manager_test.go
+++ b/core/service/session_manager_test.go
@@ -19,6 +19,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"github.com/mysteriumnetwork/node/p2p"
 	"github.com/mysteriumnetwork/node/pb"
 	sessionEvent "github.com/mysteriumnetwork/node/session/event"
+	"github.com/mysteriumnetwork/node/trace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,11 +59,12 @@ var (
 )
 
 type mockBalanceTracker struct {
-	errorToReturn error
+	paymentError      error
+	firstPaymentError error
 }
 
 func (m mockBalanceTracker) Start() error {
-	return m.errorToReturn
+	return m.paymentError
 }
 
 func (m mockBalanceTracker) Stop() {
@@ -69,11 +72,7 @@ func (m mockBalanceTracker) Stop() {
 }
 
 func (m mockBalanceTracker) WaitFirstInvoice(time.Duration) error {
-	return nil
-}
-
-func mockPaymentEngineFactory(providerID, consumerID identity.Identity, accountant common.Address, sessionID string) (PaymentEngine, error) {
-	return &mockBalanceTracker{}, nil
+	return m.firstPaymentError
 }
 
 type mockP2PChannel struct{}
@@ -92,9 +91,9 @@ func (m *mockP2PChannel) Conn() *net.UDPConn { return nil }
 func (m *mockP2PChannel) Close() error { return nil }
 
 func TestManager_Start_StoresSession(t *testing.T) {
-	sessionStore := NewSessionPool(mocks.NewEventBus())
-
-	manager := newManager(currentService, sessionStore)
+	publisher := mocks.NewEventBus()
+	sessionStore := NewSessionPool(publisher)
+	manager := newManager(currentService, sessionStore, publisher, &mockBalanceTracker{})
 
 	_, err := manager.Start(&pb.SessionRequest{
 		Consumer: &pb.ConsumerInfo{
@@ -107,6 +106,89 @@ func TestManager_Start_StoresSession(t *testing.T) {
 
 	session := sessionStore.GetAll()[0]
 	assert.Equal(t, consumerID, session.ConsumerID)
+
+	assert.Eventually(t, func() bool {
+		history := publisher.GetEventHistory()
+		if len(history) != 5 {
+			return false
+		}
+
+		assert.Equal(t, sessionEvent.AppTopicSession, history[0].Topic)
+		startEvent := history[0].Event.(sessionEvent.AppEventSession)
+		assert.Equal(t, sessionEvent.CreatedStatus, startEvent.Status)
+		assert.Equal(t, consumerID, startEvent.Session.ConsumerID)
+		assert.Equal(t, accountantID, startEvent.Session.AccountantID)
+		assert.Equal(t, currentProposal, startEvent.Session.Proposal)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[1].Topic)
+		traceEvent1 := history[1].Event.(trace.Event)
+		assert.Equal(t, "Provider whole session create", traceEvent1.Key)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[2].Topic)
+		traceEvent2 := history[2].Event.(trace.Event)
+		assert.Equal(t, "Provider session start", traceEvent2.Key)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[3].Topic)
+		traceEvent3 := history[3].Event.(trace.Event)
+		assert.Equal(t, "Provider payments", traceEvent3.Key)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[4].Topic)
+		traceEvent4 := history[4].Event.(trace.Event)
+		assert.Equal(t, "Provider config", traceEvent4.Key)
+
+		return true
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestManager_Start_DisconnectsOnPaymentError(t *testing.T) {
+	publisher := mocks.NewEventBus()
+	sessionStore := NewSessionPool(publisher)
+	manager := newManager(currentService, sessionStore, publisher, &mockBalanceTracker{
+		firstPaymentError: errors.New("sorry, your money ended"),
+	})
+
+	_, err := manager.Start(&pb.SessionRequest{
+		Consumer: &pb.ConsumerInfo{
+			Id:           consumerID.Address,
+			AccountantID: accountantID.String(),
+		},
+		ProposalID: int64(currentProposalID),
+	})
+	assert.EqualError(t, err, "first invoice was not paid: sorry, your money ended")
+	assert.Eventually(t, func() bool {
+		history := publisher.GetEventHistory()
+		if len(history) != 5 {
+			return false
+		}
+
+		assert.Equal(t, sessionEvent.AppTopicSession, history[0].Topic)
+		startEvent := history[0].Event.(sessionEvent.AppEventSession)
+		assert.Equal(t, sessionEvent.CreatedStatus, startEvent.Status)
+		assert.Equal(t, consumerID, startEvent.Session.ConsumerID)
+		assert.Equal(t, accountantID, startEvent.Session.AccountantID)
+		assert.Equal(t, currentProposal, startEvent.Session.Proposal)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[1].Topic)
+		traceEvent1 := history[1].Event.(trace.Event)
+		assert.Equal(t, "Provider whole session create", traceEvent1.Key)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[2].Topic)
+		traceEvent2 := history[2].Event.(trace.Event)
+		assert.Equal(t, "Provider session start", traceEvent2.Key)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[3].Topic)
+		traceEvent3 := history[3].Event.(trace.Event)
+		assert.Equal(t, "Provider payments", traceEvent3.Key)
+
+		assert.Equal(t, sessionEvent.AppTopicSession, history[4].Topic)
+		closeEvent := history[4].Event.(sessionEvent.AppEventSession)
+		assert.Equal(t, sessionEvent.RemovedStatus, closeEvent.Status)
+		assert.Equal(t, consumerID, closeEvent.Session.ConsumerID)
+		assert.Equal(t, accountantID, closeEvent.Session.AccountantID)
+		assert.Equal(t, currentProposal, closeEvent.Session.Proposal)
+
+		return true
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestManager_Start_Second_Session_Destroy_Stale_Session(t *testing.T) {
@@ -118,8 +200,9 @@ func TestManager_Start_Second_Session_Destroy_Stale_Session(t *testing.T) {
 		ProposalID: int64(currentProposalID),
 	}
 
-	sessionStore := NewSessionPool(mocks.NewEventBus())
-	manager := newManager(currentService, sessionStore)
+	publisher := mocks.NewEventBus()
+	sessionStore := NewSessionPool(publisher)
+	manager := newManager(currentService, sessionStore, publisher, &mockBalanceTracker{})
 
 	_, err := manager.Start(sessionRequest)
 	assert.NoError(t, err)
@@ -138,9 +221,9 @@ func TestManager_Start_Second_Session_Destroy_Stale_Session(t *testing.T) {
 }
 
 func TestManager_Start_RejectsUnknownProposal(t *testing.T) {
+	publisher := mocks.NewEventBus()
 	sessionStore := NewSessionPool(mocks.NewEventBus())
-
-	manager := newManager(currentService, sessionStore)
+	manager := newManager(currentService, sessionStore, publisher, &mockBalanceTracker{})
 
 	_, err := manager.Start(&pb.SessionRequest{
 		Consumer: &pb.ConsumerInfo{
@@ -149,8 +232,25 @@ func TestManager_Start_RejectsUnknownProposal(t *testing.T) {
 		},
 		ProposalID: int64(69),
 	})
+
 	assert.Exactly(t, err, ErrorInvalidProposal)
 	assert.Len(t, sessionStore.GetAll(), 0)
+	assert.Eventually(t, func() bool {
+		history := publisher.GetEventHistory()
+		if len(history) != 2 {
+			return false
+		}
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[0].Topic)
+		traceEvent1 := history[0].Event.(trace.Event)
+		assert.Equal(t, "Provider whole session create", traceEvent1.Key)
+
+		assert.Equal(t, trace.AppTopicTraceEvent, history[1].Topic)
+		traceEvent2 := history[1].Event.(trace.Event)
+		assert.Equal(t, "Provider session start", traceEvent2.Key)
+
+		return true
+	}, time.Second, 10*time.Millisecond)
 }
 
 type MockNatEventTracker struct {
@@ -161,17 +261,18 @@ func (mnet *MockNatEventTracker) LastEvent() *event.Event {
 }
 
 func TestManager_AcknowledgeSession_RejectsUnknown(t *testing.T) {
-	sessionStore := NewSessionPool(mocks.NewEventBus())
+	publisher := mocks.NewEventBus()
+	sessionStore := NewSessionPool(publisher)
+	manager := newManager(currentService, sessionStore, publisher, &mockBalanceTracker{})
 
-	manager := newManager(currentService, sessionStore)
 	err := manager.Acknowledge(consumerID, "")
 	assert.Exactly(t, err, ErrorSessionNotExists)
 }
 
 func TestManager_AcknowledgeSession_RejectsBadClient(t *testing.T) {
+	publisher := mocks.NewEventBus()
 	sessionStore := NewSessionPool(mocks.NewEventBus())
-
-	manager := newManager(currentService, sessionStore)
+	manager := newManager(currentService, sessionStore, publisher, &mockBalanceTracker{})
 
 	session, err := manager.Start(&pb.SessionRequest{
 		Consumer: &pb.ConsumerInfo{
@@ -187,20 +288,38 @@ func TestManager_AcknowledgeSession_RejectsBadClient(t *testing.T) {
 }
 
 func TestManager_AcknowledgeSession_PublishesEvent(t *testing.T) {
-	sessionStore := NewSessionPool(mocks.NewEventBus())
+	publisher := mocks.NewEventBus()
+
+	sessionStore := NewSessionPool(publisher)
 	session := &Session{ID: "1", ConsumerID: consumerID}
 	sessionStore.Add(session)
 
-	mp := mocks.NewEventBus()
-	manager := newManager(currentService, sessionStore)
-	manager.publisher = mp
+	manager := newManager(currentService, sessionStore, publisher, &mockBalanceTracker{})
 
 	err := manager.Acknowledge(consumerID, string(session.ID))
 	assert.Nil(t, err)
-
-	assert.Eventually(t, lastEventMatches(mp, session.ID, sessionEvent.AcknowledgedStatus), 2*time.Second, 10*time.Millisecond)
+	assert.Eventually(t, func() bool {
+		// Check that state event with StateIPNotChanged status was called.
+		history := publisher.GetEventHistory()
+		for _, v := range history {
+			if v.Topic == sessionEvent.AppTopicSession && v.Event.(sessionEvent.AppEventSession).Status == sessionEvent.AcknowledgedStatus {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
-func newManager(service *Instance, sessions *SessionPool) *SessionManager {
-	return NewSessionManager(service, sessions, mockPaymentEngineFactory, &MockNatEventTracker{}, mocks.NewEventBus(), &mockP2PChannel{}, DefaultConfig())
+func newManager(service *Instance, sessions *SessionPool, publisher publisher, paymentEngine PaymentEngine) *SessionManager {
+	return NewSessionManager(
+		service,
+		sessions,
+		func(_, _ identity.Identity, _ common.Address, _ string) (PaymentEngine, error) {
+			return paymentEngine, nil
+		},
+		&MockNatEventTracker{},
+		publisher,
+		&mockP2PChannel{},
+		DefaultConfig(),
+	)
 }

--- a/core/service/session_pool.go
+++ b/core/service/session_pool.go
@@ -28,7 +28,7 @@ import (
 // NewSessionPool initiates new session storage
 func NewSessionPool(publisher publisher) *SessionPool {
 	sm := &SessionPool{
-		sessions:  make(map[session.ID]Session),
+		sessions:  make(map[session.ID]*Session),
 		lock:      sync.Mutex{},
 		publisher: publisher,
 	}
@@ -37,14 +37,14 @@ func NewSessionPool(publisher publisher) *SessionPool {
 
 // SessionPool maintains all current sessions in memory
 type SessionPool struct {
-	sessions  map[session.ID]Session
+	sessions  map[session.ID]*Session
 	lock      sync.Mutex
 	publisher publisher
 }
 
 // Add puts given session to storage and publishes a creation event.
 // Multiple sessions per peerID is possible in case different services are used
-func (sp *SessionPool) Add(instance Session) {
+func (sp *SessionPool) Add(instance *Session) {
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 
@@ -53,13 +53,13 @@ func (sp *SessionPool) Add(instance Session) {
 }
 
 // GetAll returns all sessions in storage
-func (sp *SessionPool) GetAll() []Session {
+func (sp *SessionPool) GetAll() []*Session {
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 
 	// we're never gonna have more than 100000 sessions ongoing on a single node - performance here should not be an issue.
 	// see Benchmark_Storage_GetAll
-	sessions := make([]Session, len(sp.sessions))
+	sessions := make([]*Session, len(sp.sessions))
 
 	i := 0
 	for _, value := range sp.sessions {
@@ -70,7 +70,7 @@ func (sp *SessionPool) GetAll() []Session {
 }
 
 // Find returns underlying session instance
-func (sp *SessionPool) Find(id session.ID) (Session, bool) {
+func (sp *SessionPool) Find(id session.ID) (*Session, bool) {
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 
@@ -85,7 +85,7 @@ type FindOpts struct {
 }
 
 // FindBy returns a session by find options.
-func (sp *SessionPool) FindBy(opts FindOpts) (Session, bool) {
+func (sp *SessionPool) FindBy(opts FindOpts) (*Session, bool) {
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 
@@ -98,7 +98,7 @@ func (sp *SessionPool) FindBy(opts FindOpts) (Session, bool) {
 		}
 		return session, true
 	}
-	return Session{}, false
+	return nil, false
 }
 
 // Remove removes given session from underlying storage

--- a/services/openvpn/service/auth_handler_test.go
+++ b/services/openvpn/service/auth_handler_test.go
@@ -33,7 +33,7 @@ const (
 
 var (
 	identityExisting = identity.FromAddress("deadbeef")
-	sessionExisting  = service.Session{
+	sessionExisting  = &service.Session{
 		ID:         session.ID(sessionExistingString),
 		ConsumerID: identityExisting,
 	}

--- a/services/openvpn/service/auth_mocks.go
+++ b/services/openvpn/service/auth_mocks.go
@@ -28,14 +28,11 @@ func createAuthHandler(identityToExtract identity.Identity) *authHandler {
 		identityToExtract,
 		nil,
 	}
-	mockSessions := &mockSessions{
-		service.Session{},
-		false,
-	}
+	mockSessions := &mockSessions{}
 	return newAuthHandler(NewClientMap(mockSessions), mockExtractor)
 }
 
-func createAuthHandlerWithSession(identityToExtract identity.Identity, sessionInstance service.Session) *authHandler {
+func createAuthHandlerWithSession(identityToExtract identity.Identity, sessionInstance *service.Session) *authHandler {
 	mockExtractor := &mockIdentityExtractor{
 		identityToExtract,
 		nil,
@@ -54,23 +51,23 @@ type mockIdentityExtractor struct {
 }
 
 // Extract returns mocked identity
-func (extractor *mockIdentityExtractor) Extract(message []byte, signature identity.Signature) (identity.Identity, error) {
+func (extractor *mockIdentityExtractor) Extract(_ []byte, _ identity.Signature) (identity.Identity, error) {
 	return extractor.OnExtractReturnIdentity, extractor.OnExtractReturnError
 }
 
 type mockSessions struct {
-	OnFindReturnSession service.Session
+	OnFindReturnSession *service.Session
 	OnFindReturnSuccess bool
 }
 
-func (sessions *mockSessions) Add(sessionInstance service.Session) {
+func (sessions *mockSessions) Add(_ *service.Session) {
 }
 
-func (sessions *mockSessions) Find(session.ID) (service.Session, bool) {
+func (sessions *mockSessions) Find(_ session.ID) (*service.Session, bool) {
 	return sessions.OnFindReturnSession, sessions.OnFindReturnSuccess
 }
 
 func (sessions *mockSessions) Remove(session.ID) {
-	sessions.OnFindReturnSession = service.Session{}
+	sessions.OnFindReturnSession = nil
 	sessions.OnFindReturnSuccess = false
 }

--- a/services/openvpn/service/client_map.go
+++ b/services/openvpn/service/client_map.go
@@ -26,9 +26,7 @@ import (
 
 // SessionMap defines map of current sessions
 type SessionMap interface {
-	Add(service.Session)
-	Find(session.ID) (service.Session, bool)
-	Remove(session.ID)
+	Find(session.ID) (*service.Session, bool)
 }
 
 // clientMap extends current sessions with client id metadata from Openvpn.
@@ -64,7 +62,7 @@ func (cm *clientMap) Remove(clientID int) {
 }
 
 // GetSession returns ongoing session instance by given session id.
-func (cm *clientMap) GetSession(id session.ID) (service.Session, bool) {
+func (cm *clientMap) GetSession(id session.ID) (*service.Session, bool) {
 	return cm.sessions.Find(id)
 }
 


### PR DESCRIPTION
Fixes: #2488

Fixing order of provider session events, session `RemovedStatus` should happen as last events. Because afterwards session is cleaned up and other events get lost.