### PR TITLE
Hermes id optional for connect

### DIFF
--- a/core/discovery/brokerdiscovery/repository_test.go
+++ b/core/discovery/brokerdiscovery/repository_test.go
@@ -76,7 +76,7 @@ func Test_Subscriber_StartSyncsNewProposals(t *testing.T) {
 	connection := nats.StartConnectionMock()
 	defer connection.Close()
 
-	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 1*time.Millisecond)
+	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 10*time.Millisecond)
 	err := repo.Start()
 	defer repo.Stop()
 	assert.NoError(t, err)
@@ -93,7 +93,7 @@ func Test_Subscriber_SkipUnsupportedProposal(t *testing.T) {
 	connection := nats.StartConnectionMock()
 	defer connection.Close()
 
-	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 1*time.Millisecond)
+	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 10*time.Millisecond)
 	err := repo.Start()
 	defer repo.Stop()
 	assert.NoError(t, err)
@@ -111,7 +111,7 @@ func Test_Subscriber_StartSyncsIdleProposals(t *testing.T) {
 	connection := nats.StartConnectionMock()
 	defer connection.Close()
 
-	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 1*time.Millisecond)
+	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 10*time.Millisecond)
 	err := repo.Start()
 	defer repo.Stop()
 	assert.NoError(t, err)
@@ -126,7 +126,7 @@ func Test_Subscriber_StartSyncsHealthyProposals(t *testing.T) {
 	connection := nats.StartConnectionMock()
 	defer connection.Close()
 
-	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 1*time.Millisecond)
+	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 10*time.Millisecond)
 	err := repo.Start()
 	defer repo.Stop()
 	assert.NoError(t, err)
@@ -149,7 +149,7 @@ func Test_Subscriber_StartSyncsStoppedProposals(t *testing.T) {
 	connection := nats.StartConnectionMock()
 	defer connection.Close()
 
-	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 1*time.Millisecond)
+	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 10*time.Millisecond)
 	repo.storage.AddProposal(proposalFirst(), proposalSecond())
 	err := repo.Start()
 	defer repo.Stop()

--- a/tequilapi/contract/connection.go
+++ b/tequilapi/contract/connection.go
@@ -142,7 +142,6 @@ type ConnectionCreateRequest struct {
 	ProviderID string `json:"provider_id"`
 
 	// hermes identity
-	// required: true
 	// example: 0x0000000000000000000000000000000000000003
 	HermesID string `json:"hermes_id"`
 
@@ -165,9 +164,6 @@ func (cr ConnectionCreateRequest) Validate() *validation.FieldErrorMap {
 	}
 	if len(cr.ProviderID) == 0 {
 		errs.ForField("provider_id").AddError("required", "Field is required")
-	}
-	if len(cr.HermesID) == 0 {
-		errs.ForField("hermes_id").AddError("required", "Field is required")
 	}
 	return errs
 }

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/julienschmidt/httprouter"
+	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/discovery/proposal"
 	"github.com/mysteriumnetwork/node/identity"
@@ -253,6 +254,7 @@ func toConnectionRequest(req *http.Request) (*contract.ConnectionCreateRequest, 
 			DisableKillSwitch: false,
 			DNS:               connection.DNSOptionAuto,
 		},
+		HermesID: config.GetString(config.FlagHermesID),
 	}
 	err := json.NewDecoder(req.Body).Decode(&connectionRequest)
 	if err != nil {

--- a/tequilapi/endpoints/connection_test.go
+++ b/tequilapi/endpoints/connection_test.go
@@ -212,7 +212,6 @@ func TestPutReturns422ErrorIfRequestBodyIsMissingFieldValues(t *testing.T) {
 		`{
 			"message" : "validation_error",
 			"errors" : {
-				"hermes_id" : [ {"code" : "required" , "message" : "Field is required" } ],
 				"consumer_id" : [ { "code" : "required" , "message" : "Field is required" } ],
 				"provider_id" : [ {"code" : "required" , "message" : "Field is required" } ]
 			}


### PR DESCRIPTION
Make HermesID optional so that it's not necessary to hardcode this ID on desktop. A similar approach to mobile where node uses defaults.