### PR TITLE
Store promises with more metadata

### DIFF
--- a/session/pingpong/hermes_promise_handler.go
+++ b/session/pingpong/hermes_promise_handler.go
@@ -40,7 +40,6 @@ import (
 
 type hermesPromiseStorage interface {
 	Store(promise HermesPromise) error
-	Get(channelID string) (HermesPromise, error)
 }
 
 type feeProvider interface {

--- a/session/pingpong/hermes_promise_handler.go
+++ b/session/pingpong/hermes_promise_handler.go
@@ -182,6 +182,7 @@ func (aph *HermesPromiseHandler) requestPromise(er enqueuedRequest) {
 	channelID, err := crypto.GenerateProviderChannelID(providerID.Address, hermesID.Hex())
 	if err != nil {
 		er.errChan <- fmt.Errorf("could not generate provider channel address: %w", err)
+		return
 	}
 
 	if !aph.transactorFee.IsValid() {

--- a/session/pingpong/hermes_promise_handler.go
+++ b/session/pingpong/hermes_promise_handler.go
@@ -39,8 +39,8 @@ import (
 )
 
 type hermesPromiseStorage interface {
-	Store(providerID identity.Identity, hermesID common.Address, promise HermesPromise) error
-	Get(providerID identity.Identity, hermesID common.Address) (HermesPromise, error)
+	Store(promise HermesPromise) error
+	Get(channelID string) (HermesPromise, error)
 }
 
 type feeProvider interface {
@@ -178,6 +178,13 @@ func (aph *HermesPromiseHandler) handleNodeStopEvents(e event.Payload) {
 func (aph *HermesPromiseHandler) requestPromise(er enqueuedRequest) {
 	defer func() { close(er.errChan) }()
 
+	providerID := er.providerID
+	hermesID := common.HexToAddress(er.em.HermesID)
+	channelID, err := crypto.GenerateProviderChannelID(providerID.Address, hermesID.Hex())
+	if err != nil {
+		er.errChan <- fmt.Errorf("could not generate provider channel address: %w", err)
+	}
+
 	if !aph.transactorFee.IsValid() {
 		aph.updateFee()
 	}
@@ -193,7 +200,7 @@ func (aph *HermesPromiseHandler) requestPromise(er enqueuedRequest) {
 		return
 	}
 
-	encrypted, err := aph.deps.Encryption.Encrypt(er.providerID.ToCommonAddress(), bytes)
+	encrypted, err := aph.deps.Encryption.Encrypt(providerID.ToCommonAddress(), bytes)
 	if err != nil {
 		er.errChan <- fmt.Errorf("could not encrypt R: %w", err)
 		return
@@ -205,27 +212,29 @@ func (aph *HermesPromiseHandler) requestPromise(er enqueuedRequest) {
 		RRecoveryData:   hex.EncodeToString(encrypted),
 	}
 
-	hermesID := common.HexToAddress(request.ExchangeMessage.HermesID)
 	hermesCaller, err := aph.getHermesCaller(hermesID)
 	if err != nil {
 		er.errChan <- fmt.Errorf("could not get hermes caller: %w", err)
 		return
 	}
 	promise, err := hermesCaller.RequestPromise(request)
-	err = aph.handleHermesError(err, er.providerID, hermesID)
+	err = aph.handleHermesError(err, providerID, hermesID)
 	if err != nil {
 		er.errChan <- fmt.Errorf("hermes request promise error: %w", err)
 		return
 	}
 
 	ap := HermesPromise{
+		ChannelID:   channelID,
+		Identity:    providerID,
+		HermesID:    hermesID,
 		Promise:     promise,
 		R:           hex.EncodeToString(er.r),
 		Revealed:    false,
 		AgreementID: er.em.AgreementID,
 	}
 
-	err = aph.deps.HermesPromiseStorage.Store(er.providerID, hermesID, ap)
+	err = aph.deps.HermesPromiseStorage.Store(ap)
 	if err != nil && !stdErr.Is(err, ErrAttemptToOverwrite) {
 		er.errChan <- fmt.Errorf("could not store hermes promise: %w", err)
 		return
@@ -234,16 +243,16 @@ func (aph *HermesPromiseHandler) requestPromise(er enqueuedRequest) {
 	aph.deps.EventBus.Publish(pinge.AppTopicHermesPromise, pinge.AppEventHermesPromise{
 		Promise:    promise,
 		HermesID:   hermesID,
-		ProviderID: er.providerID,
+		ProviderID: providerID,
 	})
 	aph.deps.EventBus.Publish(sessionEvent.AppTopicTokensEarned, sessionEvent.AppEventTokensEarned{
-		ProviderID: er.providerID,
+		ProviderID: providerID,
 		SessionID:  er.sessionID,
 		Total:      er.em.AgreementTotal,
 	})
 
-	err = aph.revealR(er.providerID, hermesID)
-	err = aph.handleHermesError(err, er.providerID, hermesID)
+	err = aph.revealR(ap)
+	err = aph.handleHermesError(err, providerID, hermesID)
 	if err != nil {
 		er.errChan <- fmt.Errorf("hermes reveal r error: %w", err)
 		return
@@ -258,35 +267,24 @@ func (aph *HermesPromiseHandler) getHermesCaller(hermesID common.Address) (Herme
 	return aph.deps.HermesCallerFactory(addr), nil
 }
 
-func (aph *HermesPromiseHandler) revealR(providerID identity.Identity, hermesID common.Address) error {
-	needsRevealing := false
-	hermesPromise, err := aph.deps.HermesPromiseStorage.Get(providerID, hermesID)
-	switch err {
-	case nil:
-		needsRevealing = !hermesPromise.Revealed
-	case ErrNotFound:
-		needsRevealing = false
-	default:
-		return fmt.Errorf("could not get hermes promise: %w", err)
-	}
-
-	if !needsRevealing {
+func (aph *HermesPromiseHandler) revealR(hermesPromise HermesPromise) error {
+	if hermesPromise.Revealed {
 		return nil
 	}
 
-	hermesCaller, err := aph.getHermesCaller(hermesID)
+	hermesCaller, err := aph.getHermesCaller(hermesPromise.HermesID)
 	if err != nil {
 		return fmt.Errorf("could not get hermes caller: %w", err)
 	}
 
-	err = hermesCaller.RevealR(hermesPromise.R, providerID.Address, hermesPromise.AgreementID)
-	handledErr := aph.handleHermesError(err, providerID, hermesID)
+	err = hermesCaller.RevealR(hermesPromise.R, hermesPromise.Identity.Address, hermesPromise.AgreementID)
+	handledErr := aph.handleHermesError(err, hermesPromise.Identity, hermesPromise.HermesID)
 	if handledErr != nil {
 		return fmt.Errorf("could not reveal R: %w", err)
 	}
 
 	hermesPromise.Revealed = true
-	err = aph.deps.HermesPromiseStorage.Store(providerID, hermesID, hermesPromise)
+	err = aph.deps.HermesPromiseStorage.Store(hermesPromise)
 	if err != nil && !stdErr.Is(err, ErrAttemptToOverwrite) {
 		return fmt.Errorf("could not store hermes promise: %w", err)
 	}

--- a/session/pingpong/hermes_promise_handler_test.go
+++ b/session/pingpong/hermes_promise_handler_test.go
@@ -61,7 +61,7 @@ func TestHermesPromiseHandler_RequestPromise(t *testing.T) {
 		Promise: crypto.Promise{},
 	}
 
-	ch := aph.RequestPromise(r, em, identity.FromAddress("asddadadqweqwe"), "session")
+	ch := aph.RequestPromise(r, em, identity.FromAddress("0x0000000000000000000000000000000000000001"), "session")
 
 	err, more := <-ch
 	assert.False(t, more)
@@ -102,7 +102,7 @@ func TestHermesPromiseHandler_RequestPromise_BubblesErrors(t *testing.T) {
 		Promise: crypto.Promise{},
 	}
 
-	ch := aph.RequestPromise(r, em, identity.FromAddress("asddadadqweqwe"), "session")
+	ch := aph.RequestPromise(r, em, identity.FromAddress("0x0000000000000000000000000000000000000001"), "session")
 
 	err, more := <-ch
 	assert.True(t, more)

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -65,7 +65,7 @@ type transactor interface {
 }
 
 type promiseStorage interface {
-	Get(id identity.Identity, hermesID common.Address) (HermesPromise, error)
+	Get(channelID string) (HermesPromise, error)
 }
 
 type receivedPromise struct {
@@ -163,7 +163,7 @@ func (aps *hermesPromiseSettler) resyncState(id identity.Identity, hermesID comm
 		return errors.Wrap(err, fmt.Sprintf("could not get provider channel for %v, hermes %v", id, hermesID.Hex()))
 	}
 
-	hermesPromise, err := aps.promiseStorage.Get(id, hermesID)
+	hermesPromise, err := aps.getLastPromise(id, hermesID)
 	if err != nil && err != ErrNotFound {
 		return errors.Wrap(err, fmt.Sprintf("could not get hermes promise for provider %v, hermes %v", id, hermesID.Hex()))
 	}
@@ -183,6 +183,15 @@ func (aps *hermesPromiseSettler) resyncState(id identity.Identity, hermesID comm
 	aps.currentState[id] = s
 	log.Info().Msgf("Loaded state for provider %q, hermesID %q: balance %v, available balance %v, unsettled balance %v", id, hermesID.Hex(), hs.balance(), hs.availableBalance(), hs.unsettledBalance())
 	return nil
+}
+
+func (aps *hermesPromiseSettler) getLastPromise(id identity.Identity, hermesID common.Address) (HermesPromise, error) {
+	channelID, err := crypto.GenerateProviderChannelID(id.Address, hermesID.Hex())
+	if err != nil {
+		return HermesPromise{}, errors.Wrap(err, "could not generate provider channel address")
+	}
+
+	return aps.promiseStorage.Get(channelID)
 }
 
 func (aps *hermesPromiseSettler) publishChangeEvent(id identity.Identity, before, after settlementState) {
@@ -315,7 +324,7 @@ func (aps *hermesPromiseSettler) handleHermesPromiseReceived(apep event.AppEvent
 }
 
 func (aps *hermesPromiseSettler) initiateSettling(providerID identity.Identity, hermesID common.Address, beneficiary common.Address) {
-	promise, err := aps.promiseStorage.Get(providerID, hermesID)
+	promise, err := aps.getLastPromise(providerID, hermesID)
 	if err == ErrNotFound {
 		log.Debug().Msgf("no promise to settle for %q %q", providerID, hermesID.Hex())
 		return
@@ -374,7 +383,7 @@ func (aps *hermesPromiseSettler) GetEarnings(id identity.Identity) event.Earning
 
 // SettleIntoStake settles the promise but transfers the money to stake increase, not to beneficiary.
 func (aps *hermesPromiseSettler) SettleIntoStake(providerID identity.Identity, hermesID common.Address) error {
-	promise, err := aps.promiseStorage.Get(providerID, hermesID)
+	promise, err := aps.getLastPromise(providerID, hermesID)
 	if err == ErrNotFound {
 		return ErrNothingToSettle
 	}
@@ -403,7 +412,7 @@ var ErrNothingToSettle = errors.New("nothing to settle for the given provider")
 
 // ForceSettle forces the settlement for a provider
 func (aps *hermesPromiseSettler) ForceSettle(providerID identity.Identity, hermesID common.Address) error {
-	promise, err := aps.promiseStorage.Get(providerID, hermesID)
+	promise, err := aps.getLastPromise(providerID, hermesID)
 	if err == ErrNotFound {
 		return ErrNothingToSettle
 	}
@@ -430,7 +439,7 @@ func (aps *hermesPromiseSettler) ForceSettle(providerID identity.Identity, herme
 
 // ForceSettle forces the settlement for a provider
 func (aps *hermesPromiseSettler) SettleWithBeneficiary(providerID identity.Identity, hermesID, beneficiary common.Address) error {
-	promise, err := aps.promiseStorage.Get(providerID, hermesID)
+	promise, err := aps.getLastPromise(providerID, hermesID)
 	if err == ErrNotFound {
 		return ErrNothingToSettle
 	}

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -188,7 +188,7 @@ func (aps *hermesPromiseSettler) resyncState(id identity.Identity, hermesID comm
 func (aps *hermesPromiseSettler) getLastPromise(id identity.Identity, hermesID common.Address) (HermesPromise, error) {
 	channelID, err := crypto.GenerateProviderChannelID(id.Address, hermesID.Hex())
 	if err != nil {
-		return HermesPromise{}, errors.Wrap(err, "could not generate provider channel address")
+		return HermesPromise{}, fmt.Errorf("could not generate provider channel address: %w", err)
 	}
 
 	return aps.promiseStorage.Get(channelID)

--- a/session/pingpong/hermes_promise_storage_test.go
+++ b/session/pingpong/hermes_promise_storage_test.go
@@ -67,6 +67,10 @@ func TestHermesPromiseStorage(t *testing.T) {
 	_, err = hermesStorage.Get("unknown_id")
 	assert.Equal(t, ErrNotFound, err)
 
+	promises, err := hermesStorage.List(HermesPromiseFilter{})
+	assert.Equal(t, []HermesPromise{}, promises)
+	assert.NoError(t, err)
+
 	// store and check that promise is stored correctly
 	err = hermesStorage.Store(firstPromise)
 	assert.NoError(t, err)
@@ -75,6 +79,10 @@ func TestHermesPromiseStorage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, firstPromise, promise)
 
+	promises, err = hermesStorage.List(HermesPromiseFilter{})
+	assert.Equal(t, []HermesPromise{firstPromise}, promises)
+	assert.NoError(t, err)
+
 	// overwrite the promise, check if it is overwritten
 	err = hermesStorage.Store(secondPromise)
 	assert.NoError(t, err)
@@ -82,6 +90,10 @@ func TestHermesPromiseStorage(t *testing.T) {
 	promise, err = hermesStorage.Get(secondPromise.ChannelID)
 	assert.NoError(t, err)
 	assert.EqualValues(t, secondPromise, promise)
+
+	promises, err = hermesStorage.List(HermesPromiseFilter{})
+	assert.Equal(t, []HermesPromise{firstPromise, secondPromise}, promises)
+	assert.NoError(t, err)
 
 	overwritingPromise := firstPromise
 	overwritingPromise.Promise.Amount = big.NewInt(0)

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -796,11 +796,11 @@ type mockHermesPromiseStorage struct {
 	errToReturn error
 }
 
-func (maps *mockHermesPromiseStorage) Store(_ identity.Identity, _ common.Address, _ HermesPromise) error {
+func (maps *mockHermesPromiseStorage) Store(_ HermesPromise) error {
 	return maps.errToReturn
 }
 
-func (maps *mockHermesPromiseStorage) Get(_ identity.Identity, _ common.Address) (HermesPromise, error) {
+func (maps *mockHermesPromiseStorage) Get(_ string) (HermesPromise, error) {
 	return maps.toReturn, maps.errToReturn
 }
 


### PR DESCRIPTION
Extended promises from accountant with more metadata:
- identity, hermesID, channelID - describes which identity and with who has with opened payment channel
- it allows to list&filter all active payment channels without knowing hermes IDs