### PR TITLE
Remove excessive eventBus publish routine

### DIFF
--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -783,7 +783,7 @@ func (m *connectionManager) setupTrafficBlock(disableKillSwitch bool) error {
 }
 
 func (m *connectionManager) publishStateEvent(state connectionstate.State) {
-	go m.eventBus.Publish(connectionstate.AppTopicConnectionState, connectionstate.AppEventConnectionState{
+	m.eventBus.Publish(connectionstate.AppTopicConnectionState, connectionstate.AppEventConnectionState{
 		State:       state,
 		SessionInfo: m.Status(),
 	})

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -217,7 +217,7 @@ func (tc *testContext) TestSessionDoesFullReconnectOnWakeupEvent() {
 	)
 
 	stateCh := make(chan connectionstate.State, 2)
-	tc.connManager.eventBus.SubscribeAsync(connectionstate.AppTopicConnectionState, func(e connectionstate.AppEventConnectionState) {
+	tc.connManager.eventBus.Subscribe(connectionstate.AppTopicConnectionState, func(e connectionstate.AppEventConnectionState) {
 		fmt.Println("got state: ", e)
 
 		if e.State == connectionstate.Connecting {


### PR DESCRIPTION
In tests we get race conditions with published event sequences when order is important. Launching Publish events in separate routine negates the purpose of SubscribeAsync.
