### PR TITLE
Reduce pinger intervals

### DIFF
--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -228,7 +228,7 @@ func (m *connectionManager) Connect(consumerID identity.Identity, hermesID commo
 
 	channel, err := m.createP2PChannel(m.currentCtx(), consumerID, providerID, proposal.ServiceType, contact)
 	if err != nil {
-		return fmt.Errorf("could not create p2p channel: %w", err)
+		return fmt.Errorf("could not create p2p channel during connect: %w", err)
 	}
 	m.channel = channel
 	tracer.EndStage(p2pChannelTrace)
@@ -415,7 +415,7 @@ func (m *connectionManager) createP2PChannel(ctx context.Context, consumerID, pr
 
 	channel, err := m.p2pDialer.Dial(timeoutCtx, consumerID, providerID, serviceType, contactDef)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("p2p dialer failed: %w", err)
 	}
 	m.addCleanupAfterDisconnect(func() error {
 		log.Trace().Msg("Cleaning: closing P2P communication channel")

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -66,9 +66,9 @@ type PingConfig struct {
 // DefaultPingConfig returns default NAT pinger config.
 func DefaultPingConfig() *PingConfig {
 	return &PingConfig{
-		Interval:            50 * time.Millisecond,
+		Interval:            5 * time.Millisecond,
 		Timeout:             10 * time.Second,
-		SendConnACKInterval: 200 * time.Millisecond,
+		SendConnACKInterval: 20 * time.Millisecond,
 	}
 }
 

--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -68,7 +68,7 @@ func DefaultPingConfig() *PingConfig {
 	return &PingConfig{
 		Interval:            5 * time.Millisecond,
 		Timeout:             10 * time.Second,
-		SendConnACKInterval: 20 * time.Millisecond,
+		SendConnACKInterval: 100 * time.Millisecond,
 	}
 }
 

--- a/nat/traversal/pinger_test.go
+++ b/nat/traversal/pinger_test.go
@@ -43,8 +43,8 @@ func TestPinger_Multiple_Stop(t *testing.T) {
 
 func TestPinger_PingPeer_N_Connections(t *testing.T) {
 	pingConfig := &PingConfig{
-		Interval:            50 * time.Millisecond,
-		SendConnACKInterval: 50 * time.Millisecond,
+		Interval:            5 * time.Millisecond,
+		SendConnACKInterval: 5 * time.Millisecond,
 		Timeout:             5 * time.Second,
 	}
 	provider := newPinger(pingConfig)

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -214,7 +214,9 @@ func (m *dialer) exchangeConfig(ctx context.Context, brokerConn nats.Connection,
 	if err != nil {
 		return nil, fmt.Errorf("could not pack signed message: %v", err)
 	}
-	_, err = m.sendSignedMsg(ctx, configExchangeACKSubject(providerID, serviceType), packedMsg, brokerConn)
+
+	err = brokerConn.Publish(configExchangeACKSubject(providerID, serviceType), packedMsg)
+
 	if err != nil {
 		return nil, fmt.Errorf("could not send signed msg: %v", err)
 	}

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -141,7 +141,7 @@ func (m *dialer) Dial(ctx context.Context, consumerID, providerID identity.Ident
 
 	channel, err := newChannel(conn1, config.privateKey, config.peerPubKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not create p2p channel: %w", err)
+		return nil, fmt.Errorf("could not create p2p channel during dial: %w", err)
 	}
 	channel.setServiceConn(conn2)
 	channel.launchReadSendLoops()
@@ -215,7 +215,11 @@ func (m *dialer) exchangeConfig(ctx context.Context, brokerConn nats.Connection,
 		return nil, fmt.Errorf("could not pack signed message: %v", err)
 	}
 
-	err = brokerConn.Publish(configExchangeACKSubject(providerID, serviceType), packedMsg)
+	// simple broker Publish will not work here since we have to delay Consumer from pinging Provider
+	//  until provider receives consumer config ( IP, ports ) and starts pinging Consumer first.
+	// This is why we use broker Request method to be sure that Provider processed our given configuration.
+	// To improve speed here investigate options to reduce broker communication round trip.
+	_, err = m.sendSignedMsg(ctx, configExchangeACKSubject(providerID, serviceType), packedMsg, brokerConn)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not send signed msg: %v", err)

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -136,7 +136,7 @@ func (m *listener) Listen(providerID identity.Identity, serviceType string, chan
 			// this might be provider / consumer performance dependent
 			// make sleep time dependent on pinger interval and wait for 2 ping iterations
 			// TODO: either reintroduce eventual increase of TTL on consumer or maintain some sane delay
-			dur := traversal.DefaultPingConfig().Interval.Milliseconds() * 2
+			dur := traversal.DefaultPingConfig().Interval.Milliseconds() * int64(len(config.localPorts)) / 2
 			log.Debug().Msgf("Delaying pings from consumer for %v ms", dur)
 			time.Sleep(time.Duration(dur) * time.Millisecond)
 


### PR DESCRIPTION
Should slice off around 1 sec in total time.  - ~300ms when using Publish method for broker.
@soffokl can you test it with long distance connections from your place? Does punching still works reliably?

UPDATE: will not use broker Publish method as we DO require ack from peer before starting to ping Provider. Provider has to start pinging first to avoid DDOS blockage on its side. 