### PR TITLE
Reconnect after wake-up on win

### DIFF
--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	p2pDialTimeout = 30 * time.Second
+	p2pDialTimeout = 60 * time.Second
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/mysteriumnetwork/go-dvpn-web v0.0.45
 	github.com/mysteriumnetwork/go-openvpn v0.0.23
 	github.com/mysteriumnetwork/go-wondershaper v1.0.1
+	github.com/mysteriumnetwork/gowinlog v0.0.0-20200817095141-ad6c5f74d12e
 	github.com/mysteriumnetwork/metrics v0.0.4
 	github.com/mysteriumnetwork/payments v0.0.14-0.20200603103214-337588427715
 	github.com/nats-io/nats-server/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
+github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
@@ -504,6 +506,8 @@ github.com/mysteriumnetwork/go-openvpn v0.0.23 h1:6BKoTwU9CpJL/Na9M9a0uaelAaVIo/
 github.com/mysteriumnetwork/go-openvpn v0.0.23/go.mod h1:YDjnxC/3sGNecq/f6GM0BGz7nnGPTPIGtQjHaoLf8UE=
 github.com/mysteriumnetwork/go-wondershaper v1.0.1 h1:vHfeQ5siADk7AOlbEBe6FLRu8N1RaVBCEBLi1VhmIrI=
 github.com/mysteriumnetwork/go-wondershaper v1.0.1/go.mod h1:pWWNkO73g3vPSVb+6O+GzjG8lqv4ByNHR6thSG7WmtY=
+github.com/mysteriumnetwork/gowinlog v0.0.0-20200817095141-ad6c5f74d12e h1:r8M+wZRiCNEX9KX2GugOiAzomEYcoOhq+F/dEgqc/Jo=
+github.com/mysteriumnetwork/gowinlog v0.0.0-20200817095141-ad6c5f74d12e/go.mod h1:izNxG4qVO/POwdPoBfECCvgl4YHRrL6VKopeqj3gNew=
 github.com/mysteriumnetwork/metrics v0.0.4 h1:xHA9JJpfR5oMEeyJ/eFl4TolksZzS3vwfAgtN+hXOoY=
 github.com/mysteriumnetwork/metrics v0.0.4/go.mod h1:QQHdm9M0p42hESbtM0dxyeooH66QTGtXAArz8qsi4Ds=
 github.com/mysteriumnetwork/payments v0.0.14-0.20200603103214-337588427715 h1:DTOhrSaVx6oFOP6XRzlsAb5E34O9DMZ6Uw9cRnq2Pv0=

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -38,7 +38,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const maxBrokerConnectAttempts = 15
+const maxBrokerConnectAttempts = 25
 
 // Dialer knows how to exchange p2p keys and encrypted configuration and creates ready to use p2p channels.
 type Dialer interface {

--- a/sleep/sleep.go
+++ b/sleep/sleep.go
@@ -17,7 +17,11 @@
 
 package sleep
 
-import "github.com/mysteriumnetwork/node/eventbus"
+import (
+	"sync"
+
+	"github.com/mysteriumnetwork/node/eventbus"
+)
 
 // Event represents sleep event triggered by underlying OS
 type Event int
@@ -38,6 +42,7 @@ var eventChannel chan Event
 type Notifier struct {
 	eventbus eventbus.Publisher
 	stop     chan struct{}
+	stopOnce sync.Once
 }
 
 // NewNotifier create sleep events notifier

--- a/sleep/sleep_darwin.go
+++ b/sleep/sleep_darwin.go
@@ -26,7 +26,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (n Notifier) Start() {
+//Start starts events notifier
+func (n *Notifier) Start() {
 	log.Debug().Msg("Register for sleep events")
 	go C.registerNotifications()
 	go func() {
@@ -38,8 +39,11 @@ func (n Notifier) Start() {
 	<-n.stop
 }
 
-func (n Notifier) Stop() {
-	log.Debug().Msg("Unregister sleep events")
-	C.unregisterNotifications()
-	close(n.stop)
+//Stop stops events notifier
+func (n *Notifier) Stop() {
+	n.stopOnce.Do(func() {
+		log.Debug().Msg("Unregister sleep events")
+		C.unregisterNotifications()
+		close(n.stop)
+	})
 }

--- a/sleep/sleep_export.go
+++ b/sleep/sleep_export.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
  * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
  *

--- a/sleep/sleep_noop.go
+++ b/sleep/sleep_noop.go
@@ -24,11 +24,11 @@ import (
 )
 
 // Start noop function
-func (n Notifier) Start() {
+func (n *Notifier) Start() {
 	log.Debug().Msg("Register for noop sleep events")
 }
 
 // Stop noop function
-func (n Notifier) Stop() {
+func (n *Notifier) Stop() {
 	log.Debug().Msg("Unregister noop sleep events")
 }

--- a/sleep/sleep_noop.go
+++ b/sleep/sleep_noop.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!windows
 
 /*
  * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.

--- a/sleep/sleep_windows.go
+++ b/sleep/sleep_windows.go
@@ -1,17 +1,34 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package sleep
 
-import "C"
 import (
-	"github.com/mysteriumnetwork/gowinlog"
+	winlog "github.com/mysteriumnetwork/gowinlog"
 	"github.com/rs/zerolog/log"
 )
 
-func (n Notifier) Start() {
+//Start starts event log notifier
+func (n *Notifier) Start() {
 	log.Debug().Msg("Register for sleep log events")
 
 	watcher, err := winlog.NewWinLogWatcher()
 	if err != nil {
-		log.Error().Msgf("couldn't create log watcher: %v\n", err)
+		log.Error().Msgf("Couldn't create log watcher: %v\n", err)
 		return
 	}
 
@@ -22,13 +39,17 @@ func (n Notifier) Start() {
 			n.eventbus.Publish(AppTopicSleepNotification, EventWakeup)
 		case err := <-watcher.Error():
 			log.Error().Msgf("Log watcher error: %v\n", err)
+		case <-n.stop:
+			break
 		}
 	}
-	<-n.stop
 	watcher.Shutdown()
 }
 
-func (n Notifier) Stop() {
-	log.Debug().Msg("Unregister sleep log events watcher")
-	close(n.stop)
+//Stop stops event log notifier
+func (n *Notifier) Stop() {
+	n.stopOnce.Do(func() {
+		log.Debug().Msg("Unregister sleep log events watcher")
+		close(n.stop)
+	})
 }

--- a/sleep/sleep_windows.go
+++ b/sleep/sleep_windows.go
@@ -1,0 +1,34 @@
+package sleep
+
+import "C"
+import (
+	"github.com/mysteriumnetwork/gowinlog"
+	"github.com/rs/zerolog/log"
+)
+
+func (n Notifier) Start() {
+	log.Debug().Msg("Register for sleep log events")
+
+	watcher, err := winlog.NewWinLogWatcher()
+	if err != nil {
+		log.Error().Msgf("couldn't create log watcher: %v\n", err)
+		return
+	}
+
+	watcher.SubscribeFromNow("System", "*[System[Provider[@Name='Microsoft-Windows-Power-Troubleshooter'] and EventID=1]]")
+	for {
+		select {
+		case <-watcher.Event():
+			n.eventbus.Publish(AppTopicSleepNotification, EventWakeup)
+		case err := <-watcher.Error():
+			log.Error().Msgf("Log watcher error: %v\n", err)
+		}
+	}
+	<-n.stop
+	watcher.Shutdown()
+}
+
+func (n Notifier) Stop() {
+	log.Debug().Msg("Unregister sleep log events watcher")
+	close(n.stop)
+}


### PR DESCRIPTION
Reconnect after receiving wake-up log event on Windows. 
Tested with windows CLI.

Due to super slow connects on windows reconnect takes a long time sometimes hitting 30sec dial timeout, thus increased to 60sec.
Looks like windows is super slow on route cleanup. Which adds up to reconnect timeout. Maybe we should investigate a bit further weather we can improve that.

Plain connect (without previous disconnect) on win depending on a node takes ~18sec which should be not acceptable. This is most likely connects to RPIs.


