### PR TITLE
Revert auto-register to MMN wo API key

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -219,7 +219,9 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	}
 
 	di.bootstrapUIServer(nodeOptions)
-	di.bootstrapMMN(nodeOptions)
+	if err := di.bootstrapMMN(nodeOptions); err != nil {
+		return err
+	}
 	if err := di.bootstrapNATComponents(nodeOptions); err != nil {
 		return err
 	}

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -302,22 +302,9 @@ func (di *Dependencies) bootstrapUIServer(options node.Options) (err error) {
 	return nil
 }
 
-func (di *Dependencies) bootstrapMMN(options node.Options) {
+func (di *Dependencies) bootstrapMMN(options node.Options) error {
 	client := mmn.NewClient(di.HTTPClient, options.MMN.Address, di.SignerFactory)
-	m := mmn.NewMMN(di.IPResolver, client)
 
-	if err := m.CollectEnvironmentInformation(); err != nil {
-		log.Error().Msgf("Failed to collect environment information for MMN: %v", err)
-	}
-
-	apiKey := config.Current.GetString("mmn.api-key")
-	isRegistrationEnabled := func() bool {
-		return len(config.Current.GetString("mmn.api-key")) != 0
-	}
-	if err := m.SubscribeToIdentityUnlockRegisterToMMN(di.EventBus, isRegistrationEnabled); err != nil {
-		log.Error().Msgf("Failed to subscribe to events for MMN: %v", err)
-	}
-
-	m.SetAPIKey(apiKey)
-	di.MMN = m
+	di.MMN = mmn.NewMMN(di.IPResolver, client)
+	return di.MMN.Subscribe(di.EventBus)
 }

--- a/mmn/mmn.go
+++ b/mmn/mmn.go
@@ -74,7 +74,6 @@ func (m *MMN) handleNodeStart(e nodevent.Payload) {
 	}
 }
 
-// handleIdentityUnlock does auto-register to MMN, but only if API key is configured.
 func (m *MMN) handleIdentityUnlock(identity string) {
 	m.lastIdentity = identity
 }
@@ -85,11 +84,12 @@ func (m *MMN) handleServiceStart(e servicestate.AppEventServiceStatus) {
 		return
 	}
 
-	isRegistrationEnabled := len(config.Current.GetString("mmn.api-key")) != 0
-	if !isRegistrationEnabled {
-		log.Debug().Msg("Identity unlocked, registration to MMN disabled because the API key missing in config.")
-		return
-	}
+	// TODO Turn off auto-register then WEB UI will have possibility to configure API key
+	// isRegistrationEnabled := len(config.Current.GetString("mmn.api-key")) != 0
+	// if !isRegistrationEnabled {
+	// 	log.Debug().Msg("Identity unlocked, registration to MMN disabled because the API key missing in config.")
+	// 	return
+	// }
 
 	if err := m.register(); err != nil {
 		log.Error().Msgf("Failed to register identity to MMN: %v", err)

--- a/mmn/mmn.go
+++ b/mmn/mmn.go
@@ -25,7 +25,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/pkg/errors"
+	nodevent "github.com/mysteriumnetwork/node/core/node/event"
+	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/rs/zerolog/log"
 
 	"github.com/mysteriumnetwork/node/config"
@@ -39,7 +40,9 @@ import (
 type MMN struct {
 	client     *client
 	ipResolver ip.Resolver
-	node       *NodeInformationDto
+
+	lastIP       string
+	lastIdentity string
 }
 
 // NewMMN creates new instance of MMN
@@ -47,60 +50,72 @@ func NewMMN(resolver ip.Resolver, client *client) *MMN {
 	return &MMN{client: client, ipResolver: resolver}
 }
 
-// CollectEnvironmentInformation sends node information to MMN on identity unlock
-func (m *MMN) CollectEnvironmentInformation() error {
-	node := &NodeInformationDto{
+// Subscribe subscribes to node events and reports them to MMN
+func (m *MMN) Subscribe(eventBus eventbus.EventBus) error {
+	if err := eventBus.SubscribeAsync(nodevent.AppTopicNode, m.handleNodeStart); err != nil {
+		return err
+	}
+	if err := eventBus.SubscribeAsync(identity.AppTopicIdentityUnlock, m.handleIdentityUnlock); err != nil {
+		return err
+	}
+	return eventBus.SubscribeAsync(servicestate.AppTopicServiceStatus, m.handleServiceStart)
+}
+
+// handleNodeStart handles node state change and fetches the IP accordingly.
+func (m *MMN) handleNodeStart(e nodevent.Payload) {
+	if e.Status != nodevent.StatusStarted {
+		return
+	}
+
+	var err error
+	m.lastIP, err = m.ipResolver.GetOutboundIP()
+	if err != nil {
+		log.Error().Msgf("Failed to get get Outbound IP for MMN: %v", err)
+	}
+}
+
+// handleIdentityUnlock does auto-register to MMN, but only if API key is configured.
+func (m *MMN) handleIdentityUnlock(identity string) {
+	m.lastIdentity = identity
+}
+
+// handleServiceStart does auto-register to MMN, but only for providers.
+func (m *MMN) handleServiceStart(e servicestate.AppEventServiceStatus) {
+	if e.Status != string(servicestate.Running) {
+		return
+	}
+
+	isRegistrationEnabled := len(config.Current.GetString("mmn.api-key")) != 0
+	if !isRegistrationEnabled {
+		log.Debug().Msg("Identity unlocked, registration to MMN disabled because the API key missing in config.")
+		return
+	}
+
+	if err := m.register(); err != nil {
+		log.Error().Msgf("Failed to register identity to MMN: %v", err)
+	}
+}
+
+func (m *MMN) register() error {
+	return m.client.RegisterNode(&NodeInformationDto{
+		LocalIP:     m.lastIP,
+		Identity:    m.lastIdentity,
+		APIKey:      config.Current.GetString("mmn.api-key"),
 		VendorID:    config.GetString(config.FlagVendorID),
 		Arch:        runtime.GOOS + "/" + runtime.GOARCH,
 		OS:          getOS(),
 		NodeVersion: metadata.VersionAsString(),
-	}
-	m.node = node
-
-	outboundIp, err := m.ipResolver.GetOutboundIP()
-	if err != nil {
-		return errors.Wrap(err, "Failed to get Outbound IP")
-	}
-
-	m.node.LocalIP = outboundIp
-
-	return nil
-}
-
-// SubscribeToIdentityUnlockRegisterToMMN subscribes to identity unlock, registers identity in MMN if the API key is set
-func (m *MMN) SubscribeToIdentityUnlockRegisterToMMN(eventBus eventbus.EventBus, isRegistrationEnabled func() bool) error {
-	return eventBus.SubscribeAsync(
-		identity.AppTopicIdentityUnlock,
-		func(identity string) {
-			m.node.Identity = identity
-
-			if !isRegistrationEnabled() {
-				log.Debug().Msg("Identity unlocked, " +
-					"registration to MMN disabled because the API key missing in config.")
-
-				return
-			}
-
-			if err := m.Register(); err != nil {
-				log.Error().Msgf("Failed to register identity to MMN: %v", err)
-			}
-		},
-	)
-}
-
-// SetAPIKey sets MMN's API key
-func (m *MMN) SetAPIKey(apiKey string) {
-	m.node.APIKey = apiKey
+	})
 }
 
 // Register registers node to MMN
 func (m *MMN) Register() error {
-	return m.client.RegisterNode(m.node)
+	return m.register()
 }
 
 // GetReport fetches node report from MMN
 func (m *MMN) GetReport() (string, error) {
-	return m.client.GetReport(m.node.Identity)
+	return m.client.GetReport(m.lastIdentity)
 }
 
 func getOS() string {

--- a/tequilapi/contract/mmn.go
+++ b/tequilapi/contract/mmn.go
@@ -17,8 +17,24 @@
 
 package contract
 
+import (
+	"github.com/mysteriumnetwork/node/tequilapi/validation"
+)
+
 // MMNApiKeyRequest request used to manage MMN's API key.
 // swagger:model MMNApiKeyRequest
 type MMNApiKeyRequest struct {
 	ApiKey string `json:"api_key"`
+}
+
+// Validate validates fields in request
+func (r MMNApiKeyRequest) Validate() *validation.FieldErrorMap {
+	errs := validation.NewErrorMap()
+	if len(r.ApiKey) == 0 {
+		errs.ForField("api_key").AddError("required", "API key is required")
+	}
+	if len(r.ApiKey) < 40 {
+		errs.ForField("api_key").AddError("invalid", "Invalid API key")
+	}
+	return errs
 }


### PR DESCRIPTION
Until provider can't set MMN API key, revert auto-register for claim feature.