### PR TITLE
Store settlement history and expose it to Tequilapi 

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -414,7 +414,7 @@ func (di *Dependencies) bootstrapStorage(path string) error {
 	di.ConsumerTotalsStorage = pingpong.NewConsumerTotalsStorage(di.Storage, di.EventBus)
 	di.AccountantPromiseStorage = pingpong.NewAccountantPromiseStorage(di.Storage)
 	di.SessionStorage = consumer_session.NewSessionStorage(di.Storage)
-	di.SettlementHistoryStorage = pingpong.NewSettlementHistoryStorage(di.Storage, pingpong.DefaultMaxEntriesPerChannel)
+	di.SettlementHistoryStorage = pingpong.NewSettlementHistoryStorage(di.Storage)
 	return di.SessionStorage.Subscribe(di.EventBus)
 }
 

--- a/core/storage/boltdb/migrations/history/sequence.go
+++ b/core/storage/boltdb/migrations/history/sequence.go
@@ -31,4 +31,10 @@ var Sequence = []migrations.Migration{
 			2018, 12, 04, 12, 00, 00, 0, time.UTC),
 		Migrate: migrations.MigrateSessionToHistory,
 	},
+	{
+		Name: "settlements-to-rows",
+		Date: time.Date(
+			2020, 8, 17, 14, 27, 00, 0, time.UTC),
+		Migrate: migrations.SettlementValuesToRows,
+	},
 }

--- a/core/storage/boltdb/migrations/settlement_history.go
+++ b/core/storage/boltdb/migrations/settlement_history.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package migrations
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/codec/json"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/session/pingpong"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"go.etcd.io/bbolt"
+)
+
+type settlementEntryOld struct {
+	Time         time.Time      `json:"time,omitempty"`
+	TxHash       common.Hash    `json:"tx_hash,omitempty"`
+	Promise      crypto.Promise `json:"promise,omitempty"`
+	Beneficiary  common.Address `json:"beneficiary,omitempty"`
+	Amount       *big.Int       `json:"amount,omitempty"`
+	TotalSettled *big.Int       `json:"total_settled,omitempty"`
+}
+
+// Convert converts the old struct to a settlement struct
+func (s settlementEntryOld) Convert() pingpong.SettlementHistoryEntry {
+	return pingpong.SettlementHistoryEntry{
+		TxHash:       s.TxHash,
+		Time:         s.Time,
+		Promise:      s.Promise,
+		Beneficiary:  s.Beneficiary,
+		Amount:       s.Amount,
+		TotalSettled: s.TotalSettled,
+	}
+}
+
+const settlementHistoryBucketOld = "settlement_history"
+const settlementHistoryBucketNew = "settlement-history"
+
+// SettlementValuesToRows converts settlement history from key-value struct to bucket with rows.
+func SettlementValuesToRows(db *storm.DB) error {
+	err := db.Bolt.View(func(tx *bbolt.Tx) error {
+		oldBucket := tx.Bucket([]byte(settlementHistoryBucketOld))
+		if oldBucket == nil {
+			// Nothing to migrate
+			return nil
+		}
+
+		newBucket := db.From(settlementHistoryBucketNew)
+
+		return oldBucket.ForEach(func(k, v []byte) error {
+			if string(k) == "__storm_metadata" {
+				return nil
+			}
+
+			var oldEntries []settlementEntryOld
+			if err := json.Codec.Unmarshal(v, &oldEntries); err != nil {
+				return err
+			}
+
+			for _, oldEntry := range oldEntries {
+				newEntry := oldEntry.Convert()
+				if err := newBucket.Save(&newEntry); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	return db.Bolt.Update(func(tx *bbolt.Tx) error {
+		oldBucket := tx.Bucket([]byte(settlementHistoryBucketOld))
+		if oldBucket == nil {
+			// Nothing to migrate
+			return nil
+		}
+
+		return tx.DeleteBucket([]byte(settlementHistoryBucketOld))
+	})
+}

--- a/core/storage/boltdb/migrations/settlement_history_test.go
+++ b/core/storage/boltdb/migrations/settlement_history_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package migrations
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/core/storage/boltdb/boltdbtest"
+	"github.com/mysteriumnetwork/node/session/pingpong"
+	"github.com/mysteriumnetwork/payments/crypto"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	oldSettlementMock = settlementEntryOld{
+		TxHash:       common.BigToHash(big.NewInt(123123123)),
+		Promise:      crypto.Promise{},
+		Beneficiary:  common.HexToAddress("0x4443189b9b945DD38E7bfB6167F9909451582eE5"),
+		Amount:       big.NewInt(123),
+		TotalSettled: big.NewInt(321),
+	}
+)
+
+func Test_ToSettlementRows_WithNoData(t *testing.T) {
+	// given
+	file, db := boltdbtest.CreateDB(t)
+	defer boltdbtest.CleanupDB(t, file, db)
+
+	// when
+	err := SettlementValuesToRows(db)
+	assert.NoError(t, err)
+}
+
+func Test_ToSettlementRows_WithData(t *testing.T) {
+	// given
+	file, db := boltdbtest.CreateDB(t)
+	defer boltdbtest.CleanupDB(t, file, db)
+
+	err := db.Set(settlementHistoryBucketOld, "1", []settlementEntryOld{oldSettlementMock})
+	assert.NoError(t, err)
+
+	// when
+	err = SettlementValuesToRows(db)
+	assert.NoError(t, err)
+
+	// then
+	var entries []pingpong.SettlementHistoryEntry
+	err = db.From(settlementHistoryBucketNew).All(&entries)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, []pingpong.SettlementHistoryEntry{oldSettlementMock.Convert()}, entries)
+}

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/urfave/cli/v2 v2.1.1
 	github.com/vcraescu/go-paginator v0.0.0-20200304054438-86d84f27c0b3
 	github.com/xtaci/kcp-go/v5 v5.5.8
+	go.etcd.io/bbolt v1.3.4
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae

--- a/session/pingpong/accountant_promise_settler.go
+++ b/session/pingpong/accountant_promise_settler.go
@@ -436,7 +436,7 @@ func (aps *accountantPromiseSettler) settle(
 
 			channelID, err := crypto.GenerateProviderChannelID(provider.Address, aps.config.AccountantAddress.Hex())
 			if err != nil {
-				log.Error().Err(err).Msg("could not generate provider channel address")
+				log.Error().Err(err).Msg("Could not generate provider channel address")
 			}
 
 			she := SettlementHistoryEntry{
@@ -453,7 +453,7 @@ func (aps *accountantPromiseSettler) settle(
 
 			err = aps.settlementHistoryStorage.Store(she)
 			if err != nil {
-				log.Error().Err(err).Msg("could not store settlement history")
+				log.Error().Err(err).Msg("Could not store settlement history")
 			}
 
 			err = aps.resyncState(provider)

--- a/session/pingpong/accountant_promise_settler.go
+++ b/session/pingpong/accountant_promise_settler.go
@@ -67,8 +67,9 @@ type promiseStorage interface {
 }
 
 type receivedPromise struct {
-	provider identity.Identity
-	promise  crypto.Promise
+	provider    identity.Identity
+	promise     crypto.Promise
+	beneficiary common.Address
 }
 
 // AccountantPromiseSettler is responsible for settling the accountant promises.
@@ -281,11 +282,11 @@ func (aps *accountantPromiseSettler) handleAccountantPromiseReceived(apep event.
 	log.Info().Msgf("Accountant promise state updated for provider %q", id)
 
 	if s.needsSettling(aps.config.Threshold) {
-		aps.initiateSettling(apep.ProviderID, apep.AccountantID)
+		aps.initiateSettling(apep.ProviderID, apep.AccountantID, s.channel.Beneficiary)
 	}
 }
 
-func (aps *accountantPromiseSettler) initiateSettling(providerID identity.Identity, accountantID common.Address) {
+func (aps *accountantPromiseSettler) initiateSettling(providerID identity.Identity, accountantID common.Address, beneficiary common.Address) {
 	promise, err := aps.promiseStorage.Get(providerID, accountantID)
 	if err == ErrNotFound {
 		log.Debug().Msgf("no promise to settle for %q %q", providerID, accountantID.Hex())
@@ -304,8 +305,9 @@ func (aps *accountantPromiseSettler) initiateSettling(providerID identity.Identi
 	promise.Promise.R = hexR
 
 	aps.settleQueue <- receivedPromise{
-		provider: providerID,
-		promise:  promise.Promise,
+		provider:    providerID,
+		promise:     promise.Promise,
+		beneficiary: beneficiary,
 	}
 }
 
@@ -320,7 +322,14 @@ func (aps *accountantPromiseSettler) listenForSettlementRequests() {
 		case <-aps.stop:
 			return
 		case p := <-aps.settleQueue:
-			go aps.settle(p, nil)
+			go aps.settle(
+				func() error {
+					return aps.transactor.SettleAndRebalance(aps.config.AccountantAddress.Hex(), p.promise)
+				},
+				p.provider,
+				p.promise,
+				p.beneficiary,
+			)
 		}
 	}
 }
@@ -352,10 +361,14 @@ func (aps *accountantPromiseSettler) ForceSettle(providerID identity.Identity, a
 	}
 
 	promise.Promise.R = hexR
-	return aps.settle(receivedPromise{
-		promise:  promise.Promise,
-		provider: providerID,
-	}, nil)
+	return aps.settle(
+		func() error {
+			return aps.transactor.SettleAndRebalance(aps.config.AccountantAddress.Hex(), promise.Promise)
+		},
+		providerID,
+		promise.Promise,
+		aps.currentState[providerID].channel.Beneficiary,
+	)
 }
 
 // ForceSettle forces the settlement for a provider
@@ -374,25 +387,34 @@ func (aps *accountantPromiseSettler) SettleWithBeneficiary(providerID identity.I
 	}
 
 	promise.Promise.R = hexR
-	return aps.settle(receivedPromise{
-		promise:  promise.Promise,
-		provider: providerID,
-	}, &beneficiary)
+	return aps.settle(
+		func() error {
+			return aps.transactor.SettleWithBeneficiary(providerID.Address, beneficiary.Hex(), aps.config.AccountantAddress.Hex(), promise.Promise)
+		},
+		providerID,
+		promise.Promise,
+		beneficiary,
+	)
 }
 
 // ErrSettleTimeout indicates that the settlement has timed out
 var ErrSettleTimeout = errors.New("settle timeout")
 
-func (aps *accountantPromiseSettler) settle(p receivedPromise, beneficiary *common.Address) error {
-	if aps.isSettling(p.provider) {
+func (aps *accountantPromiseSettler) settle(
+	settleFunc func() error,
+	provider identity.Identity,
+	promise crypto.Promise,
+	beneficiary common.Address,
+) error {
+	if aps.isSettling(provider) {
 		return errors.New("provider already has settlement in progress")
 	}
 
-	aps.setSettling(p.provider, true)
-	log.Info().Msgf("Marked provider %v as requesting settlement", p.provider)
-	sink, cancel, err := aps.bc.SubscribeToPromiseSettledEvent(p.provider.ToCommonAddress(), aps.config.AccountantAddress)
+	aps.setSettling(provider, true)
+	log.Info().Msgf("Marked provider %v as requesting settlement", provider)
+	sink, cancel, err := aps.bc.SubscribeToPromiseSettledEvent(provider.ToCommonAddress(), aps.config.AccountantAddress)
 	if err != nil {
-		aps.setSettling(p.provider, false)
+		aps.setSettling(provider, false)
 		log.Error().Err(err).Msg("Could not subscribe to promise settlement")
 		return err
 	}
@@ -400,7 +422,7 @@ func (aps *accountantPromiseSettler) settle(p receivedPromise, beneficiary *comm
 	errCh := make(chan error)
 	go func() {
 		defer cancel()
-		defer aps.setSettling(p.provider, false)
+		defer aps.setSettling(provider, false)
 		defer close(errCh)
 		select {
 		case <-aps.stop:
@@ -410,25 +432,23 @@ func (aps *accountantPromiseSettler) settle(p receivedPromise, beneficiary *comm
 				break
 			}
 
-			log.Info().Msgf("Settling complete for provider %v", p.provider)
+			log.Info().Msgf("Settling complete for provider %v", provider)
 
-			channelID, err := crypto.GenerateProviderChannelID(p.provider.Address, aps.config.AccountantAddress.Hex())
+			channelID, err := crypto.GenerateProviderChannelID(provider.Address, aps.config.AccountantAddress.Hex())
 			if err != nil {
 				log.Error().Err(err).Msg("could not generate provider channel address")
 			}
 
 			she := SettlementHistoryEntry{
 				TxHash:         info.Raw.TxHash,
-				ProviderID:     p.provider,
+				ProviderID:     provider,
 				AccountantID:   aps.config.AccountantAddress,
 				ChannelAddress: common.HexToAddress(channelID),
 				Time:           time.Now().UTC(),
-				Promise:        p.promise,
+				Promise:        promise,
+				Beneficiary:    beneficiary,
 				Amount:         info.Amount,
 				TotalSettled:   info.TotalSettled,
-			}
-			if beneficiary != nil {
-				she.Beneficiary = *beneficiary
 			}
 
 			err = aps.settlementHistoryStorage.Store(she)
@@ -436,17 +456,17 @@ func (aps *accountantPromiseSettler) settle(p receivedPromise, beneficiary *comm
 				log.Error().Err(err).Msg("could not store settlement history")
 			}
 
-			err = aps.resyncState(p.provider)
+			err = aps.resyncState(provider)
 			if err != nil {
 				// This will get retried so we do not need to explicitly retry
 				// TODO: maybe add a sane limit of retries
-				log.Error().Err(err).Msgf("Resync failed for provider %v", p.provider)
+				log.Error().Err(err).Msgf("Resync failed for provider %v", provider)
 			} else {
-				log.Info().Msgf("Resync success for provider %v", p.provider)
+				log.Info().Msgf("Resync success for provider %v", provider)
 			}
 			return
 		case <-time.After(aps.config.MaxWaitForSettlement):
-			log.Info().Msgf("Settle timeout for %v", p.provider)
+			log.Info().Msgf("Settle timeout for %v", provider)
 
 			// send a signal to waiter that the settlement has timed out
 			errCh <- ErrSettleTimeout
@@ -454,19 +474,10 @@ func (aps *accountantPromiseSettler) settle(p receivedPromise, beneficiary *comm
 		}
 	}()
 
-	var settleFunc = func() error {
-		return aps.transactor.SettleAndRebalance(aps.config.AccountantAddress.Hex(), p.promise)
-	}
-	if beneficiary != nil {
-		settleFunc = func() error {
-			return aps.transactor.SettleWithBeneficiary(p.provider.Address, beneficiary.Hex(), aps.config.AccountantAddress.Hex(), p.promise)
-		}
-	}
-
 	err = settleFunc()
 	if err != nil {
 		cancel()
-		log.Error().Err(err).Msgf("Could not settle promise for %v", p.provider.Address)
+		log.Error().Err(err).Msgf("Could not settle promise for %v", provider)
 		return err
 	}
 

--- a/session/pingpong/accountant_promise_settler_test.go
+++ b/session/pingpong/accountant_promise_settler_test.go
@@ -503,6 +503,6 @@ func (mt *mockTransactor) FetchRegistrationStatus(id string) (registry.Transacto
 
 type settlementHistoryStorageMock struct{}
 
-func (shsm *settlementHistoryStorageMock) Store(provider identity.Identity, accountant common.Address, she SettlementHistoryEntry) error {
+func (shsm *settlementHistoryStorageMock) Store(_ SettlementHistoryEntry) error {
 	return nil
 }

--- a/session/pingpong/settlement_history_storage.go
+++ b/session/pingpong/settlement_history_storage.go
@@ -18,103 +18,59 @@
 package pingpong
 
 import (
-	"fmt"
 	"math/big"
-	"sort"
-	"sync"
 	"time"
 
+	"github.com/asdine/storm/v3/q"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/core/storage/boltdb"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/payments/crypto"
 )
 
 // SettlementHistoryStorage stores the settlement events for historical purposes.
 type SettlementHistoryStorage struct {
-	bolt                 persistentStorage
-	maxEntriesPerChannel int
-	lock                 sync.Mutex
+	bolt *boltdb.Bolt
 }
 
-// DefaultMaxEntriesPerChannel represents the default settlement history limit.
-const DefaultMaxEntriesPerChannel = 100
-
 // NewSettlementHistoryStorage returns a new instance of the SettlementHistoryStorage.
-func NewSettlementHistoryStorage(bolt persistentStorage, maxEntries int) *SettlementHistoryStorage {
+func NewSettlementHistoryStorage(bolt *boltdb.Bolt) *SettlementHistoryStorage {
 	return &SettlementHistoryStorage{
-		bolt:                 bolt,
-		maxEntriesPerChannel: maxEntries,
+		bolt: bolt,
 	}
 }
 
 // SettlementHistoryEntry represents a settlement history entry
 type SettlementHistoryEntry struct {
-	Time         time.Time      `json:"time,omitempty"`
-	TxHash       common.Hash    `json:"tx_hash,omitempty"`
-	Promise      crypto.Promise `json:"promise,omitempty"`
-	Beneficiary  common.Address `json:"beneficiary,omitempty"`
-	Amount       *big.Int       `json:"amount,omitempty"`
-	TotalSettled *big.Int       `json:"total_settled,omitempty"`
+	TxHash         common.Hash       `json:"tx_hash,omitempty" storm:"id"`
+	ProviderID     identity.Identity `json:"provider_id,omitempty"`
+	AccountantID   common.Address    `json:"accountant_id,omitempty"`
+	ChannelAddress common.Address    `json:"channel_address,omitempty"`
+	Time           time.Time         `json:"time,omitempty"`
+	Promise        crypto.Promise    `json:"promise,omitempty"`
+	Beneficiary    common.Address    `json:"beneficiary,omitempty"`
+	Amount         *big.Int          `json:"amount,omitempty"`
+	TotalSettled   *big.Int          `json:"total_settled,omitempty"`
 }
 
-const settlementHistoryBucket = "settlement_history"
+const settlementHistoryBucket = "settlement-history"
 
-// Store sotres a given settlement history entry.
-func (shs *SettlementHistoryStorage) Store(provider identity.Identity, accountant common.Address, she SettlementHistoryEntry) error {
-	shs.lock.Lock()
-	defer shs.lock.Unlock()
-	addr, err := crypto.GenerateProviderChannelID(provider.Address, accountant.Hex())
-	if err != nil {
-		return fmt.Errorf("could not generate provider channel address: %w", err)
-	}
-
-	she.Time = time.Now().UTC()
-	toStore := []SettlementHistoryEntry{she}
-	entries, err := shs.get(addr)
-	if err != nil {
-		if err.Error() == errBoltNotFound {
-			// if not found, just store and return
-			return shs.store(addr, toStore)
-		}
-		return fmt.Errorf("could not get previous settlement history: %w", err)
-	}
-
-	// sort by date
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Time.After(entries[j].Time) })
-
-	//  remove old ones if needed to prevent excessive history storage
-	if len(entries) < shs.maxEntriesPerChannel {
-		toStore = append(toStore, entries...)
-	} else if len(entries) == shs.maxEntriesPerChannel {
-		toStore = append(toStore, entries[:len(entries)-1]...)
-	} else {
-		diff := len(entries) - shs.maxEntriesPerChannel + 1
-		toStore = append(toStore, entries[:len(entries)-diff]...)
-	}
-
-	return shs.store(addr, toStore)
-}
-
-func (shs *SettlementHistoryStorage) store(channel string, she []SettlementHistoryEntry) error {
-	err := shs.bolt.SetValue(settlementHistoryBucket, channel, she)
-	if err != nil {
-		return fmt.Errorf("could not store settlement history: %w", err)
-	}
-	return nil
+// Store stores a given settlement history entry.
+func (shs *SettlementHistoryStorage) Store(she SettlementHistoryEntry) error {
+	return shs.bolt.DB().From(settlementHistoryBucket).Save(&she)
 }
 
 // Get returns the settlement history for given provider accountant combination.
 func (shs *SettlementHistoryStorage) Get(provider identity.Identity, accountant common.Address) ([]SettlementHistoryEntry, error) {
-	shs.lock.Lock()
-	defer shs.lock.Unlock()
-	addr, err := crypto.GenerateProviderChannelID(provider.Address, accountant.Hex())
-	if err != nil {
-		return []SettlementHistoryEntry{}, fmt.Errorf("could not generate provider channel address: %w", err)
-	}
-	return shs.get(addr)
-}
+	query := shs.bolt.DB().
+		From(settlementHistoryBucket).
+		Select(
+			q.Eq("ProviderID", provider),
+			q.Eq("AccountantID", accountant),
+		).
+		OrderBy("Time").
+		Reverse()
 
-func (shs *SettlementHistoryStorage) get(channel string) ([]SettlementHistoryEntry, error) {
 	var res []SettlementHistoryEntry
-	return res, shs.bolt.GetValue(settlementHistoryBucket, channel, &res)
+	return res, query.Find(&res)
 }

--- a/session/pingpong/settlement_history_storage.go
+++ b/session/pingpong/settlement_history_storage.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/asdine/storm/v3"
 	"github.com/asdine/storm/v3/q"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb"
@@ -42,15 +43,15 @@ func NewSettlementHistoryStorage(bolt *boltdb.Bolt) *SettlementHistoryStorage {
 
 // SettlementHistoryEntry represents a settlement history entry
 type SettlementHistoryEntry struct {
-	TxHash         common.Hash       `json:"tx_hash,omitempty" storm:"id"`
-	ProviderID     identity.Identity `json:"provider_id,omitempty"`
-	AccountantID   common.Address    `json:"accountant_id,omitempty"`
-	ChannelAddress common.Address    `json:"channel_address,omitempty"`
-	Time           time.Time         `json:"time,omitempty"`
-	Promise        crypto.Promise    `json:"promise,omitempty"`
-	Beneficiary    common.Address    `json:"beneficiary,omitempty"`
-	Amount         *big.Int          `json:"amount,omitempty"`
-	TotalSettled   *big.Int          `json:"total_settled,omitempty"`
+	TxHash         common.Hash `storm:"id"`
+	ProviderID     identity.Identity
+	AccountantID   common.Address
+	ChannelAddress common.Address
+	Time           time.Time
+	Promise        crypto.Promise
+	Beneficiary    common.Address
+	Amount         *big.Int
+	TotalSettled   *big.Int
 }
 
 const settlementHistoryBucket = "settlement-history"
@@ -60,17 +61,81 @@ func (shs *SettlementHistoryStorage) Store(she SettlementHistoryEntry) error {
 	return shs.bolt.DB().From(settlementHistoryBucket).Save(&she)
 }
 
-// Get returns the settlement history for given provider accountant combination.
-func (shs *SettlementHistoryStorage) Get(provider identity.Identity, accountant common.Address) ([]SettlementHistoryEntry, error) {
-	query := shs.bolt.DB().
-		From(settlementHistoryBucket).
-		Select(
-			q.Eq("ProviderID", provider),
-			q.Eq("AccountantID", accountant),
-		).
+// Query executes given query.
+func (shs *SettlementHistoryStorage) Query(query *SettlementHistoryQuery) (err error) {
+	return query.run(shs.bolt.DB().From(settlementHistoryBucket))
+}
+
+// NewSettlementHistoryQuery creates instance of query.
+func NewSettlementHistoryQuery() *SettlementHistoryQuery {
+	return &SettlementHistoryQuery{}
+}
+
+// SettlementHistoryQuery defines all flags for filtering in settlement history storage.
+type SettlementHistoryQuery struct {
+	Entries []SettlementHistoryEntry
+
+	filterFrom       *time.Time
+	filterTo         *time.Time
+	filterProvider   *identity.Identity
+	filterAccountant *common.Address
+}
+
+// FilterFrom filters fetched sessions from given time.
+func (qr *SettlementHistoryQuery) FilterFrom(from time.Time) *SettlementHistoryQuery {
+	from = from.UTC()
+	qr.filterFrom = &from
+	return qr
+}
+
+// FilterTo filters fetched sessions to given time.
+func (qr *SettlementHistoryQuery) FilterTo(to time.Time) *SettlementHistoryQuery {
+	to = to.UTC()
+	qr.filterTo = &to
+	return qr
+}
+
+// FilterProviderID filters fetched entries by provider ID.
+func (qr *SettlementHistoryQuery) FilterProviderID(providerID identity.Identity) *SettlementHistoryQuery {
+	qr.filterProvider = &providerID
+	return qr
+}
+
+// FilterAccountantID filters fetched entries by accountant ID.
+func (qr *SettlementHistoryQuery) FilterAccountantID(accountantID common.Address) *SettlementHistoryQuery {
+	qr.filterAccountant = &accountantID
+	return qr
+}
+
+// FetchEntries fetches list of sessions to Query.Entries.
+func (qr *SettlementHistoryQuery) FetchEntries() *SettlementHistoryQuery {
+	return qr
+}
+
+func (qr *SettlementHistoryQuery) run(node storm.Node) error {
+	where := make([]q.Matcher, 0)
+	if qr.filterFrom != nil {
+		where = append(where, q.Gte("Time", qr.filterFrom))
+	}
+	if qr.filterTo != nil {
+		where = append(where, q.Lte("Time", qr.filterTo))
+	}
+	if qr.filterProvider != nil {
+		where = append(where, q.Eq("ProviderID", qr.filterProvider))
+	}
+	if qr.filterAccountant != nil {
+		where = append(where, q.Eq("AccountantID", qr.filterAccountant))
+	}
+
+	sq := node.
+		Select(q.And(where...)).
 		OrderBy("Time").
 		Reverse()
 
-	var res []SettlementHistoryEntry
-	return res, query.Find(&res)
+	err := sq.Find(&qr.Entries)
+	if err == storm.ErrNotFound {
+		qr.Entries = []SettlementHistoryEntry{}
+		return nil
+	}
+	return err
 }

--- a/session/pingpong/settlement_history_storage_test.go
+++ b/session/pingpong/settlement_history_storage_test.go
@@ -65,10 +65,12 @@ func TestSettlementHistoryStorage(t *testing.T) {
 		TotalSettled: big.NewInt(654),
 	}
 
-	t.Run("Returns not found if no results exist", func(t *testing.T) {
-		entries, err := storage.Get(providerID, accountantID)
-		assert.EqualError(t, err, errBoltNotFound)
-		assert.Len(t, entries, 0)
+	t.Run("Returns empty list if no results exist", func(t *testing.T) {
+		query := NewSettlementHistoryQuery().FetchEntries()
+
+		err := storage.Query(query)
+		assert.NoError(t, err)
+		assert.Len(t, query.Entries, 0)
 	})
 
 	t.Run("Inserts a history entry successfully", func(t *testing.T) {
@@ -77,19 +79,21 @@ func TestSettlementHistoryStorage(t *testing.T) {
 	})
 
 	t.Run("Fetches the inserted entry", func(t *testing.T) {
-		entries, err := storage.Get(providerID, accountantID)
+		query := NewSettlementHistoryQuery().FetchEntries()
+		err := storage.Query(query)
 		assert.NoError(t, err)
-		assert.Len(t, entries, 1)
-		assert.EqualValues(t, []SettlementHistoryEntry{entry1}, entries)
+		assert.Len(t, query.Entries, 1)
+		assert.EqualValues(t, []SettlementHistoryEntry{entry1}, query.Entries)
 	})
 
 	t.Run("Returns sorted results", func(t *testing.T) {
 		err := storage.Store(entry2)
 		assert.NoError(t, err)
 
-		entries, err := storage.Get(providerID, accountantID)
+		query := NewSettlementHistoryQuery().FetchEntries()
+		err = storage.Query(query)
 		assert.NoError(t, err)
-		assert.Len(t, entries, 2)
-		assert.EqualValues(t, []SettlementHistoryEntry{entry2, entry1}, entries)
+		assert.Len(t, query.Entries, 2)
+		assert.EqualValues(t, []SettlementHistoryEntry{entry2, entry1}, query.Entries)
 	})
 }

--- a/session/pingpong/settlement_history_storage_test.go
+++ b/session/pingpong/settlement_history_storage_test.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/core/storage/boltdb"
@@ -39,16 +40,29 @@ func TestSettlementHistoryStorage(t *testing.T) {
 	assert.NoError(t, err)
 	defer bolt.Close()
 
-	storage := NewSettlementHistoryStorage(bolt, 3)
+	storage := NewSettlementHistoryStorage(bolt)
 
 	accountantID := common.HexToAddress("0x3313189b9b945DD38E7bfB6167F9909451582eE5")
 	providerID := identity.FromAddress("0x79bb2a1c5E0075005F084a66A44D5e930A88eC86")
-	entry := SettlementHistoryEntry{
-		TxHash:       common.BigToHash(big.NewInt(123123123)),
+	entry1 := SettlementHistoryEntry{
+		TxHash:       common.BigToHash(big.NewInt(1)),
+		ProviderID:   providerID,
+		AccountantID: accountantID,
+		Time:         time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC),
 		Promise:      crypto.Promise{},
 		Beneficiary:  common.HexToAddress("0x4443189b9b945DD38E7bfB6167F9909451582eE5"),
 		Amount:       big.NewInt(123),
 		TotalSettled: big.NewInt(321),
+	}
+	entry2 := SettlementHistoryEntry{
+		TxHash:       common.BigToHash(big.NewInt(2)),
+		ProviderID:   providerID,
+		AccountantID: accountantID,
+		Time:         time.Date(2020, 1, 1, 2, 0, 0, 0, time.UTC),
+		Promise:      crypto.Promise{},
+		Beneficiary:  common.HexToAddress("0x4443189b9b945DD38E7bfB6167F9909451582eE5"),
+		Amount:       big.NewInt(456),
+		TotalSettled: big.NewInt(654),
 	}
 
 	t.Run("Returns not found if no results exist", func(t *testing.T) {
@@ -58,7 +72,7 @@ func TestSettlementHistoryStorage(t *testing.T) {
 	})
 
 	t.Run("Inserts a history entry successfully", func(t *testing.T) {
-		err := storage.Store(providerID, accountantID, entry)
+		err := storage.Store(entry1)
 		assert.NoError(t, err)
 	})
 
@@ -66,34 +80,16 @@ func TestSettlementHistoryStorage(t *testing.T) {
 		entries, err := storage.Get(providerID, accountantID)
 		assert.NoError(t, err)
 		assert.Len(t, entries, 1)
-
-		assert.NotEqual(t, entry.Time, entries[0].Time)
-		copy := entry
-		copy.Time = entries[0].Time
-		assert.EqualValues(t, copy, entries[0])
-	})
-
-	t.Run("Overrides old values if limit exceeded", func(t *testing.T) {
-		err = storage.Store(providerID, accountantID, SettlementHistoryEntry{})
-		assert.NoError(t, err)
-		err = storage.Store(providerID, accountantID, SettlementHistoryEntry{})
-		assert.NoError(t, err)
-		err = storage.Store(providerID, accountantID, SettlementHistoryEntry{})
-		assert.NoError(t, err)
-		err = storage.Store(providerID, accountantID, SettlementHistoryEntry{})
-		assert.NoError(t, err)
-
-		entries, err := storage.Get(providerID, accountantID)
-		assert.NoError(t, err)
-		assert.Len(t, entries, 3)
+		assert.EqualValues(t, []SettlementHistoryEntry{entry1}, entries)
 	})
 
 	t.Run("Returns sorted results", func(t *testing.T) {
+		err := storage.Store(entry2)
+		assert.NoError(t, err)
+
 		entries, err := storage.Get(providerID, accountantID)
 		assert.NoError(t, err)
-		assert.Len(t, entries, 3)
-
-		assert.True(t, entries[0].Time.After(entries[1].Time))
-		assert.True(t, entries[1].Time.After(entries[2].Time))
+		assert.Len(t, entries, 2)
+		assert.EqualValues(t, []SettlementHistoryEntry{entry2, entry1}, entries)
 	})
 }

--- a/session/pingpong/settlement_history_storage_test.go
+++ b/session/pingpong/settlement_history_storage_test.go
@@ -66,11 +66,10 @@ func TestSettlementHistoryStorage(t *testing.T) {
 	}
 
 	t.Run("Returns empty list if no results exist", func(t *testing.T) {
-		query := NewSettlementHistoryQuery().FetchEntries()
-
-		err := storage.Query(query)
+		entries, err := storage.List(SettlementHistoryFilter{})
 		assert.NoError(t, err)
-		assert.Len(t, query.Entries, 0)
+		assert.Len(t, entries, 0)
+		assert.EqualValues(t, []SettlementHistoryEntry{}, entries)
 	})
 
 	t.Run("Inserts a history entry successfully", func(t *testing.T) {
@@ -79,21 +78,19 @@ func TestSettlementHistoryStorage(t *testing.T) {
 	})
 
 	t.Run("Fetches the inserted entry", func(t *testing.T) {
-		query := NewSettlementHistoryQuery().FetchEntries()
-		err := storage.Query(query)
+		entries, err := storage.List(SettlementHistoryFilter{})
 		assert.NoError(t, err)
-		assert.Len(t, query.Entries, 1)
-		assert.EqualValues(t, []SettlementHistoryEntry{entry1}, query.Entries)
+		assert.Len(t, entries, 1)
+		assert.EqualValues(t, []SettlementHistoryEntry{entry1}, entries)
 	})
 
 	t.Run("Returns sorted results", func(t *testing.T) {
 		err := storage.Store(entry2)
 		assert.NoError(t, err)
 
-		query := NewSettlementHistoryQuery().FetchEntries()
-		err = storage.Query(query)
+		entries, err := storage.List(SettlementHistoryFilter{})
 		assert.NoError(t, err)
-		assert.Len(t, query.Entries, 2)
-		assert.EqualValues(t, []SettlementHistoryEntry{entry2, entry1}, query.Entries)
+		assert.Len(t, entries, 2)
+		assert.EqualValues(t, []SettlementHistoryEntry{entry2, entry1}, entries)
 	})
 }

--- a/tequilapi/contract/transactor.go
+++ b/tequilapi/contract/transactor.go
@@ -21,10 +21,14 @@ import (
 	"time"
 
 	"github.com/mysteriumnetwork/node/session/pingpong"
+	"github.com/vcraescu/go-paginator"
 )
 
 // NewSettlementListResponse maps to API settlement list.
-func NewSettlementListResponse(settlements []pingpong.SettlementHistoryEntry) ListSettlementsResponse {
+func NewSettlementListResponse(
+	settlements []pingpong.SettlementHistoryEntry,
+	paginator *paginator.Paginator,
+) ListSettlementsResponse {
 	dtoArray := make([]SettlementDTO, len(settlements))
 	for i, settlement := range settlements {
 		dtoArray[i] = NewSettlementDTO(settlement)
@@ -32,6 +36,7 @@ func NewSettlementListResponse(settlements []pingpong.SettlementHistoryEntry) Li
 
 	return ListSettlementsResponse{
 		Settlements: dtoArray,
+		Paging:      NewPagingDTO(paginator),
 	}
 }
 
@@ -39,6 +44,7 @@ func NewSettlementListResponse(settlements []pingpong.SettlementHistoryEntry) Li
 // swagger:model ListSettlementsResponse
 type ListSettlementsResponse struct {
 	Settlements []SettlementDTO `json:"settlements"`
+	Paging      PagingDTO       `json:"paging"`
 }
 
 // NewSettlementDTO maps to API settlement.

--- a/tequilapi/contract/transactor.go
+++ b/tequilapi/contract/transactor.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+import (
+	"time"
+
+	"github.com/mysteriumnetwork/node/session/pingpong"
+)
+
+// NewSettlementListResponse maps to API settlement list.
+func NewSettlementListResponse(settlements []pingpong.SettlementHistoryEntry) ListSettlementsResponse {
+	dtoArray := make([]SettlementDTO, len(settlements))
+	for i, settlement := range settlements {
+		dtoArray[i] = NewSettlementDTO(settlement)
+	}
+
+	return ListSettlementsResponse{
+		Settlements: dtoArray,
+	}
+}
+
+// ListSettlementsResponse defines settlement list representable as json.
+// swagger:model ListSettlementsResponse
+type ListSettlementsResponse struct {
+	Settlements []SettlementDTO `json:"settlements"`
+}
+
+// NewSettlementDTO maps to API settlement.
+func NewSettlementDTO(settlement pingpong.SettlementHistoryEntry) SettlementDTO {
+	return SettlementDTO{
+		TxHash:         settlement.TxHash.Hex(),
+		ProviderID:     settlement.ProviderID.Address,
+		AccountantID:   settlement.AccountantID.Hex(),
+		ChannelAddress: settlement.ChannelAddress.Hex(),
+		Beneficiary:    settlement.Beneficiary.Hex(),
+		Amount:         settlement.Amount.Uint64(),
+		At:             settlement.Time.Format(time.RFC3339),
+	}
+}
+
+// SettlementDTO represents the settlement object.
+// swagger:model SettlementDTO
+type SettlementDTO struct {
+	// example: 0x20c070a9be65355adbd2ba479e095e2e8ed7e692596548734984eab75d3fdfa5
+	TxHash string `json:"tx_hash" storm:"id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	ProviderID string `json:"provider_id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	AccountantID string `json:"accountant_id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	ChannelAddress string `json:"channel_address"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	Beneficiary string `json:"beneficiary"`
+
+	// example: 500000
+	Amount uint64 `json:"amount"`
+
+	// example: 2019-06-06T11:04:43.910035Z
+	At string `json:"at"`
+}

--- a/tequilapi/contract/transactor.go
+++ b/tequilapi/contract/transactor.go
@@ -56,7 +56,7 @@ func NewSettlementDTO(settlement pingpong.SettlementHistoryEntry) SettlementDTO 
 		ChannelAddress: settlement.ChannelAddress.Hex(),
 		Beneficiary:    settlement.Beneficiary.Hex(),
 		Amount:         settlement.Amount.Uint64(),
-		At:             settlement.Time.Format(time.RFC3339),
+		SettledAt:      settlement.Time.Format(time.RFC3339),
 	}
 }
 
@@ -82,5 +82,5 @@ type SettlementDTO struct {
 	Amount uint64 `json:"amount"`
 
 	// example: 2019-06-06T11:04:43.910035Z
-	At string `json:"at"`
+	SettledAt string `json:"settled_at"`
 }

--- a/tequilapi/endpoints/sessions.go
+++ b/tequilapi/endpoints/sessions.go
@@ -51,11 +51,11 @@ func NewSessionsEndpoint(sessionStorage sessionStorage) *sessionsEndpoint {
 // description: Returns list of sessions history
 // parameters:
 //   - in: query
-//     name: create_from
+//     name: date_from
 //     description: Created date to filter the sessions from this date. Formatted in RFC3339 e.g. 2020-07-01T00:00:00Z.
 //     type: string
 //   - in: query
-//     name: create_to
+//     name: date_to
 //     description: Created date to filter the sessions until this date. Formatted in RFC3339 e.g. 2020-07-01T00:00:00Z.
 //     type: string
 //   - in: query
@@ -90,25 +90,25 @@ func NewSessionsEndpoint(sessionStorage sessionStorage) *sessionsEndpoint {
 func (endpoint *sessionsEndpoint) List(resp http.ResponseWriter, request *http.Request, _ httprouter.Params) {
 	query := session.NewQuery()
 
-	from := time.Now().AddDate(0, 0, -30)
-	if fromStr := request.URL.Query().Get("create_from"); fromStr != "" {
+	dateFrom := time.Now().AddDate(0, 0, -30)
+	if fromStr := request.URL.Query().Get("date_from"); fromStr != "" {
 		var err error
-		if from, err = time.Parse(time.RFC3339, fromStr); err != nil {
+		if dateFrom, err = time.Parse(time.RFC3339, fromStr); err != nil {
 			utils.SendError(resp, err, http.StatusBadRequest)
 			return
 		}
 	}
-	query.FilterFrom(from)
+	query.FilterFrom(dateFrom)
 
-	to := time.Now()
-	if toStr := request.URL.Query().Get("created_to"); toStr != "" {
+	dateTo := time.Now()
+	if toStr := request.URL.Query().Get("date_to"); toStr != "" {
 		var err error
-		if to, err = time.Parse(time.RFC3339, toStr); err != nil {
+		if dateTo, err = time.Parse(time.RFC3339, toStr); err != nil {
 			utils.SendError(resp, err, http.StatusBadRequest)
 			return
 		}
 	}
-	query.FilterTo(to)
+	query.FilterTo(dateTo)
 
 	if direction := request.URL.Query().Get("direction"); direction != "" {
 		query.FilterDirection(direction)

--- a/tequilapi/endpoints/transactor.go
+++ b/tequilapi/endpoints/transactor.go
@@ -312,11 +312,11 @@ func (te *transactorEndpoint) SetBeneficiary(resp http.ResponseWriter, request *
 // description: Returns settlement history
 // parameters:
 //   - in: query
-//     name: at_from
+//     name: date_from
 //     description: To filter the settlements from this date. Formatted in RFC3339 e.g. 2020-07-01T00:00:00Z.
 //     type: string
 //   - in: query
-//     name: at_to
+//     name: date_to
 //     description: To filter the settlements until this date. Formatted in RFC3339 e.g. 2020-07-01T00:00:00Z.
 //     type: string
 //   - in: query
@@ -343,25 +343,25 @@ func (te *transactorEndpoint) SetBeneficiary(resp http.ResponseWriter, request *
 func (te *transactorEndpoint) SettlementHistory(resp http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	query := pingpong.NewSettlementHistoryQuery()
 
-	from := time.Now().AddDate(0, 0, -30)
-	if fromStr := req.URL.Query().Get("at_from"); fromStr != "" {
+	dateFrom := time.Now().AddDate(0, 0, -30)
+	if fromStr := req.URL.Query().Get("settled_at_from"); fromStr != "" {
 		var err error
-		if from, err = time.Parse(time.RFC3339, fromStr); err != nil {
+		if dateFrom, err = time.Parse(time.RFC3339, fromStr); err != nil {
 			utils.SendError(resp, err, http.StatusBadRequest)
 			return
 		}
 	}
-	query.FilterFrom(from)
+	query.FilterFrom(dateFrom)
 
-	to := time.Now()
-	if toStr := req.URL.Query().Get("at_to"); toStr != "" {
+	dateTo := time.Now()
+	if toStr := req.URL.Query().Get("settled_at_to"); toStr != "" {
 		var err error
-		if to, err = time.Parse(time.RFC3339, toStr); err != nil {
+		if dateTo, err = time.Parse(time.RFC3339, toStr); err != nil {
 			utils.SendError(resp, err, http.StatusBadRequest)
 			return
 		}
 	}
-	query.FilterTo(to)
+	query.FilterTo(dateTo)
 
 	if providerID := req.URL.Query().Get("provider_id"); providerID != "" {
 		query.FilterProviderID(identity.FromAddress(providerID))

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -386,7 +386,6 @@ type settlementHistoryProviderMock struct {
 	errToReturn               error
 }
 
-func (shpm *settlementHistoryProviderMock) Query(query *pingpong.SettlementHistoryQuery) error {
-	query.Entries = shpm.settlementHistoryToReturn
-	return shpm.errToReturn
+func (shpm *settlementHistoryProviderMock) List(_ pingpong.SettlementHistoryFilter) ([]pingpong.SettlementHistoryEntry, error) {
+	return shpm.settlementHistoryToReturn, shpm.errToReturn
 }

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -308,7 +308,7 @@ func Test_SettleHistory(t *testing.T) {
 						"channel_address": "0x0000000000000000000000000000000000000000",
 						"beneficiary":"0x4443189b9B945dD38e7bfB6167F9909451582EE5",
 						"amount": 123,
-						"at": "2020-01-02T03:04:05Z"
+						"settled_at": "2020-01-02T03:04:05Z"
 					},
 					{
 						"tx_hash": "0x9eea5c4da8a67929d5dd5d8b6dedb3bd44e7bd3ec299f8972f3212db8afb938a",
@@ -317,7 +317,7 @@ func Test_SettleHistory(t *testing.T) {
 						"channel_address": "0x0000000000000000000000000000000000000000",
 						"beneficiary": "0x0000000000000000000000000000000000000000",
 						"amount": 456,
-						"at": "2020-06-07T08:09:10Z"
+						"settled_at": "2020-06-07T08:09:10Z"
 					}
 				],
 				"paging": {

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -319,7 +319,14 @@ func Test_SettleHistory(t *testing.T) {
 						"amount": 456,
 						"at": "2020-06-07T08:09:10Z"
 					}
-				]
+				],
+				"paging": {
+					"total_items": 2,
+					"total_pages": 1,
+					"current_page": 1,
+					"previous_page": null,
+					"next_page": null
+				}
 			}`,
 			resp.Body.String(),
 		)

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -19,12 +19,13 @@ package endpoints
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/julienschmidt/httprouter"
@@ -241,50 +242,6 @@ func Test_SettleSync_ReturnsError(t *testing.T) {
 }
 
 func Test_SettleHistory(t *testing.T) {
-	t.Run("returns error on missing providerID", func(t *testing.T) {
-		mockResponse := ""
-		server := newTestTransactorServer(http.StatusAccepted, mockResponse)
-		defer server.Close()
-
-		router := httprouter.New()
-		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", fakeSignerFactory, mocks.NewEventBus(), nil)
-		AddRoutesForTransactor(router, tr, nil, &settlementHistoryProviderMock{})
-
-		req, err := http.NewRequest(
-			http.MethodGet,
-			"/transactor/settle/history",
-			nil,
-		)
-		assert.Nil(t, err)
-
-		resp := httptest.NewRecorder()
-		router.ServeHTTP(resp, req)
-
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.JSONEq(t, `{"message":"providerID is required"}`, resp.Body.String())
-	})
-	t.Run("returns error on missing accountantID", func(t *testing.T) {
-		mockResponse := ""
-		server := newTestTransactorServer(http.StatusAccepted, mockResponse)
-		defer server.Close()
-
-		router := httprouter.New()
-		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", fakeSignerFactory, mocks.NewEventBus(), nil)
-		AddRoutesForTransactor(router, tr, nil, &settlementHistoryProviderMock{})
-
-		req, err := http.NewRequest(
-			http.MethodGet,
-			"/transactor/settle/history?providerID=0xbe180c8CA53F280C7BE8669596fF7939d933AA10",
-			nil,
-		)
-		assert.Nil(t, err)
-
-		resp := httptest.NewRecorder()
-		router.ServeHTTP(resp, req)
-
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.JSONEq(t, `{"message":"accountantID is required"}`, resp.Body.String())
-	})
 	t.Run("returns error on failed history retrieval", func(t *testing.T) {
 		mockResponse := ""
 		server := newTestTransactorServer(http.StatusAccepted, mockResponse)
@@ -308,17 +265,26 @@ func Test_SettleHistory(t *testing.T) {
 		assert.JSONEq(t, `{"message":"explosions everywhere"}`, resp.Body.String())
 	})
 	t.Run("returns settlement history", func(t *testing.T) {
-		expectedJSON := `[{"time":"2020-05-26T09:12:32.475904Z","tx_hash":"0x88af51047ff2da1e3626722fe239f70c3ddd668f067b2ac8d67b280d2eff39f7","promise":{"ChannelID":"+6pGXXkM8mIuwjZ72JNukxcqE1UkhbC47Ijg4UqurJY=","Amount":30245,"Fee":0,"Hashlock":"6RauIa1dz9pXOca788BIJigdgIzWVbn9k3VXZLvp2gM=","R":"qhLbkT/xKQFxvf7bE66yA/mr4LY5WEnqP/280KnNHi8=","Signature":"pqHSWofpfM7cUZ2KfhKmzd+iyxs6xsbWqXOkO0noCRwEfHHZtAP2S9E+sE72m2bFQmTtPB8mzQ6X0aNrn9h39Rw="},"beneficiary":"0x0000000000000000000000000000000000000000","amount":30091,"total_settled":30245},{"time":"2020-05-26T08:15:58.386698Z","tx_hash":"0x9eea5c4da8a67929d5dd5d8b6dedb3bd44e7bd3ec299f8972f3212db8afb938a","promise":{"ChannelID":"+6pGXXkM8mIuwjZ72JNukxcqE1UkhbC47Ijg4UqurJY=","Amount":154,"Fee":0,"Hashlock":"wIAKURZIMqlrlyjXNOX+Y8xIDyPSBZuMFU37bNJrRNQ=","R":"PqnMB6sYiwgM+pPdnk5Q8TOw93E78M7aFz1G2DkBKJE=","Signature":"elsD3ennGajAjUg7Ky4M4+8Olde2V2vNwm2v1c5pqQs/6V0mY7ECPLUzsU8dGKKI5EceFUVGqTnKrcLIUwRY6xs="},"beneficiary":"0x0000000000000000000000000000000000000000","amount":154,"total_settled":154}]`
-		res := []pingpong.SettlementHistoryEntry{}
-		err := json.Unmarshal([]byte(expectedJSON), &res)
-		assert.Nil(t, err)
-		mockResponse := ""
-		server := newTestTransactorServer(http.StatusAccepted, mockResponse)
+		mockStorage := &settlementHistoryProviderMock{settlementHistoryToReturn: []pingpong.SettlementHistoryEntry{
+			{
+				TxHash:      common.HexToHash("0x88af51047ff2da1e3626722fe239f70c3ddd668f067b2ac8d67b280d2eff39f7"),
+				Time:        time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC),
+				Beneficiary: common.HexToAddress("0x4443189b9b945DD38E7bfB6167F9909451582eE5"),
+				Amount:      big.NewInt(123),
+			},
+			{
+				TxHash: common.HexToHash("0x9eea5c4da8a67929d5dd5d8b6dedb3bd44e7bd3ec299f8972f3212db8afb938a"),
+				Time:   time.Date(2020, 6, 7, 8, 9, 10, 0, time.UTC),
+				Amount: big.NewInt(456),
+			},
+		}}
+
+		server := newTestTransactorServer(http.StatusAccepted, "")
 		defer server.Close()
 
 		router := httprouter.New()
 		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", fakeSignerFactory, mocks.NewEventBus(), nil)
-		AddRoutesForTransactor(router, tr, nil, &settlementHistoryProviderMock{settlementHistoryToReturn: res})
+		AddRoutesForTransactor(router, tr, nil, mockStorage)
 
 		req, err := http.NewRequest(
 			http.MethodGet,
@@ -331,7 +297,32 @@ func Test_SettleHistory(t *testing.T) {
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.JSONEq(t, expectedJSON, resp.Body.String())
+		assert.JSONEq(
+			t,
+			`{
+				"settlements": [
+					{
+						"tx_hash": "0x88af51047ff2da1e3626722fe239f70c3ddd668f067b2ac8d67b280d2eff39f7",
+						"provider_id": "",
+						"accountant_id": "0x0000000000000000000000000000000000000000",
+						"channel_address": "0x0000000000000000000000000000000000000000",
+						"beneficiary":"0x4443189b9B945dD38e7bfB6167F9909451582EE5",
+						"amount": 123,
+						"at": "2020-01-02T03:04:05Z"
+					},
+					{
+						"tx_hash": "0x9eea5c4da8a67929d5dd5d8b6dedb3bd44e7bd3ec299f8972f3212db8afb938a",
+						"provider_id": "",
+						"accountant_id": "0x0000000000000000000000000000000000000000",
+						"channel_address": "0x0000000000000000000000000000000000000000",
+						"beneficiary": "0x0000000000000000000000000000000000000000",
+						"amount": 456,
+						"at": "2020-06-07T08:09:10Z"
+					}
+				]
+			}`,
+			resp.Body.String(),
+		)
 	})
 }
 
@@ -388,6 +379,7 @@ type settlementHistoryProviderMock struct {
 	errToReturn               error
 }
 
-func (shpm *settlementHistoryProviderMock) Get(provider identity.Identity, accountant common.Address) ([]pingpong.SettlementHistoryEntry, error) {
-	return shpm.settlementHistoryToReturn, shpm.errToReturn
+func (shpm *settlementHistoryProviderMock) Query(query *pingpong.SettlementHistoryQuery) error {
+	query.Entries = shpm.settlementHistoryToReturn
+	return shpm.errToReturn
 }


### PR DESCRIPTION
Closes: #2524

Starting to store settlements of your identities with more fields: `providerID`, `accountantID`, `channelAddress`, `beneficiary`.
Also exposing them in paginated Tequilapi endpoint `/transactor/settle/history`.