### PR TITLE
Publish tracer events in same order as added

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -19,7 +19,6 @@ package trace
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -36,7 +35,7 @@ const (
 // NewTracer returns new tracer instance.
 func NewTracer() *Tracer {
 	return &Tracer{
-		stages: make(map[string]*stage),
+		stages: make([]*stage, 0),
 	}
 }
 
@@ -44,7 +43,7 @@ func NewTracer() *Tracer {
 // to record stages times for tracing how long it took time.
 type Tracer struct {
 	mu       sync.Mutex
-	stages   map[string]*stage
+	stages   []*stage
 	finished bool
 }
 
@@ -57,16 +56,15 @@ func (t *Tracer) StartStage(key string) string {
 		log.Error().Msg("Tracer is already finished")
 		return ""
 	}
-
-	if _, ok := t.stages[key]; ok {
+	if _, ok := t.findStage(key); ok {
 		log.Error().Msgf("Stage %s was already started", key)
 		return ""
 	}
 
-	t.stages[key] = &stage{
+	t.stages = append(t.stages, &stage{
 		key:   key,
 		start: time.Now(),
-	}
+	})
 	return key
 }
 
@@ -79,12 +77,12 @@ func (t *Tracer) EndStage(key string) {
 		log.Error().Msg("Tracer is already finished")
 		return
 	}
-
-	if s, ok := t.stages[key]; ok {
-		s.end = time.Now()
-	} else {
+	s, ok := t.findStage(key)
+	if !ok {
 		log.Error().Msgf("Stage %s was not started", key)
 	}
+
+	s.end = time.Now()
 }
 
 // Finish finishes tracing and returns formatted string with stages durations.
@@ -93,17 +91,8 @@ func (t *Tracer) Finish(eventPublisher eventbus.Publisher, id string) string {
 	defer t.mu.Unlock()
 	t.finished = true
 
-	// Sort stages by start time.
-	var stages []*stage
-	for _, v := range t.stages {
-		stages = append(stages, v)
-	}
-	sort.Slice(stages, func(i, j int) bool {
-		return stages[i].start.Before(stages[j].start)
-	})
-
 	var strs []string
-	for _, s := range stages {
+	for _, s := range t.stages {
 		if s.end.After(time.Time{}) {
 			t.publishStageEvent(eventPublisher, id, *s)
 			strs = append(strs, fmt.Sprintf("%q took %s", s.key, s.end.Sub(s.start).String()))
@@ -113,6 +102,15 @@ func (t *Tracer) Finish(eventPublisher eventbus.Publisher, id string) string {
 	}
 
 	return strings.Join(strs, ", ")
+}
+
+func (t *Tracer) findStage(key string) (*stage, bool) {
+	for _, s := range t.stages {
+		if s.key == key {
+			return s, true
+		}
+	}
+	return nil, false
 }
 
 func (t *Tracer) publishStageEvent(eventPublisher eventbus.Publisher, id string, stage stage) {


### PR DESCRIPTION
Fixes flaky tests, like:

```
session_manager_test.go:125: 
        	Error Trace:	session_manager_test.go:125
        	            				asm_amd64.s:1357
        	Error:      	Not equal: 
        	            	expected: "Provider whole session create"
        	            	actual  : "Provider session start"
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-Provider whole session create
        	            	+Provider session start
        	Test:       	TestManager_Start_StoresSession
    session_manager_test.go:129: 
        	Error Trace:	session_manager_test.go:129
        	            				asm_amd64.s:1357
        	Error:      	Not equal: 
        	            	expected: "Provider session start"
        	            	actual  : "Provider whole session create"
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-Provider session start
        	            	+Provider whole session create
        	Test:       	TestManager_Start_StoresSession
```

```
panic: interface conversion: interface {} is trace.Event, not event.AppEventSession
goroutine 39 [running]:
github.com/mysteriumnetwork/node/core/service.TestManager_Start_DisconnectsOnPaymentError.func1(0x476121)
	/home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/core/service/session_manager_test.go:165 +0xe03
github.com/stretchr/testify/assert.Eventually.func1(0xc000258460, 0xc0003ee820)
	/home/gitlab-runner/go/pkg/mod/github.com/stretchr/testify@v1.4.1-0.20200130210847-518a1491c713/assert/assertions.go:1585 +0x35
created by github.com/stretchr/testify/assert.Eventually
	/home/gitlab-runner/go/pkg/mod/github.com/stretchr/testify@v1.4.1-0.20200130210847-518a1491c713/assert/assertions.go:1585 +0x328
```