### PR TITLE
Trace p2p channel creation times

### DIFF
--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -181,11 +181,8 @@ func NewManager(
 func (m *connectionManager) Connect(consumerID identity.Identity, hermesID common.Address, proposal market.ServiceProposal, params ConnectParams) (err error) {
 	var sessionID session.ID
 
-	tracer := trace.NewTracer()
-	connectTrace := tracer.StartStage("Consumer whole Connect")
-
+	tracer := trace.NewTracer("Consumer whole Connect")
 	defer func() {
-		tracer.EndStage(connectTrace)
 		traceResult := tracer.Finish(m.eventBus, string(sessionID))
 		log.Debug().Msgf("Consumer connection trace: %s", traceResult)
 	}()

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -220,46 +220,37 @@ func (m *connectionManager) Connect(consumerID identity.Identity, hermesID commo
 
 	providerID := identity.FromAddress(proposal.ProviderID)
 
-	p2pChannelTrace := tracer.StartStage("Consumer P2P channel creation")
-	contact, err := p2p.ParseContact(proposal.ProviderContacts)
-	if err != nil {
-		return fmt.Errorf("provider does not support p2p communication: %w", err)
-	}
-
-	channel, err := m.createP2PChannel(m.currentCtx(), consumerID, providerID, proposal.ServiceType, contact)
+	err = m.createP2PChannel(m.currentCtx(), consumerID, providerID, proposal, tracer)
 	if err != nil {
 		return fmt.Errorf("could not create p2p channel during connect: %w", err)
 	}
-	m.channel = channel
-	tracer.EndStage(p2pChannelTrace)
 
-	sessionCreateTrace := tracer.StartStage("Consumer session creation")
 	connection, err := m.newConnection(proposal.ServiceType)
 	if err != nil {
 		return err
 	}
 
-	paymentSession, err := m.launchPayments(channel, consumerID, providerID, hermesID, proposal)
+	paymentSession, err := m.paymentLoop(m.channel, consumerID, providerID, hermesID, proposal)
 	if err != nil {
 		return err
 	}
 
-	sessionDTO, err := m.createP2PSession(m.currentCtx(), connection, channel, consumerID, hermesID, proposal)
+	sessionDTO, err := m.createP2PSession(m.currentCtx(), connection, m.channel, consumerID, hermesID, proposal, tracer)
 	sessionID = session.ID(sessionDTO.GetID())
 	if err != nil {
-		m.sendSessionStatus(channel, consumerID, sessionID, connectivity.StatusSessionEstablishmentFailed, err)
+		m.sendSessionStatus(m.channel, consumerID, sessionID, connectivity.StatusSessionEstablishmentFailed, err)
 		return err
 	}
 
+	traceStart := tracer.StartStage("Consumer session creation (start)")
+	go m.keepAliveLoop(m.channel, sessionID)
 	m.setStatus(func(status *connectionstate.Status) {
 		status.SessionID = sessionID
 	})
 	m.publishSessionCreate(sessionID)
 	paymentSession.SetSessionID(string(sessionID))
-	tracer.EndStage(sessionCreateTrace)
+	tracer.EndStage(traceStart)
 
-	connectionTrace := tracer.StartStage("Consumer start connection")
-	originalPublicIP := m.getPublicIP()
 	// Try to establish connection with peer.
 	m.connectOptions = ConnectOptions{
 		SessionID:       sessionID,
@@ -268,19 +259,17 @@ func (m *connectionManager) Connect(consumerID identity.Identity, hermesID commo
 		ConsumerID:      consumerID,
 		ProviderID:      providerID,
 		Proposal:        proposal,
-		ProviderNATConn: channel.ServiceConn(),
-		ChannelConn:     channel.Conn(),
+		ProviderNATConn: m.channel.ServiceConn(),
+		ChannelConn:     m.channel.Conn(),
 		HermesID:        hermesID,
 	}
-	err = m.startConnection(m.currentCtx(), connection, m.connectOptions)
-	tracer.EndStage(connectionTrace)
-
+	err = m.startConnection(m.currentCtx(), connection, m.connectOptions, tracer)
 	if err != nil {
 		if err == context.Canceled {
 			return ErrConnectionCancelled
 		}
 		m.addCleanupAfterDisconnect(func() error {
-			return m.sendSessionStatus(channel, consumerID, sessionID, connectivity.StatusConnectionFailed, err)
+			return m.sendSessionStatus(m.channel, consumerID, sessionID, connectivity.StatusConnectionFailed, err)
 		})
 		m.publishStateEvent(connectionstate.StateConnectionFailed)
 
@@ -288,12 +277,6 @@ func (m *connectionManager) Connect(consumerID identity.Identity, hermesID commo
 		m.Cancel()
 		return err
 	}
-
-	// Clear IP cache so session IP check can report that IP has really changed.
-	m.clearIPCache()
-
-	go m.keepAliveLoop(channel, sessionID)
-	go m.checkSessionIP(channel, consumerID, sessionID, originalPublicIP)
 
 	return nil
 }
@@ -365,7 +348,7 @@ func (m *connectionManager) getPublicIP() string {
 	return currentPublicIP
 }
 
-func (m *connectionManager) launchPayments(channel p2p.Channel, consumerID, providerID identity.Identity, hermesID common.Address, proposal market.ServiceProposal) (PaymentIssuer, error) {
+func (m *connectionManager) paymentLoop(channel p2p.Channel, consumerID, providerID identity.Identity, hermesID common.Address, proposal market.ServiceProposal) (PaymentIssuer, error) {
 	payments, err := m.paymentEngineFactory(channel, consumerID, providerID, hermesID, proposal)
 	if err != nil {
 		return nil, err
@@ -377,7 +360,16 @@ func (m *connectionManager) launchPayments(channel p2p.Channel, consumerID, prov
 		return nil
 	})
 
-	go m.payForService(payments)
+	go func() {
+		err := payments.Start()
+		if err != nil {
+			log.Error().Err(err).Msg("Payment error")
+			err = m.Disconnect()
+			if err != nil {
+				log.Error().Err(err).Msg("Could not disconnect gracefully")
+			}
+		}
+	}()
 	return payments, nil
 }
 
@@ -409,13 +401,22 @@ func (m *connectionManager) cleanAfterDisconnect() {
 	m.cleanupAfterDisconnect = nil
 }
 
-func (m *connectionManager) createP2PChannel(ctx context.Context, consumerID, providerID identity.Identity, serviceType string, contactDef p2p.ContactDefinition) (p2p.Channel, error) {
+func (m *connectionManager) createP2PChannel(ctx context.Context, consumerID, providerID identity.Identity, proposal market.ServiceProposal, tracer *trace.Tracer) error {
+	trace := tracer.StartStage("Consumer P2P channel creation")
+	defer tracer.EndStage(trace)
+
+	contactDef, err := p2p.ParseContact(proposal.ProviderContacts)
+	if err != nil {
+		return fmt.Errorf("provider does not support p2p communication: %w", err)
+	}
+
 	timeoutCtx, cancel := context.WithTimeout(ctx, p2pDialTimeout)
 	defer cancel()
 
-	channel, err := m.p2pDialer.Dial(timeoutCtx, consumerID, providerID, serviceType, contactDef)
+	// TODO register all handlers before channel read/write loops
+	channel, err := m.p2pDialer.Dial(timeoutCtx, consumerID, providerID, proposal.ServiceType, contactDef, tracer)
 	if err != nil {
-		return nil, fmt.Errorf("p2p dialer failed: %w", err)
+		return fmt.Errorf("p2p dialer failed: %w", err)
 	}
 	m.addCleanupAfterDisconnect(func() error {
 		log.Trace().Msg("Cleaning: closing P2P communication channel")
@@ -423,7 +424,9 @@ func (m *connectionManager) createP2PChannel(ctx context.Context, consumerID, pr
 
 		return channel.Close()
 	})
-	return channel, nil
+
+	m.channel = channel
+	return nil
 }
 
 func (m *connectionManager) addCleanupAfterDisconnect(fn func() error) {
@@ -438,7 +441,10 @@ func (m *connectionManager) addCleanup(fn func() error) {
 	m.cleanup = append(m.cleanup, fn)
 }
 
-func (m *connectionManager) createP2PSession(ctx context.Context, c Connection, p2pChannel p2p.ChannelSender, consumerID identity.Identity, hermesID common.Address, proposal market.ServiceProposal) (*pb.SessionResponse, error) {
+func (m *connectionManager) createP2PSession(ctx context.Context, c Connection, p2pChannel p2p.ChannelSender, consumerID identity.Identity, hermesID common.Address, proposal market.ServiceProposal, tracer *trace.Tracer) (*pb.SessionResponse, error) {
+	trace := tracer.StartStage("Consumer session creation")
+	defer tracer.EndStage(trace)
+
 	sessionCreateConfig, err := c.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("could not get session config: %w", err)
@@ -529,7 +535,12 @@ func (m *connectionManager) publishSessionCreate(sessionID session.ID) {
 	})
 }
 
-func (m *connectionManager) startConnection(ctx context.Context, conn Connection, connectOptions ConnectOptions) (err error) {
+func (m *connectionManager) startConnection(ctx context.Context, conn Connection, connectOptions ConnectOptions, tracer *trace.Tracer) (err error) {
+	trace := tracer.StartStage("Consumer start connection")
+	defer tracer.EndStage(trace)
+
+	originalPublicIP := m.getPublicIP()
+
 	if err = conn.Start(ctx, connectOptions); err != nil {
 		return err
 	}
@@ -561,6 +572,12 @@ func (m *connectionManager) startConnection(ctx context.Context, conn Connection
 
 	go m.consumeConnectionStates(conn.State())
 	go m.connectionWaiter(conn)
+
+	// Clear IP cache so session IP check can report that IP has really changed.
+	m.clearIPCache()
+
+	go m.checkSessionIP(m.channel, connectOptions.ConsumerID, connectOptions.SessionID, originalPublicIP)
+
 	return nil
 }
 
@@ -669,17 +686,6 @@ func (m *connectionManager) disconnect() {
 	m.statusNotConnected()
 
 	m.cleanAfterDisconnect()
-}
-
-func (m *connectionManager) payForService(payments PaymentIssuer) {
-	err := payments.Start()
-	if err != nil {
-		log.Error().Err(err).Msg("Payment error")
-		err = m.Disconnect()
-		if err != nil {
-			log.Error().Err(err).Msg("Could not disconnect gracefully")
-		}
-	}
 }
 
 func (m *connectionManager) connectionWaiter(connection Connection) {

--- a/core/connection/manager_test.go
+++ b/core/connection/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/connection/connectionstate"
 	"github.com/mysteriumnetwork/node/core/location"
 	"github.com/mysteriumnetwork/node/core/location/locationstate"
+	"github.com/mysteriumnetwork/node/trace"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -677,7 +678,7 @@ type mockP2PDialer struct {
 	ch *mockP2PChannel
 }
 
-func (m mockP2PDialer) Dial(ctx context.Context, consumerID identity.Identity, providerID identity.Identity, serviceType string, contactDef p2p.ContactDefinition) (p2p.Channel, error) {
+func (m mockP2PDialer) Dial(ctx context.Context, consumerID identity.Identity, providerID identity.Identity, serviceType string, contactDef p2p.ContactDefinition, tracer *trace.Tracer) (p2p.Channel, error) {
 	return m.ch, nil
 }
 
@@ -718,6 +719,10 @@ func (m *mockP2PChannel) Send(_ context.Context, topic string, msg *p2p.Message)
 }
 
 func (m *mockP2PChannel) Handle(topic string, handler p2p.HandlerFunc) {
+}
+
+func (m *mockP2PChannel) Tracer() *trace.Tracer {
+	return nil
 }
 
 func (m *mockP2PChannel) ServiceConn() *net.UDPConn {

--- a/core/quality/morqa_transport.go
+++ b/core/quality/morqa_transport.go
@@ -155,6 +155,7 @@ func proposalEventToMetricsEvent(ctx market.ServiceProposal, info appInfo) (stri
 
 func traceEventToMetricsEvent(ctx sessionTraceContext, info appInfo) (string, *metrics.Event) {
 	sender, target, isProvider := ctx.Consumer, ctx.Provider, false
+	// TODO Remove this workaround by generating&signing&publishing `metrics.Event` in same place
 	if strings.HasPrefix(ctx.Stage, "Provider") {
 		sender, target, isProvider = ctx.Provider, ctx.Consumer, true
 	}

--- a/core/service/session.go
+++ b/core/service/session.go
@@ -95,7 +95,7 @@ func (s *Session) toEvent(status event.Status) event.AppEventSession {
 }
 
 // NewSession creates a blank new session with an ID.
-func NewSession(service *Instance, request *pb.SessionRequest) (*Session, error) {
+func NewSession(service *Instance, request *pb.SessionRequest, tracer *trace.Tracer) (*Session, error) {
 	uid, err := uuid.NewV4()
 	if err != nil {
 		return nil, err
@@ -117,6 +117,6 @@ func NewSession(service *Instance, request *pb.SessionRequest) (*Session, error)
 		request:          request,
 		done:             make(chan struct{}),
 		cleanup:          make([]func() error, 0),
-		tracer:           trace.NewTracer(),
+		tracer:           tracer,
 	}, nil
 }

--- a/core/service/session_pool_test.go
+++ b/core/service/session_pool_test.go
@@ -34,7 +34,7 @@ var (
 	sessionExisting, _ = NewSession(
 		&Instance{ID: "1"},
 		&pb.SessionRequest{Consumer: &pb.ConsumerInfo{Id: "deadbeef"}},
-		trace.NewTracer(),
+		trace.NewTracer(""),
 	)
 )
 
@@ -57,7 +57,7 @@ func TestSessionPool_FindSession_Unknown(t *testing.T) {
 
 func TestSessionPool_Add(t *testing.T) {
 	pool := mockPool(mocks.NewEventBus(), sessionExisting)
-	sessionNew, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
+	sessionNew, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer(""))
 
 	pool.Add(sessionNew)
 	assert.Exactly(
@@ -69,7 +69,7 @@ func TestSessionPool_Add(t *testing.T) {
 
 func TestSessionPool_Add_PublishesEvents(t *testing.T) {
 	// given
-	session, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
+	session, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer(""))
 	mp := mocks.NewEventBus()
 	pool := NewSessionPool(mp)
 
@@ -88,8 +88,8 @@ func TestSessionPool_FindByPeer(t *testing.T) {
 }
 
 func TestSessionPool_GetAll(t *testing.T) {
-	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
-	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
+	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer(""))
+	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer(""))
 
 	pool := &SessionPool{
 		sessions: map[session.ID]*Session{
@@ -122,10 +122,10 @@ func TestSessionPool_RemoveNonExisting(t *testing.T) {
 func TestSessionPool_Remove_Does_Not_Panic(t *testing.T) {
 	pool := mockPool(mocks.NewEventBus(), sessionExisting)
 
-	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
+	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer(""))
 	pool.Add(sessionFirst)
 
-	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
+	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer(""))
 	pool.Add(sessionSecond)
 
 	pool.Remove(sessionFirst.ID)

--- a/core/service/session_pool_test.go
+++ b/core/service/session_pool_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mysteriumnetwork/node/pb"
 	"github.com/mysteriumnetwork/node/session"
 	sessionEvent "github.com/mysteriumnetwork/node/session/event"
+	"github.com/mysteriumnetwork/node/trace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,6 +34,7 @@ var (
 	sessionExisting, _ = NewSession(
 		&Instance{ID: "1"},
 		&pb.SessionRequest{Consumer: &pb.ConsumerInfo{Id: "deadbeef"}},
+		trace.NewTracer(),
 	)
 )
 
@@ -55,7 +57,7 @@ func TestSessionPool_FindSession_Unknown(t *testing.T) {
 
 func TestSessionPool_Add(t *testing.T) {
 	pool := mockPool(mocks.NewEventBus(), sessionExisting)
-	sessionNew, _ := NewSession(&Instance{}, &pb.SessionRequest{})
+	sessionNew, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
 
 	pool.Add(sessionNew)
 	assert.Exactly(
@@ -67,7 +69,7 @@ func TestSessionPool_Add(t *testing.T) {
 
 func TestSessionPool_Add_PublishesEvents(t *testing.T) {
 	// given
-	session, _ := NewSession(&Instance{}, &pb.SessionRequest{})
+	session, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
 	mp := mocks.NewEventBus()
 	pool := NewSessionPool(mp)
 
@@ -86,8 +88,8 @@ func TestSessionPool_FindByPeer(t *testing.T) {
 }
 
 func TestSessionPool_GetAll(t *testing.T) {
-	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{})
-	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{})
+	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
+	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
 
 	pool := &SessionPool{
 		sessions: map[session.ID]*Session{
@@ -120,10 +122,10 @@ func TestSessionPool_RemoveNonExisting(t *testing.T) {
 func TestSessionPool_Remove_Does_Not_Panic(t *testing.T) {
 	pool := mockPool(mocks.NewEventBus(), sessionExisting)
 
-	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{})
+	sessionFirst, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
 	pool.Add(sessionFirst)
 
-	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{})
+	sessionSecond, _ := NewSession(&Instance{}, &pb.SessionRequest{}, trace.NewTracer())
 	pool.Add(sessionSecond)
 
 	pool.Remove(sessionFirst.ID)

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mysteriumnetwork/node/trace"
 	nats_lib "github.com/nats-io/nats.go"
 
 	"github.com/mysteriumnetwork/node/communication/nats"
@@ -44,7 +45,7 @@ const maxBrokerConnectAttempts = 25
 type Dialer interface {
 	// Dial exchanges p2p configuration via broker, performs NAT pinging if needed
 	// and create p2p channel which is ready for communication.
-	Dial(ctx context.Context, consumerID, providerID identity.Identity, serviceType string, contactDef ContactDefinition) (Channel, error)
+	Dial(ctx context.Context, consumerID, providerID identity.Identity, serviceType string, contactDef ContactDefinition, tracer *trace.Tracer) (Channel, error)
 }
 
 // NewDialer creates new p2p communication dialer which is used on consumer side.
@@ -71,24 +72,14 @@ type dialer struct {
 
 // Dial exchanges p2p configuration via broker, performs NAT pinging if needed
 // and create p2p channel which is ready for communication.
-func (m *dialer) Dial(ctx context.Context, consumerID, providerID identity.Identity, serviceType string, contactDef ContactDefinition) (Channel, error) {
-	var brokerConn nats.Connection
-	var err error
+func (m *dialer) Dial(ctx context.Context, consumerID, providerID identity.Identity, serviceType string, contactDef ContactDefinition, tracer *trace.Tracer) (Channel, error) {
+	config := &p2pConnectConfig{tracer: tracer}
 
-	// broker connect might fail due to reconfiguration of network routes in progress
-	for i := 0; i < maxBrokerConnectAttempts; i++ {
-		brokerConn, err = m.broker.Connect(contactDef.BrokerAddresses...)
-		if err != nil {
-			log.Warn().Msgf("broker connect failed - attempting again in 1sec: %s", err)
-			time.Sleep(time.Second)
-			continue
-		}
-		break
-	}
+	// Send initial exchange with signed consumer public key.
+	brokerConn, err := m.connect(contactDef, tracer)
 	if err != nil {
 		return nil, fmt.Errorf("could not open broker conn: %w", err)
 	}
-
 	defer brokerConn.Close()
 
 	peerReady := make(chan struct{})
@@ -101,37 +92,33 @@ func (m *dialer) Dial(ctx context.Context, consumerID, providerID identity.Ident
 		}
 	})
 
-	config, err := m.exchangeConfig(ctx, brokerConn, providerID, serviceType, consumerID)
+	config, err = m.startConfigExchange(config, ctx, brokerConn, providerID, serviceType, consumerID)
 	if err != nil {
 		return nil, fmt.Errorf("could not exchange config: %w", err)
 	}
 
-	if _, err := firewall.AllowIPAccess(config.peerPublicIP); err != nil {
-		return nil, fmt.Errorf("could not add peer IP firewall rule: %w", err)
+	config.publicIP, config.localPorts, err = m.prepareLocalPorts(config)
+	if err != nil {
+		return nil, fmt.Errorf("could not prepare ports: %w", err)
 	}
 
-	var conn1, conn2 *net.UDPConn
+	// Finally send consumer encrypted and signed connect config in ack message.
+	err = m.ackConfigExchange(config, ctx, brokerConn, providerID, serviceType, consumerID)
+	if err != nil {
+		return nil, fmt.Errorf("could not ack config: %w", err)
+	}
+
+	dial := m.dialPinger
 	if len(config.peerPorts) == requiredConnCount {
-		log.Debug().Msg("Skipping provider ping")
-		conn1, err = net.DialUDP("udp4", &net.UDPAddr{Port: config.localPorts[0]}, &net.UDPAddr{IP: net.ParseIP(config.peerIP()), Port: config.peerPorts[0]})
-		if err != nil {
-			return nil, fmt.Errorf("could not create UDP conn for p2p channel: %w", err)
-		}
-		conn2, err = net.DialUDP("udp4", &net.UDPAddr{Port: config.localPorts[1]}, &net.UDPAddr{IP: net.ParseIP(config.peerIP()), Port: config.peerPorts[1]})
-		if err != nil {
-			return nil, fmt.Errorf("could not create UDP conn for service: %w", err)
-		}
-	} else {
-		log.Debug().Msgf("Pinging provider %s with IP %s using ports %v:%v", providerID.Address, config.peerIP(), config.localPorts, config.peerPorts)
-		conns, err := m.consumerPinger.PingProviderPeer(ctx, config.peerIP(), config.localPorts, config.peerPorts, consumerInitialTTL, requiredConnCount)
-		if err != nil {
-			return nil, fmt.Errorf("could not ping peer: %w", err)
-		}
-		conn1 = conns[0]
-		conn2 = conns[1]
+		dial = m.dialDirect
+	}
+	conn1, conn2, err := dial(ctx, providerID, config)
+	if err != nil {
+		return nil, fmt.Errorf("could not dial p2p channel: %w", err)
 	}
 
 	// Wait until provider confirms that channel handlers are ready.
+	traceAck := config.tracer.StartStage("Consumer P2P dial ack")
 	select {
 	case <-peerReady:
 		log.Debug().Msg("Received handlers ready message from provider")
@@ -143,19 +130,40 @@ func (m *dialer) Dial(ctx context.Context, consumerID, providerID identity.Ident
 	if err != nil {
 		return nil, fmt.Errorf("could not create p2p channel during dial: %w", err)
 	}
+	channel.setTracer(tracer)
 	channel.setServiceConn(conn2)
 	channel.launchReadSendLoops()
+	config.tracer.EndStage(traceAck)
 
 	return channel, nil
 }
 
-func (m *dialer) exchangeConfig(ctx context.Context, brokerConn nats.Connection, providerID identity.Identity, serviceType string, consumerID identity.Identity) (*p2pConnectConfig, error) {
+func (m *dialer) connect(contactDef ContactDefinition, tracer *trace.Tracer) (conn nats.Connection, err error) {
+	trace := tracer.StartStage("Consumer P2P connect")
+	defer tracer.EndStage(trace)
+
+	// broker connect might fail due to reconfiguration of network routes in progress
+	for i := 0; i < maxBrokerConnectAttempts; i++ {
+		conn, err = m.broker.Connect(contactDef.BrokerAddresses...)
+		if err != nil {
+			log.Warn().Msgf("broker connect failed - attempting again in 1sec: %s", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		break
+	}
+	return conn, err
+}
+
+func (m *dialer) startConfigExchange(config *p2pConnectConfig, ctx context.Context, brokerConn nats.Connection, providerID identity.Identity, serviceType string, consumerID identity.Identity) (*p2pConnectConfig, error) {
+	trace := config.tracer.StartStage("Consumer P2P exchange")
+	defer config.tracer.EndStage(trace)
+
 	pubKey, privateKey, err := GenerateKey()
 	if err != nil {
 		return nil, fmt.Errorf("could not generate consumer p2p keys: %w", err)
 	}
 
-	// Send initial exchange with signed consumer public key.
 	beginExchangeMsg := &pb.P2PConfigExchangeMsg{
 		PublicKey: pubKey.Hex(),
 	}
@@ -188,31 +196,34 @@ func (m *dialer) exchangeConfig(ctx context.Context, brokerConn nats.Connection,
 	}
 	log.Debug().Msgf("Consumer %s received provider %s with config: %v", consumerID.Address, providerID.Address, peerConnConfig)
 
-	// Finally send consumer encrypted and signed connect config in ack message.
-	publicIP, err := m.ipResolver.GetPublicIP()
-	if err != nil {
-		return nil, fmt.Errorf("could not get public IP: %v", err)
-	}
-	localPorts, err := acquireLocalPorts(m.portPool, len(peerConnConfig.Ports))
-	if err != nil {
-		return nil, fmt.Errorf("could not acquire local ports: %v", err)
-	}
+	config.publicKey = pubKey
+	config.privateKey = privateKey
+	config.peerPubKey = peerPubKey
+	config.peerPublicIP = peerConnConfig.PublicIP
+	config.peerPorts = int32ToIntSlice(peerConnConfig.Ports)
+	return config, nil
+}
+
+func (m *dialer) ackConfigExchange(config *p2pConnectConfig, ctx context.Context, brokerConn nats.Connection, providerID identity.Identity, serviceType string, consumerID identity.Identity) error {
+	trace := config.tracer.StartStage("Consumer P2P exchange ack")
+	defer config.tracer.EndStage(trace)
+
 	connConfig := &pb.P2PConnectConfig{
-		PublicIP: publicIP,
-		Ports:    intToInt32Slice(localPorts),
+		PublicIP: config.publicIP,
+		Ports:    intToInt32Slice(config.localPorts),
 	}
-	connConfigCiphertext, err := encryptConnConfigMsg(connConfig, privateKey, peerPubKey)
+	connConfigCiphertext, err := encryptConnConfigMsg(connConfig, config.privateKey, config.peerPubKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not encrypt config msg: %v", err)
+		return fmt.Errorf("could not encrypt config msg: %v", err)
 	}
 	endExchangeMsg := &pb.P2PConfigExchangeMsg{
-		PublicKey:        pubKey.Hex(),
+		PublicKey:        config.publicKey.Hex(),
 		ConfigCiphertext: connConfigCiphertext,
 	}
 	log.Debug().Msgf("Consumer %s sending ack with encrypted config to provider %s", consumerID.Address, providerID.Address)
-	packedMsg, err = packSignedMsg(m.signer, consumerID, endExchangeMsg)
+	packedMsg, err := packSignedMsg(m.signer, consumerID, endExchangeMsg)
 	if err != nil {
-		return nil, fmt.Errorf("could not pack signed message: %v", err)
+		return fmt.Errorf("could not pack signed message: %v", err)
 	}
 
 	// simple broker Publish will not work here since we have to delay Consumer from pinging Provider
@@ -222,17 +233,64 @@ func (m *dialer) exchangeConfig(ctx context.Context, brokerConn nats.Connection,
 	_, err = m.sendSignedMsg(ctx, configExchangeACKSubject(providerID, serviceType), packedMsg, brokerConn)
 
 	if err != nil {
-		return nil, fmt.Errorf("could not send signed msg: %v", err)
+		return fmt.Errorf("could not send signed msg: %v", err)
 	}
 
-	return &p2pConnectConfig{
-		publicIP:     publicIP,
-		privateKey:   privateKey,
-		localPorts:   localPorts,
-		peerPubKey:   peerPubKey,
-		peerPublicIP: peerConnConfig.PublicIP,
-		peerPorts:    int32ToIntSlice(peerConnConfig.Ports),
-	}, nil
+	return nil
+}
+
+func (m *dialer) prepareLocalPorts(config *p2pConnectConfig) (string, []int, error) {
+	trace := config.tracer.StartStage("Consumer P2P exchange (ports)")
+	defer config.tracer.EndStage(trace)
+
+	// Finally send consumer encrypted and signed connect config in ack message.
+	publicIP, err := m.ipResolver.GetPublicIP()
+	if err != nil {
+		return "", nil, fmt.Errorf("could not get public IP: %v", err)
+	}
+
+	localPorts, err := acquireLocalPorts(m.portPool, len(config.peerPorts))
+	if err != nil {
+		return publicIP, nil, fmt.Errorf("could not acquire local ports: %v", err)
+	}
+
+	return publicIP, localPorts, nil
+}
+
+func (m *dialer) dialDirect(ctx context.Context, providerID identity.Identity, config *p2pConnectConfig) (*net.UDPConn, *net.UDPConn, error) {
+	trace := config.tracer.StartStage("Consumer P2P dial (upnp)")
+	defer config.tracer.EndStage(trace)
+
+	if _, err := firewall.AllowIPAccess(config.peerPublicIP); err != nil {
+		return nil, nil, fmt.Errorf("could not add peer IP firewall rule: %w", err)
+	}
+
+	log.Debug().Msg("Skipping provider ping")
+	conn1, err := net.DialUDP("udp4", &net.UDPAddr{Port: config.localPorts[0]}, &net.UDPAddr{IP: net.ParseIP(config.peerIP()), Port: config.peerPorts[0]})
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not create UDP conn for p2p channel: %w", err)
+	}
+	conn2, err := net.DialUDP("udp4", &net.UDPAddr{Port: config.localPorts[1]}, &net.UDPAddr{IP: net.ParseIP(config.peerIP()), Port: config.peerPorts[1]})
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not create UDP conn for service: %w", err)
+	}
+	return conn1, conn2, err
+}
+
+func (m *dialer) dialPinger(ctx context.Context, providerID identity.Identity, config *p2pConnectConfig) (*net.UDPConn, *net.UDPConn, error) {
+	trace := config.tracer.StartStage("Consumer P2P dial (pinger)")
+	defer config.tracer.EndStage(trace)
+
+	if _, err := firewall.AllowIPAccess(config.peerPublicIP); err != nil {
+		return nil, nil, fmt.Errorf("could not add peer IP firewall rule: %w", err)
+	}
+
+	log.Debug().Msgf("Pinging provider %s with IP %s using ports %v:%v", providerID.Address, config.peerIP(), config.localPorts, config.peerPorts)
+	conns, err := m.consumerPinger.PingProviderPeer(ctx, config.peerIP(), config.localPorts, config.peerPorts, consumerInitialTTL, requiredConnCount)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not ping peer: %w", err)
+	}
+	return conns[0], conns[1], nil
 }
 
 func (m *dialer) sendSignedMsg(ctx context.Context, subject string, msg []byte, brokerConn nats.Connection) ([]byte, error) {

--- a/p2p/dialer_test.go
+++ b/p2p/dialer_test.go
@@ -97,7 +97,7 @@ func TestDialer_Exchange_And_Communication_With_Provider(t *testing.T) {
 			channelDialer := NewDialer(mockBroker, signerFactory, verifier, test.ipResolver, test.natConsumerPinger, portPool)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			consumerChannel, err := channelDialer.Dial(ctx, identity.FromAddress("0x2"), providerID, "wireguard", ContactDefinition{BrokerAddresses: []string{"broker"}}, trace.NewTracer())
+			consumerChannel, err := channelDialer.Dial(ctx, identity.FromAddress("0x2"), providerID, "wireguard", ContactDefinition{BrokerAddresses: []string{"broker"}}, trace.NewTracer("Dial"))
 			assert.NoError(t, err)
 			defer consumerChannel.Close()
 

--- a/p2p/dialer_test.go
+++ b/p2p/dialer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/nat/mapping"
 	"github.com/mysteriumnetwork/node/nat/traversal"
+	"github.com/mysteriumnetwork/node/trace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,7 +97,7 @@ func TestDialer_Exchange_And_Communication_With_Provider(t *testing.T) {
 			channelDialer := NewDialer(mockBroker, signerFactory, verifier, test.ipResolver, test.natConsumerPinger, portPool)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			consumerChannel, err := channelDialer.Dial(ctx, identity.FromAddress("0x2"), providerID, "wireguard", ContactDefinition{BrokerAddresses: []string{"broker"}})
+			consumerChannel, err := channelDialer.Dial(ctx, identity.FromAddress("0x2"), providerID, "wireguard", ContactDefinition{BrokerAddresses: []string{"broker"}}, trace.NewTracer())
 			assert.NoError(t, err)
 			defer consumerChannel.Close()
 

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -220,7 +220,8 @@ func (m *listener) Listen(providerID identity.Identity, serviceType string, chan
 }
 
 func (m *listener) providerStartConfigExchange(signerID identity.Identity, msg *nats_lib.Msg, outboundIP string) error {
-	tracer := trace.NewTracer()
+	tracer := trace.NewTracer("Provider whole Connect")
+
 	trace := tracer.StartStage("Provider P2P exchange")
 	defer tracer.EndStage(trace)
 

--- a/services/openvpn/service/auth_handler_test.go
+++ b/services/openvpn/service/auth_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/pb"
+	"github.com/mysteriumnetwork/node/trace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,6 +33,7 @@ var (
 	sessionExisting, _ = service.NewSession(
 		&service.Instance{},
 		&pb.SessionRequest{Consumer: &pb.ConsumerInfo{Id: identityExisting.Address}},
+		trace.NewTracer(),
 	)
 	sessionExistingString = string(sessionExisting.ID)
 )

--- a/services/openvpn/service/auth_handler_test.go
+++ b/services/openvpn/service/auth_handler_test.go
@@ -33,7 +33,7 @@ var (
 	sessionExisting, _ = service.NewSession(
 		&service.Instance{},
 		&pb.SessionRequest{Consumer: &pb.ConsumerInfo{Id: identityExisting.Address}},
-		trace.NewTracer(),
+		trace.NewTracer(""),
 	)
 	sessionExistingString = string(sessionExisting.ID)
 )

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -33,15 +33,18 @@ const (
 )
 
 // NewTracer returns new tracer instance.
-func NewTracer() *Tracer {
-	return &Tracer{
+func NewTracer(name string) *Tracer {
+	tracer := &Tracer{
 		stages: make([]*stage, 0),
 	}
+	tracer.name = tracer.StartStage(name)
+	return tracer
 }
 
 // Tracer represents tracer which records stages durations. It can be used
 // to record stages times for tracing how long it took time.
 type Tracer struct {
+	name     string
 	mu       sync.Mutex
 	stages   []*stage
 	finished bool
@@ -87,6 +90,8 @@ func (t *Tracer) EndStage(key string) {
 
 // Finish finishes tracing and returns formatted string with stages durations.
 func (t *Tracer) Finish(eventPublisher eventbus.Publisher, id string) string {
+	t.EndStage(t.name)
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.finished = true


### PR DESCRIPTION
These changes traces connect times all the way from P2P handshake start both on consumer and provider side.
Whole connect time divided to more sub-steps also: 

```
2020-08-28T16:46:33.000 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer whole Connect Duration:5.575511756s}
2020-08-28T16:46:33.000 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer P2P channel creation Duration:3.874768579s}
2020-08-28T16:46:33.000 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer P2P connect Duration:215.394899ms}
2020-08-28T16:46:33.000 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer P2P exchange Duration:1.389004913s}
2020-08-28T16:46:33.001 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer P2P exchange (ports) Duration:667.315174ms}
2020-08-28T16:46:33.001 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer P2P exchange ack Duration:314.559483ms}
2020-08-28T16:46:33.001 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer P2P dial (pinger) Duration:808.651302ms}
2020-08-28T16:46:33.001 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer P2P dial ack Duration:479.342048ms}
2020-08-28T16:46:33.001 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer session creation Duration:631.949459ms}
2020-08-28T16:46:33.001 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer session creation (start) Duration:31.513816ms}
2020-08-28T16:46:33.002 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:76805cae-a508-474d-a571-e52965a5bcf9 Key:Consumer start connection Duration:1.036613917s}
2020-08-28T16:46:33.002 DBG core/connection/manager.go:187           > Consumer connection trace: "Consumer whole Connect" took 5.575511756s, "Consumer P2P channel creation" took 3.874768579s, "Consumer P2P connect" took 215.394899ms, "Consumer P2P exchange" took 1.389004913s, "Consumer P2P exchange (ports)" took 667.315174ms, "Consumer P2P exchange ack" took 314.559483ms, "Consumer P2P dial (pinger)" took 808.651302ms, "Consumer P2P dial ack" took 479.342048ms, "Consumer session creation" took 631.949459ms, "Consumer session creation (start)" took 31.513816ms, "Consumer start connection" took 1.036613917s
```

```
2020-08-28T16:49:43.809 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider whole Connect Duration:1.758634673s}
2020-08-28T16:49:43.809 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider P2P exchange Duration:1.004869495s}
2020-08-28T16:49:43.809 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider P2P exchange (ports) Duration:1.003096607s}
2020-08-28T16:49:43.809 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider P2P exchange ack Duration:101.185631ms}
2020-08-28T16:49:43.810 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider P2P dial (upnp) Duration:413.675µs}
2020-08-28T16:49:43.810 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider P2P dial ack Duration:1.269673ms}
2020-08-28T16:49:43.810 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider session create Duration:476.177623ms}
2020-08-28T16:49:43.810 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider session create (start) Duration:35.921956ms}
2020-08-28T16:49:43.810 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider session create (payment) Duration:288.092657ms}
2020-08-28T16:49:43.810 DBG eventbus/event_bus.go:81                 > Published topic="Trace" event={ID:6048dd5c-3510-4733-8ec8-d050119f5aef Key:Provider session create (configure) Duration:152.157225ms}
2020-08-28T16:49:43.811 DBG core/service/session_manager.go:172      > Provider connection trace: "Provider whole Connect" took 1.758634673s, "Provider P2P exchange" took 1.004869495s, "Provider P2P exchange (ports)" took 1.003096607s, "Provider P2P exchange ack" took 101.185631ms, "Provider P2P dial (upnp)" took 413.675µs, "Provider P2P dial ack" took 1.269673ms, "Provider session create" took 476.177623ms, "Provider session create (start)" took 35.921956ms, "Provider session create (payment)" took 288.092657ms, "Provider session create (configure)" took 152.157225ms
```