### PR TITLE
Provider sends 1st invoice wo delay

### DIFF
--- a/core/service/manager.go
+++ b/core/service/manager.go
@@ -148,6 +148,7 @@ func (manager *Manager) Start(providerID identity.Identity, serviceType string, 
 		subscribeSessionStatus(ch, manager.statusStorage)
 		subscribeSessionAcknowledge(mng, ch)
 		subscribeSessionDestroy(mng, ch)
+		subscribeSessionPayments(mng, ch)
 	}
 	stopP2PListener, err := manager.p2pListener.Listen(providerID, serviceType, channelHandlers)
 	if err != nil {

--- a/core/service/session_manager.go
+++ b/core/service/session_manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mysteriumnetwork/node/pb"
 	"github.com/mysteriumnetwork/node/session"
 	sevent "github.com/mysteriumnetwork/node/session/event"
+	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -102,7 +103,7 @@ type PromiseProcessor interface {
 }
 
 // PaymentEngineFactory creates a new instance of payment engine
-type PaymentEngineFactory func(providerID, consumerID identity.Identity, accountantID common.Address, sessionID string) (PaymentEngine, error)
+type PaymentEngineFactory func(providerID, consumerID identity.Identity, accountantID common.Address, sessionID string, exchangeChan chan crypto.ExchangeMessage) (PaymentEngine, error)
 
 // PaymentEngine is responsible for interacting with the consumer in regard to payments.
 type PaymentEngine interface {
@@ -132,6 +133,7 @@ func NewSessionManager(
 		natEventGetter:       natEventGetter,
 		publisher:            publisher,
 		paymentEngineFactory: paymentEngineFactory,
+		paymentEngineChan:    make(chan crypto.ExchangeMessage, 1),
 		channel:              channel,
 		config:               config,
 	}
@@ -142,6 +144,7 @@ type SessionManager struct {
 	service              *Instance
 	sessionStorage       *SessionPool
 	paymentEngineFactory PaymentEngineFactory
+	paymentEngineChan    chan crypto.ExchangeMessage
 	natEventGetter       NATEventGetter
 	publisher            publisher
 	channel              p2p.Channel
@@ -260,7 +263,7 @@ func (manager *SessionManager) paymentLoop(session *Session) error {
 	defer session.tracer.EndStage(trace)
 
 	log.Info().Msg("Using new payments")
-	engine, err := manager.paymentEngineFactory(manager.service.ProviderID, session.ConsumerID, session.AccountantID, string(session.ID))
+	engine, err := manager.paymentEngineFactory(manager.service.ProviderID, session.ConsumerID, session.AccountantID, string(session.ID), manager.paymentEngineChan)
 	if err != nil {
 		return err
 	}

--- a/core/service/session_manager_test.go
+++ b/core/service/session_manager_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mysteriumnetwork/node/pb"
 	sessionEvent "github.com/mysteriumnetwork/node/session/event"
 	"github.com/mysteriumnetwork/node/trace"
+	"github.com/mysteriumnetwork/payments/crypto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -317,7 +318,7 @@ func newManager(service *Instance, sessions *SessionPool, publisher publisher, p
 	return NewSessionManager(
 		service,
 		sessions,
-		func(_, _ identity.Identity, _ common.Address, _ string) (PaymentEngine, error) {
+		func(_, _ identity.Identity, _ common.Address, _ string, _ chan crypto.ExchangeMessage) (PaymentEngine, error) {
 			return paymentEngine, nil
 		},
 		&MockNatEventTracker{},

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -121,8 +121,6 @@ func InvoiceFactoryCreator(
 			ChargePeriodLeeway:         2 * time.Minute,
 			ExchangeMessageChan:        exchangeChan,
 			ExchangeMessageWaitTimeout: promiseTimeout,
-			FirstInvoiceSendTimeout:    10 * time.Second,
-			FirstInvoiceSendDuration:   1 * time.Second,
 			ProviderID:                 providerID,
 			ConsumersAccountantID:      accountantID,
 			ProvidersAccountantID:      providersAccountant,

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -108,12 +108,8 @@ func InvoiceFactoryCreator(
 	proposal market.ServiceProposal,
 	promiseHandler promiseHandler,
 	providersAccountant common.Address,
-) func(identity.Identity, identity.Identity, common.Address, string) (service.PaymentEngine, error) {
-	return func(providerID, consumerID identity.Identity, accountantID common.Address, sessionID string) (service.PaymentEngine, error) {
-		exchangeChan, err := exchangeMessageReceiver(channel)
-		if err != nil {
-			return nil, err
-		}
+) func(identity.Identity, identity.Identity, common.Address, string, chan crypto.ExchangeMessage) (service.PaymentEngine, error) {
+	return func(providerID, consumerID identity.Identity, accountantID common.Address, sessionID string, exchangeChan chan crypto.ExchangeMessage) (service.PaymentEngine, error) {
 		timeTracker := session.NewTracker(mbtime.Now)
 		deps := InvoiceTrackerDeps{
 			Proposal:                   proposal,

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -19,7 +19,6 @@ package pingpong
 
 import (
 	"encoding/hex"
-	stdErrors "errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -33,7 +32,6 @@ import (
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/mysteriumnetwork/node/mocks"
 	"github.com/mysteriumnetwork/node/money"
-	"github.com/mysteriumnetwork/node/p2p"
 	"github.com/mysteriumnetwork/node/session"
 	"github.com/mysteriumnetwork/node/session/mbtime"
 	"github.com/mysteriumnetwork/payments/crypto"
@@ -104,8 +102,6 @@ func Test_InvoiceTracker_Start_Stop(t *testing.T) {
 		ChargePeriod:               time.Nanosecond,
 		ChargePeriodLeeway:         15 * time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
-		FirstInvoiceSendDuration:   time.Nanosecond,
-		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
 		ConsumersAccountantID:      acc.Address,
@@ -265,8 +261,6 @@ func Test_InvoiceTracker_BubblesErrors(t *testing.T) {
 		TimeTracker:                &tracker,
 		ChargePeriod:               time.Millisecond,
 		ChargePeriodLeeway:         15 * time.Minute,
-		FirstInvoiceSendDuration:   time.Millisecond,
-		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
@@ -327,8 +321,6 @@ func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
 		TimeTracker:                &tracker,
 		ChargePeriod:               time.Nanosecond,
 		ChargePeriodLeeway:         15 * time.Minute,
-		FirstInvoiceSendDuration:   time.Nanosecond,
-		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
@@ -351,62 +343,6 @@ func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
 
 	invoiceTracker.Stop()
 	assert.NoError(t, <-errChan)
-}
-
-func Test_InvoiceTracker_SendsFirstInvoice_Return_Timeout_Err(t *testing.T) {
-	dir, err := ioutil.TempDir("", "invoice_tracker_test")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
-
-	ks := identity.NewMockKeystore()
-	acc, err := ks.NewAccount("")
-	assert.Nil(t, err)
-	mockSender := &MockPeerInvoiceSender{
-		mockError: p2p.ErrSendTimeout,
-	}
-
-	exchangeMessageChan := make(chan crypto.ExchangeMessage)
-	bolt, err := boltdb.NewStorage(dir)
-	assert.Nil(t, err)
-	defer bolt.Close()
-
-	tracker := session.NewTracker(mbtime.Now)
-	invoiceStorage := NewProviderInvoiceStorage(NewInvoiceStorage(bolt))
-	deps := InvoiceTrackerDeps{
-		Proposal: market.ServiceProposal{
-			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(1000000000000, money.CurrencyMyst),
-				rate:  market.PaymentRate{PerTime: time.Minute},
-			},
-		},
-		Peer:                       identity.FromAddress("some peer"),
-		PeerInvoiceSender:          mockSender,
-		InvoiceStorage:             invoiceStorage,
-		TimeTracker:                &tracker,
-		ChargePeriod:               time.Nanosecond,
-		ChargePeriodLeeway:         5 * time.Nanosecond,
-		FirstInvoiceSendDuration:   time.Millisecond,
-		FirstInvoiceSendTimeout:    time.Nanosecond,
-		ExchangeMessageChan:        exchangeMessageChan,
-		ExchangeMessageWaitTimeout: time.Second,
-		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
-		ConsumersAccountantID:      acc.Address,
-		ProvidersAccountantID:      acc.Address,
-		ChannelAddressCalculator:   NewChannelAddressCalculator(acc.Address.Hex(), acc.Address.Hex(), acc.Address.Hex()),
-		BlockchainHelper:           &mockBlockchainHelper{isRegistered: true},
-		EventBus:                   mocks.NewEventBus(),
-	}
-	invoiceTracker := NewInvoiceTracker(deps)
-	defer invoiceTracker.Stop()
-
-	errChan := make(chan error)
-	go func() { errChan <- invoiceTracker.Start() }()
-
-	err = <-errChan
-
-	if !stdErrors.Is(err, ErrFirstInvoiceSendTimeout) {
-		t.Fatalf("expected err %v, got: %v", ErrFirstInvoiceSendTimeout, err)
-	}
 }
 
 func Test_InvoiceTracker_FirstInvoice_Has_Static_Value(t *testing.T) {
@@ -441,8 +377,6 @@ func Test_InvoiceTracker_FirstInvoice_Has_Static_Value(t *testing.T) {
 		TimeTracker:                &tracker,
 		ChargePeriod:               time.Nanosecond,
 		ChargePeriodLeeway:         15 * time.Minute,
-		FirstInvoiceSendDuration:   time.Nanosecond,
-		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),
@@ -493,8 +427,6 @@ func Test_InvoiceTracker_FreeServiceSendsInvoices(t *testing.T) {
 		TimeTracker:                &tracker,
 		ChargePeriod:               time.Nanosecond,
 		ChargePeriodLeeway:         15 * time.Second,
-		FirstInvoiceSendDuration:   time.Nanosecond,
-		FirstInvoiceSendTimeout:    time.Minute,
 		ExchangeMessageChan:        exchangeMessageChan,
 		ExchangeMessageWaitTimeout: time.Second,
 		ProviderID:                 identity.FromAddress(acc.Address.Hex()),


### PR DESCRIPTION
Optimising provider lag on session establishment by removing sleep before provider sends 1st invoice. Also subscribe P2P payment messages earlier.

Before:
```
Provider connection trace: "Provider whole session create" took 1.47595767s, "Provider session start" took 31.068551ms, "Provider payments" took 1.328130467s, "Provider config" took 116.749528ms
```

After:
```
Provider connection trace: "Provider whole session create" took 386.80665ms, "Provider session start" took 33.366328ms, "Provider payments" took 273.28457ms, "Provider config" took 80.151728ms
```