### PR TITLE
Decouple earning balance from settling to HermesChannelRepository

### DIFF
--- a/cmd/commands/daemon/command.go
+++ b/cmd/commands/daemon/command.go
@@ -65,7 +65,7 @@ func describeQuit(err error) error {
 	if err == nil {
 		log.Info().Msg("Stopping application")
 	} else {
-		log.Error().Msgf("Terminating application due to error: %+v\n", err)
+		log.Error().Err(err).Msgf("Terminating application due to error")
 	}
 	return err
 }

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -159,6 +159,7 @@ type Dependencies struct {
 	ConsumerTotalsStorage    *pingpong.ConsumerTotalsStorage
 	HermesPromiseStorage     *pingpong.HermesPromiseStorage
 	ConsumerBalanceTracker   *pingpong.ConsumerBalanceTracker
+	HermesChannelRepository  *pingpong.HermesChannelRepository
 	HermesPromiseSettler     pingpong.HermesPromiseSettler
 	HermesURLGetter          *pingpong.HermesURLGetter
 	HermesCaller             *pingpong.HermesCaller
@@ -307,7 +308,7 @@ func (di *Dependencies) bootstrapStateKeeper(options node.Options) error {
 		IdentityRegistry:          di.IdentityRegistry,
 		IdentityChannelCalculator: di.ChannelAddressCalculator,
 		BalanceProvider:           di.ConsumerBalanceTracker,
-		EarningsProvider:          di.HermesPromiseSettler,
+		EarningsProvider:          di.HermesChannelRepository,
 	}
 	di.StateKeeper = state.NewKeeper(deps, state.DefaultDebounceDuration)
 	return di.StateKeeper.Subscribe(di.EventBus)
@@ -550,7 +551,7 @@ func (di *Dependencies) bootstrapTequilapi(nodeOptions node.Options, listener ne
 	router := tequilapi.NewAPIRouter()
 	tequilapi_endpoints.AddRouteForStop(router, utils.SoftKiller(di.Shutdown))
 	tequilapi_endpoints.AddRoutesForAuthentication(router, di.Authenticator, di.JWTAuthenticator)
-	tequilapi_endpoints.AddRoutesForIdentities(router, di.IdentityManager, di.IdentitySelector, di.IdentityRegistry, di.ConsumerBalanceTracker, di.ChannelAddressCalculator, di.HermesPromiseSettler, di.BCHelper)
+	tequilapi_endpoints.AddRoutesForIdentities(router, di.IdentityManager, di.IdentitySelector, di.IdentityRegistry, di.ConsumerBalanceTracker, di.ChannelAddressCalculator, di.HermesChannelRepository, di.BCHelper)
 	tequilapi_endpoints.AddRoutesForConnection(router, di.ConnectionManager, di.StateKeeper, di.ProposalRepository, di.IdentityRegistry)
 	tequilapi_endpoints.AddRoutesForSessions(router, di.SessionStorage)
 	tequilapi_endpoints.AddRoutesForConnectionLocation(router, di.IPResolver, di.LocationResolver, di.LocationResolver)

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -187,7 +187,7 @@ func (di *Dependencies) bootstrapHermesPromiseSettler(nodeOptions node.Options) 
 	di.HermesPromiseSettler = pingpong.NewHermesPromiseSettler(
 		di.EventBus,
 		di.Transactor,
-		di.HermesPromiseStorage,
+		pingpong.NewHermesChannelRepository(di.HermesPromiseStorage, di.BCHelper),
 		di.BCHelper,
 		di.IdentityRegistry,
 		di.Keystore,

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -180,7 +180,7 @@ func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) err
 func (di *Dependencies) bootstrapHermesPromiseSettler(nodeOptions node.Options) error {
 	di.HermesChannelRepository = pingpong.NewHermesChannelRepository(di.HermesPromiseStorage, di.BCHelper, di.EventBus)
 	if err := di.HermesChannelRepository.Subscribe(di.EventBus); err != nil {
-		log.Error().Msg("Failed to subscribe channel repository")
+		log.Error().Err(err).Msg("Failed to subscribe channel repository")
 		return errors.Wrap(err, "could not subscribe channel repository to relevant events")
 	}
 
@@ -266,7 +266,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 
 	serviceCleaner := service.Cleaner{SessionStorage: di.ServiceSessions}
 	if err := di.EventBus.Subscribe(servicestate.AppTopicServiceStatus, serviceCleaner.HandleServiceStatus); err != nil {
-		log.Error().Msg("Failed to subscribe service cleaner")
+		log.Error().Err(err).Msg("Failed to subscribe service cleaner")
 	}
 
 	return nil

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -834,7 +834,7 @@ func (m *connectionManager) currentCtx() context.Context {
 func (m *connectionManager) Reconnect() {
 	err := m.Disconnect()
 	if err != nil {
-		log.Error().Msgf("Failed to disconnect stale session: %v", err)
+		log.Error().Err(err).Msgf("Failed to disconnect stale session")
 	}
 	log.Info().Msg("Waiting for previous session to cleanup")
 
@@ -843,7 +843,7 @@ func (m *connectionManager) Reconnect() {
 	<-m.cleanupFinished
 	err = m.Connect(m.connectOptions.ConsumerID, m.connectOptions.HermesID, m.connectOptions.Proposal, m.connectOptions.Params)
 	if err != nil {
-		log.Error().Msgf("Failed to Reconnect: %v", err)
+		log.Error().Err(err).Msgf("Failed to reconnect")
 	}
 }
 

--- a/session/pingpong/hermes_channel.go
+++ b/session/pingpong/hermes_channel.go
@@ -23,11 +23,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/payments/client"
-	"github.com/mysteriumnetwork/payments/crypto"
 )
 
 // NewHermesChannel creates HermesChannel model.
-func NewHermesChannel(id identity.Identity, hermesID common.Address, channel client.ProviderChannel, promise crypto.Promise) HermesChannel {
+func NewHermesChannel(id identity.Identity, hermesID common.Address, channel client.ProviderChannel, promise HermesPromise) HermesChannel {
 	return HermesChannel{
 		Identity:    id,
 		HermesID:    hermesID,
@@ -41,20 +40,20 @@ type HermesChannel struct {
 	Identity    identity.Identity
 	HermesID    common.Address
 	channel     client.ProviderChannel
-	lastPromise crypto.Promise
+	lastPromise HermesPromise
 }
 
 // hasPromise returns flag if channel has something promised at all.
 func (hc HermesChannel) hasPromise() bool {
-	return hc.lastPromise.Amount != nil
+	return hc.lastPromise.Promise.Amount != nil
 }
 
 // lifetimeBalance returns earnings of all history.
 func (hc HermesChannel) lifetimeBalance() *big.Int {
-	if hc.lastPromise.Amount == nil {
+	if hc.lastPromise.Promise.Amount == nil {
 		return new(big.Int)
 	}
-	return hc.lastPromise.Amount
+	return hc.lastPromise.Promise.Amount
 }
 
 // unsettledBalance returns current unsettled earnings.
@@ -65,8 +64,8 @@ func (hc HermesChannel) unsettledBalance() *big.Int {
 	}
 
 	lastPromise := new(big.Int)
-	if hc.lastPromise.Amount != nil {
-		lastPromise = hc.lastPromise.Amount
+	if hc.lastPromise.Promise.Amount != nil {
+		lastPromise = hc.lastPromise.Promise.Amount
 	}
 
 	return safeSub(lastPromise, settled)
@@ -88,8 +87,8 @@ func (hc HermesChannel) availableBalance() *big.Int {
 
 func (hc HermesChannel) balance() *big.Int {
 	promised := new(big.Int)
-	if hc.lastPromise.Amount != nil {
-		promised = hc.lastPromise.Amount
+	if hc.lastPromise.Promise.Amount != nil {
+		promised = hc.lastPromise.Promise.Amount
 	}
 	return safeSub(hc.availableBalance(), promised)
 }

--- a/session/pingpong/hermes_channel.go
+++ b/session/pingpong/hermes_channel.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"math/big"
+
+	"github.com/mysteriumnetwork/payments/client"
+	"github.com/mysteriumnetwork/payments/crypto"
+)
+
+// HermesChannel represents opened payment channel between identity and hermes.
+type HermesChannel struct {
+	channel     client.ProviderChannel
+	lastPromise crypto.Promise
+}
+
+// lifetimeBalance returns earnings of all history.
+func (hc HermesChannel) lifetimeBalance() *big.Int {
+	if hc.lastPromise.Amount == nil {
+		return new(big.Int)
+	}
+	return hc.lastPromise.Amount
+}
+
+// unsettledBalance returns current unsettled earnings.
+func (hc HermesChannel) unsettledBalance() *big.Int {
+	settled := new(big.Int)
+	if hc.channel.Settled != nil {
+		settled = hc.channel.Settled
+	}
+
+	lastPromise := new(big.Int)
+	if hc.lastPromise.Amount != nil {
+		lastPromise = hc.lastPromise.Amount
+	}
+
+	return safeSub(lastPromise, settled)
+}
+
+func (hc HermesChannel) availableBalance() *big.Int {
+	balance := new(big.Int)
+	if hc.channel.Balance != nil {
+		balance = hc.channel.Balance
+	}
+
+	settled := new(big.Int)
+	if hc.channel.Settled != nil {
+		settled = hc.channel.Settled
+	}
+
+	return new(big.Int).Add(balance, settled)
+}
+
+func (hc HermesChannel) balance() *big.Int {
+	promised := new(big.Int)
+	if hc.lastPromise.Amount != nil {
+		promised = hc.lastPromise.Amount
+	}
+	return safeSub(hc.availableBalance(), promised)
+}

--- a/session/pingpong/hermes_channel.go
+++ b/session/pingpong/hermes_channel.go
@@ -20,12 +20,16 @@ package pingpong
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/payments/client"
 	"github.com/mysteriumnetwork/payments/crypto"
 )
 
 // HermesChannel represents opened payment channel between identity and hermes.
 type HermesChannel struct {
+	Identity    identity.Identity
+	HermesID    common.Address
 	channel     client.ProviderChannel
 	lastPromise crypto.Promise
 }

--- a/session/pingpong/hermes_channel.go
+++ b/session/pingpong/hermes_channel.go
@@ -43,11 +43,6 @@ type HermesChannel struct {
 	lastPromise HermesPromise
 }
 
-// hasPromise returns flag if channel has something promised at all.
-func (hc HermesChannel) hasPromise() bool {
-	return hc.lastPromise.Promise.Amount != nil
-}
-
 // lifetimeBalance returns earnings of all history.
 func (hc HermesChannel) lifetimeBalance() *big.Int {
 	if hc.lastPromise.Promise.Amount == nil {

--- a/session/pingpong/hermes_channel.go
+++ b/session/pingpong/hermes_channel.go
@@ -26,12 +26,27 @@ import (
 	"github.com/mysteriumnetwork/payments/crypto"
 )
 
+// NewHermesChannel creates HermesChannel model.
+func NewHermesChannel(id identity.Identity, hermesID common.Address, channel client.ProviderChannel, promise crypto.Promise) HermesChannel {
+	return HermesChannel{
+		Identity:    id,
+		HermesID:    hermesID,
+		channel:     channel,
+		lastPromise: promise,
+	}
+}
+
 // HermesChannel represents opened payment channel between identity and hermes.
 type HermesChannel struct {
 	Identity    identity.Identity
 	HermesID    common.Address
 	channel     client.ProviderChannel
 	lastPromise crypto.Promise
+}
+
+// hasPromise returns flag if channel has something promised at all.
+func (hc HermesChannel) hasPromise() bool {
+	return hc.lastPromise.Amount != nil
 }
 
 // lifetimeBalance returns earnings of all history.

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -67,7 +67,7 @@ func (hcr *HermesChannelRepository) Get(id identity.Identity, hermesID common.Ad
 		return HermesChannel{}, errors.Wrap(err, fmt.Sprintf("could not get hermes promise for provider %v, hermes %v", id, hermesID.Hex()))
 	}
 
-	return NewHermesChannel(id, hermesID, channel, promise.Promise), nil
+	return NewHermesChannel(id, hermesID, channel, promise), nil
 }
 
 // List retrieves the promise for the given hermes.
@@ -84,7 +84,7 @@ func (hcr *HermesChannelRepository) List(filter HermesPromiseFilter) ([]HermesCh
 			return []HermesChannel{}, err
 		}
 
-		result[i] = NewHermesChannel(promise.Identity, promise.HermesID, channel, promise.Promise)
+		result[i] = NewHermesChannel(promise.Identity, promise.HermesID, channel, promise)
 	}
 
 	return result, err

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -54,7 +54,7 @@ func NewHermesChannelRepository(promiseProvider promiseProvider, channelProvider
 func (hcr *HermesChannelRepository) Get(id identity.Identity, hermesID common.Address) (HermesChannel, error) {
 	channelID, err := crypto.GenerateProviderChannelID(id.Address, hermesID.Hex())
 	if err != nil {
-		return HermesChannel{}, errors.Wrap(err, "could not generate provider channel address")
+		return HermesChannel{}, fmt.Errorf("could not generate provider channel address: %w", err)
 	}
 
 	channel, err := hcr.fetchChannel(id, hermesID)

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/payments/client"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/pkg/errors"
+)
+
+type promiseProvider interface {
+	Get(channelID string) (HermesPromise, error)
+	List(filter HermesPromiseFilter) ([]HermesPromise, error)
+}
+
+type channelProvider interface {
+	GetProviderChannel(hermesAddress common.Address, addressToCheck common.Address, pending bool) (client.ProviderChannel, error)
+}
+
+// HermesChannelRepository is fetches HermesChannel models from blockchain.
+type HermesChannelRepository struct {
+	promises promiseProvider
+	channels channelProvider
+}
+
+// NewHermesChannelRepository returns a new instance of HermesChannelRepository.
+func NewHermesChannelRepository(promiseProvider promiseProvider, channelProvider channelProvider) *HermesChannelRepository {
+	return &HermesChannelRepository{
+		promises: promiseProvider,
+		channels: channelProvider,
+	}
+}
+
+// Get retrieves current channel for given identity.
+func (hcr *HermesChannelRepository) Get(id identity.Identity, hermesID common.Address) (HermesChannel, error) {
+	channelID, err := crypto.GenerateProviderChannelID(id.Address, hermesID.Hex())
+	if err != nil {
+		return HermesChannel{}, errors.Wrap(err, "could not generate provider channel address")
+	}
+
+	promise, err := hcr.promises.Get(channelID)
+	if err != nil {
+		return HermesChannel{}, err
+	}
+
+	return hcr.toChannel(promise)
+}
+
+// List retrieves the promise for the given hermes.
+func (hcr *HermesChannelRepository) List(filter HermesPromiseFilter) ([]HermesChannel, error) {
+	promises, err := hcr.promises.List(filter)
+	if err != nil {
+		return []HermesChannel{}, err
+	}
+
+	result := make([]HermesChannel, len(promises))
+	for i, promise := range promises {
+		result[i], err = hcr.toChannel(promise)
+		if err != nil {
+			return []HermesChannel{}, err
+		}
+	}
+
+	return result, err
+}
+
+func (hcr *HermesChannelRepository) toChannel(promise HermesPromise) (result HermesChannel, err error) {
+	result.Identity = promise.Identity
+	result.HermesID = promise.HermesID
+	result.lastPromise = promise.Promise
+	// TODO Should call GetProviderChannelByID() but can't pass pending=false
+	result.channel, err = hcr.channels.GetProviderChannel(promise.HermesID, promise.Identity.ToCommonAddress(), true)
+	if err != nil {
+		return result, errors.Wrap(err, fmt.Sprintf("could not get provider channel for %v, hermes %v", promise.Identity, promise.HermesID.Hex()))
+	}
+
+	return result, nil
+}

--- a/session/pingpong/hermes_channel_repository_test.go
+++ b/session/pingpong/hermes_channel_repository_test.go
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pingpong
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/mocks"
+	"github.com/mysteriumnetwork/node/session/pingpong/event"
+	"github.com/mysteriumnetwork/payments/client"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHermesChannelRepository_Fetch_returns_errors(t *testing.T) {
+	// given
+	id := identity.FromAddress("0x0000000000000000000000000000000000000001")
+	hermesID = common.HexToAddress("0x00000000000000000000000000000000000000002")
+	promiseProvider := &mockHermesPromiseStorage{}
+	channelStatusProvider := &mockProviderChannelStatusProvider{}
+	repo := NewHermesChannelRepository(promiseProvider, channelStatusProvider, mocks.NewEventBus())
+
+	// when
+	channelStatusProvider.channelReturnError = errMock
+	promiseProvider.errToReturn = nil
+	_, err := repo.Fetch(id, hermesID)
+	// then
+	assert.Errorf(t, err, "could not get provider channel for %v, hermes %v: %v", mockID, common.Address{}.Hex(), errMock.Error())
+
+	// when
+	channelStatusProvider.channelReturnError = nil
+	promiseProvider.errToReturn = errMock
+	_, err = repo.Fetch(mockID, hermesID)
+	// then
+	assert.Errorf(t, err, "could not get hermes promise for provider %v, hermes %v: %v", mockID, common.Address{}.Hex(), errMock.Error())
+
+}
+
+func TestHermesChannelRepository_Fetch_handles_no_promise(t *testing.T) {
+	// given
+	id := identity.FromAddress("0x0000000000000000000000000000000000000001")
+	hermesID = common.HexToAddress("0x00000000000000000000000000000000000000002")
+
+	expectedPromise := HermesPromise{}
+	promiseProvider := &mockHermesPromiseStorage{
+		toReturn:    expectedPromise,
+		errToReturn: ErrNotFound,
+	}
+
+	expectedChannelStatus := client.ProviderChannel{
+		Balance: big.NewInt(1000000000000),
+		Settled: big.NewInt(9000000),
+		Stake:   big.NewInt(12312323),
+	}
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: expectedChannelStatus,
+	}
+
+	// when
+	repo := NewHermesChannelRepository(promiseProvider, channelStatusProvider, mocks.NewEventBus())
+	channel, err := repo.Fetch(id, hermesID)
+	assert.NoError(t, err)
+
+	// then
+	expectedBalance := new(big.Int).Add(expectedChannelStatus.Balance, expectedChannelStatus.Settled)
+	assert.Equal(t, expectedBalance, channel.balance())
+	assert.Equal(t, expectedBalance, channel.availableBalance())
+}
+
+func TestHermesChannelRepository_Fetch_takes_promise_into_account(t *testing.T) {
+	// given
+	id := identity.FromAddress("0x0000000000000000000000000000000000000001")
+	hermesID = common.HexToAddress("0x00000000000000000000000000000000000000002")
+
+	expectedPromise := HermesPromise{
+		Promise: crypto.Promise{Amount: big.NewInt(7000000)},
+	}
+	promiseProvider := &mockHermesPromiseStorage{
+		toReturn: expectedPromise,
+	}
+
+	expectedChannelStatus := client.ProviderChannel{
+		Balance: big.NewInt(1000000000000),
+		Settled: big.NewInt(9000000),
+		Stake:   big.NewInt(12312323),
+	}
+	channelStatusProvider := &mockProviderChannelStatusProvider{
+		channelToReturn: expectedChannelStatus,
+	}
+
+	// when
+	repo := NewHermesChannelRepository(promiseProvider, channelStatusProvider, mocks.NewEventBus())
+	channel, err := repo.Fetch(id, hermesID)
+	assert.NoError(t, err)
+
+	// then
+	added := new(big.Int).Add(expectedChannelStatus.Balance, expectedChannelStatus.Settled)
+	expectedBalance := added.Sub(added, expectedPromise.Promise.Amount)
+	assert.Equal(t, expectedBalance, channel.balance())
+	assert.Equal(t, new(big.Int).Add(expectedChannelStatus.Balance, expectedChannelStatus.Settled), channel.availableBalance())
+}
+
+func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
+	// given
+	id := identity.FromAddress("0x0000000000000000000000000000000000000001")
+	hermesID = common.HexToAddress("0x00000000000000000000000000000000000000002")
+	expectedPromise1 := HermesPromise{
+		Promise: crypto.Promise{Amount: big.NewInt(7000000)},
+	}
+	expectedPromise2 := HermesPromise{
+		Promise: crypto.Promise{Amount: big.NewInt(8000000)},
+	}
+	expectedChannelStatus1 := client.ProviderChannel{
+		Balance: big.NewInt(1000000000000),
+		Settled: big.NewInt(9000000),
+		Stake:   big.NewInt(12312323),
+	}
+	expectedChannelStatus2 := client.ProviderChannel{
+		Balance: big.NewInt(1000000000001),
+		Settled: big.NewInt(9000001),
+		Stake:   big.NewInt(12312324),
+	}
+
+	promiseProvider := &mockHermesPromiseStorage{}
+	channelStatusProvider := &mockProviderChannelStatusProvider{}
+	publisher := mocks.NewEventBus()
+	repo := NewHermesChannelRepository(promiseProvider, channelStatusProvider, publisher)
+
+	// when
+	promiseProvider.toReturn = expectedPromise1
+	channelStatusProvider.channelToReturn = expectedChannelStatus1
+	channel, err := repo.Fetch(id, hermesID)
+	assert.NoError(t, err)
+
+	// then
+	expectedChannel1 := NewHermesChannel(id, hermesID, expectedChannelStatus1, expectedPromise1)
+	assert.Equal(t, expectedChannel1, channel)
+	assert.Eventually(t, func() bool {
+		lastEvent, ok := publisher.Pop().(event.AppEventEarningsChanged)
+		if !ok {
+			return false
+		}
+		assert.Equal(
+			t,
+			event.AppEventEarningsChanged{
+				Identity: id,
+				Previous: event.Earnings{
+					LifetimeBalance:  big.NewInt(0),
+					UnsettledBalance: big.NewInt(0),
+				},
+				Current: event.Earnings{
+					LifetimeBalance:  expectedChannel1.lifetimeBalance(),
+					UnsettledBalance: expectedChannel1.unsettledBalance(),
+				},
+			},
+			lastEvent,
+		)
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// when
+	promiseProvider.toReturn = expectedPromise2
+	channelStatusProvider.channelToReturn = expectedChannelStatus2
+	channel, err = repo.Fetch(id, hermesID)
+	assert.NoError(t, err)
+
+	// then
+	expectedChannel2 := NewHermesChannel(id, hermesID, expectedChannelStatus2, expectedPromise2)
+	assert.Equal(t, expectedChannel2, channel)
+	assert.Eventually(t, func() bool {
+		lastEvent, ok := publisher.Pop().(event.AppEventEarningsChanged)
+		if !ok {
+			return false
+		}
+		assert.Equal(
+			t,
+			event.AppEventEarningsChanged{
+				Identity: id,
+				Previous: event.Earnings{
+					LifetimeBalance:  expectedChannel1.lifetimeBalance(),
+					UnsettledBalance: expectedChannel1.unsettledBalance(),
+				},
+				Current: event.Earnings{
+					LifetimeBalance:  expectedChannel2.lifetimeBalance(),
+					UnsettledBalance: expectedChannel2.unsettledBalance(),
+				},
+			},
+			lastEvent,
+		)
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+}

--- a/session/pingpong/hermes_channel_test.go
+++ b/session/pingpong/hermes_channel_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pingpong
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/mysteriumnetwork/payments/client"
+	"github.com/mysteriumnetwork/payments/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHermesChannel_balance(t *testing.T) {
+	channel := HermesChannel{
+		channel: client.ProviderChannel{
+			Balance: big.NewInt(100),
+			Settled: big.NewInt(10),
+		},
+		lastPromise: crypto.Promise{
+			Amount: big.NewInt(15),
+		},
+	}
+	assert.Equal(t, big.NewInt(110), channel.availableBalance())
+	assert.Equal(t, big.NewInt(95), channel.balance())
+	assert.Equal(t, big.NewInt(5), channel.unsettledBalance())
+
+	channel = HermesChannel{
+		channel: client.ProviderChannel{
+			Balance: big.NewInt(100),
+			Settled: big.NewInt(10),
+		},
+		lastPromise: crypto.Promise{
+			Amount: big.NewInt(16),
+		},
+	}
+	assert.Equal(t, big.NewInt(110), channel.availableBalance())
+	assert.Equal(t, big.NewInt(94), channel.balance())
+	assert.Equal(t, big.NewInt(6), channel.unsettledBalance())
+}

--- a/session/pingpong/hermes_channel_test.go
+++ b/session/pingpong/hermes_channel_test.go
@@ -32,8 +32,8 @@ func TestHermesChannel_balance(t *testing.T) {
 			Balance: big.NewInt(100),
 			Settled: big.NewInt(10),
 		},
-		lastPromise: crypto.Promise{
-			Amount: big.NewInt(15),
+		lastPromise: HermesPromise{
+			Promise: crypto.Promise{Amount: big.NewInt(15)},
 		},
 	}
 	assert.Equal(t, big.NewInt(110), channel.availableBalance())
@@ -45,8 +45,8 @@ func TestHermesChannel_balance(t *testing.T) {
 			Balance: big.NewInt(100),
 			Settled: big.NewInt(10),
 		},
-		lastPromise: crypto.Promise{
-			Amount: big.NewInt(16),
+		lastPromise: HermesPromise{
+			Promise: crypto.Promise{Amount: big.NewInt(16)},
 		},
 	}
 	assert.Equal(t, big.NewInt(110), channel.availableBalance())

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -63,7 +63,8 @@ type transactor interface {
 }
 
 type hermesChannelProvider interface {
-	Get(id identity.Identity, hermesID common.Address) (HermesChannel, error)
+	Get(id identity.Identity, hermesID common.Address) (HermesChannel, bool)
+	Fetch(id identity.Identity, hermesID common.Address) (HermesChannel, error)
 }
 
 type receivedPromise struct {
@@ -75,17 +76,14 @@ type receivedPromise struct {
 
 // HermesPromiseSettler is responsible for settling the hermes promises.
 type HermesPromiseSettler interface {
-	GetEarnings(id identity.Identity) event.Earnings
 	ForceSettle(providerID identity.Identity, hermesID common.Address) error
 	SettleWithBeneficiary(providerID identity.Identity, beneficiary, hermesID common.Address) error
 	SettleIntoStake(providerID identity.Identity, hermesID common.Address) error
 	GetHermesFee(common.Address) (uint16, error)
-	Subscribe() error
 }
 
 // hermesPromiseSettler is responsible for settling the hermes promises.
 type hermesPromiseSettler struct {
-	eventBus                   eventbus.EventBus
 	bc                         providerChannelStatusProvider
 	config                     HermesPromiseSettlerConfig
 	lock                       sync.RWMutex
@@ -109,9 +107,8 @@ type HermesPromiseSettlerConfig struct {
 }
 
 // NewHermesPromiseSettler creates a new instance of hermes promise settler.
-func NewHermesPromiseSettler(eventBus eventbus.EventBus, transactor transactor, channelProvider hermesChannelProvider, providerChannelStatusProvider providerChannelStatusProvider, registrationStatusProvider registrationStatusProvider, ks ks, settlementHistoryStorage settlementHistoryStorage, config HermesPromiseSettlerConfig) *hermesPromiseSettler {
+func NewHermesPromiseSettler(transactor transactor, channelProvider hermesChannelProvider, providerChannelStatusProvider providerChannelStatusProvider, registrationStatusProvider registrationStatusProvider, ks ks, settlementHistoryStorage settlementHistoryStorage, config HermesPromiseSettlerConfig) *hermesPromiseSettler {
 	return &hermesPromiseSettler{
-		eventBus:                   eventBus,
 		bc:                         providerChannelStatusProvider,
 		ks:                         ks,
 		registrationStatusProvider: registrationStatusProvider,
@@ -133,78 +130,54 @@ func (aps *hermesPromiseSettler) GetHermesFee(hermesID common.Address) (uint16, 
 }
 
 // loadInitialState loads the initial state for the given identity. Inteded to be called on service start.
-func (aps *hermesPromiseSettler) loadInitialState(addr identity.Identity) error {
+func (aps *hermesPromiseSettler) loadInitialState(id identity.Identity) error {
 	aps.lock.Lock()
 	defer aps.lock.Unlock()
 
-	if _, ok := aps.currentState[addr]; ok {
-		log.Info().Msgf("State for %v already loaded, skipping", addr)
+	if _, ok := aps.currentState[id]; ok {
+		log.Info().Msgf("State for %v already loaded, skipping", id)
 		return nil
 	}
 
-	status, err := aps.registrationStatusProvider.GetRegistrationStatus(addr)
+	status, err := aps.registrationStatusProvider.GetRegistrationStatus(id)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("could not check registration status for %v", addr))
+		return errors.Wrap(err, fmt.Sprintf("could not check registration status for %v", id))
 	}
 
 	if status != registry.Registered {
-		log.Info().Msgf("Provider %v not registered, skipping", addr)
+		log.Info().Msgf("Provider %v not registered, skipping", id)
 		return nil
 	}
 
-	_, err = aps.resyncState(addr, aps.config.HermesAddress)
-	return err
-}
-
-func (aps *hermesPromiseSettler) resyncState(id identity.Identity, hermesID common.Address) (HermesChannel, error) {
-	hc, err := aps.channelProvider.Get(id, hermesID)
-	if err != nil && err != ErrNotFound {
-		return HermesChannel{}, err
+	aps.currentState[id] = settlementState{
+		registered: true,
 	}
-
-	s := aps.currentState[id]
-	if len(s.hermeses) == 0 {
-		s.hermeses = make(map[common.Address]HermesChannel)
-	}
-	s.registered = true
-	s.hermeses[hermesID] = hc
-	go aps.publishChangeEvent(id, aps.currentState[id], s)
-	aps.currentState[id] = s
-	log.Info().Msgf("Loaded state for provider %q, hermesID %q: balance %v, available balance %v, unsettled balance %v", id, hermesID.Hex(), hc.balance(), hc.availableBalance(), hc.unsettledBalance())
-	return hc, nil
-}
-
-func (aps *hermesPromiseSettler) publishChangeEvent(id identity.Identity, before, after settlementState) {
-	aps.eventBus.Publish(event.AppTopicEarningsChanged, event.AppEventEarningsChanged{
-		Identity: id,
-		Previous: before.Earnings(),
-		Current:  after.Earnings(),
-	})
+	return nil
 }
 
 // Subscribe subscribes the hermes promise settler to the appropriate events
-func (aps *hermesPromiseSettler) Subscribe() error {
-	err := aps.eventBus.SubscribeAsync(nodevent.AppTopicNode, aps.handleNodeEvent)
+func (aps *hermesPromiseSettler) Subscribe(bus eventbus.Subscriber) error {
+	err := bus.SubscribeAsync(nodevent.AppTopicNode, aps.handleNodeEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to node status event")
 	}
 
-	err = aps.eventBus.SubscribeAsync(registry.AppTopicIdentityRegistration, aps.handleRegistrationEvent)
+	err = bus.SubscribeAsync(registry.AppTopicIdentityRegistration, aps.handleRegistrationEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to registration event")
 	}
 
-	err = aps.eventBus.SubscribeAsync(servicestate.AppTopicServiceStatus, aps.handleServiceEvent)
+	err = bus.SubscribeAsync(servicestate.AppTopicServiceStatus, aps.handleServiceEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to service status event")
 	}
 
-	err = aps.eventBus.SubscribeAsync(event.AppTopicSettlementRequest, aps.handleSettlementEvent)
+	err = bus.SubscribeAsync(event.AppTopicSettlementRequest, aps.handleSettlementEvent)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe to settlement event")
 	}
 
-	err = aps.eventBus.SubscribeAsync(event.AppTopicHermesPromise, aps.handleHermesPromiseReceived)
+	err = bus.SubscribeAsync(event.AppTopicHermesPromise, aps.handleHermesPromiseReceived)
 	return errors.Wrap(err, "could not subscribe to hermes promise event")
 }
 
@@ -249,12 +222,9 @@ func (aps *hermesPromiseSettler) handleRegistrationEvent(payload registry.AppEve
 	}
 	log.Info().Msgf("Identity registration event received for provider %q", payload.ID)
 
-	_, err := aps.resyncState(payload.ID, aps.config.HermesAddress)
-	if err != nil {
-		log.Error().Err(err).Msgf("Could not resync state for provider %v", payload.ID)
-		return
-	}
-
+	s := aps.currentState[payload.ID]
+	s.registered = true
+	aps.currentState[payload.ID] = s
 	log.Info().Msgf("Identity registration event handled for provider %q", payload.ID)
 }
 
@@ -274,21 +244,21 @@ func (aps *hermesPromiseSettler) handleHermesPromiseReceived(apep event.AppEvent
 		return
 	}
 
-	hermes, err := aps.resyncState(id, apep.HermesID)
-	if err != nil {
+	channel, err := aps.channelProvider.Fetch(id, apep.HermesID)
+	if err != nil && err != ErrNotFound {
 		log.Error().Err(err).Msgf("could not sync state for provider %v, hermesID %v", apep.ProviderID, apep.HermesID.Hex())
 		return
 	}
 	log.Info().Msgf("Hermes %q promise state updated for provider %q", apep.HermesID.Hex(), id)
 
-	if s.needsSettling(aps.config.Threshold, apep.HermesID) {
-		if hermes.channel.Stake != nil && hermes.channel.StakeGoal != nil && hermes.channel.Stake.Uint64() < hermes.channel.StakeGoal.Uint64() {
+	if s.needsSettling(aps.config.Threshold, channel) {
+		if channel.channel.Stake != nil && channel.channel.StakeGoal != nil && channel.channel.Stake.Uint64() < channel.channel.StakeGoal.Uint64() {
 			go func() {
 				err := aps.SettleIntoStake(id, apep.HermesID)
 				log.Error().Err(err).Msgf("could not settle into stake for %q", apep.ProviderID)
 			}()
 		} else {
-			aps.initiateSettling(hermes)
+			aps.initiateSettling(channel)
 		}
 	}
 }
@@ -333,22 +303,11 @@ func (aps *hermesPromiseSettler) listenForSettlementRequests() {
 	}
 }
 
-// GetEarnings returns current settlement status for given identity
-func (aps *hermesPromiseSettler) GetEarnings(id identity.Identity) event.Earnings {
-	aps.lock.RLock()
-	defer aps.lock.RUnlock()
-
-	return aps.currentState[id].Earnings()
-}
-
 // SettleIntoStake settles the promise but transfers the money to stake increase, not to beneficiary.
 func (aps *hermesPromiseSettler) SettleIntoStake(providerID identity.Identity, hermesID common.Address) error {
-	channel, err := aps.channelProvider.Get(providerID, hermesID)
-	if err == ErrNotFound {
+	channel, found := aps.channelProvider.Get(providerID, hermesID)
+	if !found {
 		return ErrNothingToSettle
-	}
-	if err != nil {
-		return errors.Wrap(err, "could not get promise from storage")
 	}
 
 	hexR, err := hex.DecodeString(channel.lastPromise.R)
@@ -372,12 +331,9 @@ var ErrNothingToSettle = errors.New("nothing to settle for the given provider")
 
 // ForceSettle forces the settlement for a provider
 func (aps *hermesPromiseSettler) ForceSettle(providerID identity.Identity, hermesID common.Address) error {
-	channel, err := aps.channelProvider.Get(providerID, hermesID)
-	if err == ErrNotFound {
+	channel, found := aps.channelProvider.Get(providerID, hermesID)
+	if !found {
 		return ErrNothingToSettle
-	}
-	if err != nil {
-		return errors.Wrap(err, "could not get promise from storage")
 	}
 
 	hexR, err := hex.DecodeString(channel.lastPromise.R)
@@ -399,12 +355,9 @@ func (aps *hermesPromiseSettler) ForceSettle(providerID identity.Identity, herme
 
 // ForceSettle forces the settlement for a provider
 func (aps *hermesPromiseSettler) SettleWithBeneficiary(providerID identity.Identity, hermesID, beneficiary common.Address) error {
-	channel, err := aps.channelProvider.Get(providerID, hermesID)
-	if err == ErrNotFound {
+	channel, found := aps.channelProvider.Get(providerID, hermesID)
+	if !found {
 		return ErrNothingToSettle
-	}
-	if err != nil {
-		return errors.Wrap(err, "could not get promise from storage")
 	}
 
 	hexR, err := hex.DecodeString(channel.lastPromise.R)
@@ -478,16 +431,13 @@ func (aps *hermesPromiseSettler) settle(
 				Amount:         info.Amount,
 				TotalSettled:   info.TotalSettled,
 			}
-
 			err = aps.settlementHistoryStorage.Store(she)
 			if err != nil {
 				log.Error().Err(err).Msg("Could not store settlement history")
 			}
 
-			_, err = aps.resyncState(provider, hermesID)
+			_, err = aps.channelProvider.Fetch(provider, hermesID)
 			if err != nil {
-				// This will get retried so we do not need to explicitly retry
-				// TODO: maybe add a sane limit of retries
 				log.Error().Err(err).Msgf("Resync failed for provider %v", provider)
 			} else {
 				log.Info().Msgf("Resync success for provider %v", provider)
@@ -555,10 +505,9 @@ func (aps *hermesPromiseSettler) handleNodeStop() {
 type settlementState struct {
 	settleInProgress bool
 	registered       bool
-	hermeses         map[common.Address]HermesChannel
 }
 
-func (ss settlementState) needsSettling(threshold float64, hermesID common.Address) bool {
+func (ss settlementState) needsSettling(threshold float64, channel HermesChannel) bool {
 	if !ss.registered {
 		return false
 	}
@@ -567,42 +516,24 @@ func (ss settlementState) needsSettling(threshold float64, hermesID common.Addre
 		return false
 	}
 
-	hermes, ok := ss.hermeses[hermesID]
-	if !ok {
-		return false
-	}
-
-	if hermes.channel.Stake.Cmp(big.NewInt(0)) == 0 {
+	if channel.channel.Stake.Cmp(big.NewInt(0)) == 0 {
 		// if starting with zero stake, only settle one myst or more.
-		if hermes.unsettledBalance().Cmp(big.NewInt(0).SetUint64(crypto.Myst)) == -1 {
+		if channel.unsettledBalance().Cmp(big.NewInt(0).SetUint64(crypto.Myst)) == -1 {
 			return false
 		}
 	}
 
-	floated := new(big.Float).SetInt(hermes.availableBalance())
+	floated := new(big.Float).SetInt(channel.availableBalance())
 	calculatedThreshold := new(big.Float).Mul(big.NewFloat(threshold), floated)
-	possibleEarnings := hermes.unsettledBalance()
+	possibleEarnings := channel.unsettledBalance()
 	i, _ := calculatedThreshold.Int(nil)
 	if possibleEarnings.Cmp(i) == -1 {
 		return false
 	}
 
-	if hermes.balance().Cmp(i) <= 0 {
+	if channel.balance().Cmp(i) <= 0 {
 		return true
 	}
 
 	return false
-}
-
-func (ss settlementState) Earnings() event.Earnings {
-	var lifetimeBalance = new(big.Int)
-	var unsettledBalance = new(big.Int)
-	for _, v := range ss.hermeses {
-		lifetimeBalance = new(big.Int).Add(lifetimeBalance, v.lifetimeBalance())
-		unsettledBalance = new(big.Int).Add(unsettledBalance, v.unsettledBalance())
-	}
-	return event.Earnings{
-		LifetimeBalance:  lifetimeBalance,
-		UnsettledBalance: unsettledBalance,
-	}
 }

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -169,6 +169,8 @@ func (aps *hermesPromiseSettler) resyncState(id identity.Identity, hermesID comm
 	}
 
 	hs := HermesChannel{
+		Identity:    id,
+		HermesID:    hermesID,
 		channel:     channel,
 		lastPromise: hermesPromise.Promise,
 	}

--- a/session/pingpong/hermes_promise_settler_test.go
+++ b/session/pingpong/hermes_promise_settler_test.go
@@ -45,12 +45,12 @@ func TestPromiseSettler_resyncState_returns_errors(t *testing.T) {
 	ks := identity.NewMockKeystore()
 
 	settler := NewHermesPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, &settlementHistoryStorageMock{}, cfg)
-	err := settler.resyncState(mockID, hermesID)
+	_, err := settler.resyncState(mockID, hermesID)
 	assert.Equal(t, fmt.Sprintf("could not get provider channel for %v, hermes %v: %v", mockID, hermesID.Hex(), errMock.Error()), err.Error())
 
 	channelStatusProvider.channelReturnError = nil
 	mapg.err = errMock
-	err = settler.resyncState(mockID, hermesID)
+	_, err = settler.resyncState(mockID, hermesID)
 	assert.Equal(t, fmt.Sprintf("could not get hermes promise for provider %v, hermes %v: %v", mockID, hermesID.Hex(), errMock.Error()), err.Error())
 }
 
@@ -66,7 +66,7 @@ func TestPromiseSettler_resyncState_handles_no_promise(t *testing.T) {
 	ks := identity.NewMockKeystore()
 
 	settler := NewHermesPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, &settlementHistoryStorageMock{}, cfg)
-	err := settler.resyncState(mockID, hermesID)
+	_, err := settler.resyncState(mockID, hermesID)
 	assert.NoError(t, err)
 
 	v := settler.currentState[mockID]
@@ -92,7 +92,7 @@ func TestPromiseSettler_resyncState_takes_promise_into_account(t *testing.T) {
 	ks := identity.NewMockKeystore()
 
 	settler := NewHermesPromiseSettler(eventbus.New(), &mockTransactor{}, mapg, channelStatusProvider, mrsp, ks, &settlementHistoryStorageMock{}, cfg)
-	err := settler.resyncState(mockID, hermesID)
+	_, err := settler.resyncState(mockID, hermesID)
 	assert.NoError(t, err)
 
 	v := settler.currentState[mockID]
@@ -141,7 +141,7 @@ func TestPromiseSettler_loadInitialState(t *testing.T) {
 	assert.EqualValues(t, settlementState{
 		registered: true,
 		hermeses: map[common.Address]HermesChannel{
-			cfg.HermesAddress: NewHermesChannel(mockID, cfg.HermesAddress, mockProviderChannel, crypto.Promise{}),
+			cfg.HermesAddress: NewHermesChannel(mockID, cfg.HermesAddress, mockProviderChannel, HermesPromise{}),
 		},
 	}, v)
 
@@ -282,8 +282,10 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 	settler.currentState[mockID] = settlementState{
 		hermeses: map[common.Address]HermesChannel{
 			cfg.HermesAddress: {
-				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
-				lastPromise: crypto.Promise{Amount: big.NewInt(8900)},
+				channel: client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
+				lastPromise: HermesPromise{
+					Promise: crypto.Promise{Amount: big.NewInt(8900)},
+				},
 			},
 		},
 		registered: true,
@@ -304,8 +306,10 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 	settler.currentState[mockID] = settlementState{
 		hermeses: map[common.Address]HermesChannel{
 			cfg.HermesAddress: {
-				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(0)},
-				lastPromise: crypto.Promise{Amount: big.NewInt(8900)},
+				channel: client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(0)},
+				lastPromise: HermesPromise{
+					Promise: crypto.Promise{Amount: big.NewInt(8900)},
+				},
 			},
 		},
 		registered: true,
@@ -373,8 +377,10 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 	s := settlementState{
 		hermeses: map[common.Address]HermesChannel{
 			{}: {
-				channel:     client.ProviderChannel{Balance: big.NewInt(100), Stake: big.NewInt(1000)},
-				lastPromise: crypto.Promise{Amount: big.NewInt(100)},
+				channel: client.ProviderChannel{Balance: big.NewInt(100), Stake: big.NewInt(1000)},
+				lastPromise: HermesPromise{
+					Promise: crypto.Promise{Amount: big.NewInt(100)},
+				},
 			},
 		},
 
@@ -384,8 +390,10 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 	s = settlementState{
 		hermeses: map[common.Address]HermesChannel{
 			{}: {
-				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
-				lastPromise: crypto.Promise{Amount: big.NewInt(9000)},
+				channel: client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
+				lastPromise: HermesPromise{
+					Promise: crypto.Promise{Amount: big.NewInt(9000)},
+				},
 			},
 		},
 		registered: true,
@@ -401,8 +409,10 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 	s = settlementState{
 		hermeses: map[common.Address]HermesChannel{
 			{}: {
-				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
-				lastPromise: crypto.Promise{Amount: big.NewInt(8999)},
+				channel: client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
+				lastPromise: HermesPromise{
+					Promise: crypto.Promise{Amount: big.NewInt(8999)},
+				},
 			},
 		},
 		registered: true,

--- a/session/pingpong/hermes_promise_settler_test.go
+++ b/session/pingpong/hermes_promise_settler_test.go
@@ -141,15 +141,7 @@ func TestPromiseSettler_loadInitialState(t *testing.T) {
 	assert.EqualValues(t, settlementState{
 		registered: true,
 		hermeses: map[common.Address]HermesChannel{
-			cfg.HermesAddress: {
-				Identity: mockID,
-				HermesID: cfg.HermesAddress,
-				channel: client.ProviderChannel{
-					Balance: big.NewInt(1000000000000),
-					Settled: big.NewInt(9000000),
-					Stake:   big.NewInt(12312323),
-				},
-			},
+			cfg.HermesAddress: NewHermesChannel(mockID, cfg.HermesAddress, mockProviderChannel, crypto.Promise{}),
 		},
 	}, v)
 

--- a/session/pingpong/hermes_promise_settler_test.go
+++ b/session/pingpong/hermes_promise_settler_test.go
@@ -140,7 +140,7 @@ func TestPromiseSettler_loadInitialState(t *testing.T) {
 	v = settler.currentState[mockID]
 	assert.EqualValues(t, settlementState{
 		registered: true,
-		hermeses: map[common.Address]hermesState{
+		hermeses: map[common.Address]HermesChannel{
 			cfg.HermesAddress: {
 				channel: client.ProviderChannel{
 					Balance: big.NewInt(1000000000000),
@@ -286,7 +286,7 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 
 	// should receive on registered provider. Should also expect a recalculated balance to be added to the settlementState
 	settler.currentState[mockID] = settlementState{
-		hermeses: map[common.Address]hermesState{
+		hermeses: map[common.Address]HermesChannel{
 			cfg.HermesAddress: {
 				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
 				lastPromise: crypto.Promise{Amount: big.NewInt(8900)},
@@ -308,7 +308,7 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 
 	// should not receive here due to balance being large and stake being small
 	settler.currentState[mockID] = settlementState{
-		hermeses: map[common.Address]hermesState{
+		hermeses: map[common.Address]HermesChannel{
 			cfg.HermesAddress: {
 				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(0)},
 				lastPromise: crypto.Promise{Amount: big.NewInt(8900)},
@@ -377,7 +377,7 @@ func TestPromiseSettler_handleNodeStart(t *testing.T) {
 
 func TestPromiseSettlerState_needsSettling(t *testing.T) {
 	s := settlementState{
-		hermeses: map[common.Address]hermesState{
+		hermeses: map[common.Address]HermesChannel{
 			{}: {
 				channel:     client.ProviderChannel{Balance: big.NewInt(100), Stake: big.NewInt(1000)},
 				lastPromise: crypto.Promise{Amount: big.NewInt(100)},
@@ -388,7 +388,7 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 	}
 	assert.True(t, s.needsSettling(0.1, common.Address{}), "should be true with zero balance left")
 	s = settlementState{
-		hermeses: map[common.Address]hermesState{
+		hermeses: map[common.Address]HermesChannel{
 			{}: {
 				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
 				lastPromise: crypto.Promise{Amount: big.NewInt(9000)},
@@ -405,7 +405,7 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 	assert.False(t, s.needsSettling(0.1, common.Address{}), "should be false with settle in progress")
 
 	s = settlementState{
-		hermeses: map[common.Address]hermesState{
+		hermeses: map[common.Address]HermesChannel{
 			{}: {
 				channel:     client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
 				lastPromise: crypto.Promise{Amount: big.NewInt(8999)},
@@ -414,42 +414,6 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 		registered: true,
 	}
 	assert.False(t, s.needsSettling(0.1, common.Address{}), "should be false with 10.01% missing")
-}
-
-func TestPromiseSettlerState_balance(t *testing.T) {
-	s := settlementState{
-		hermeses: map[common.Address]hermesState{
-			{}: {
-				channel: client.ProviderChannel{
-					Balance: big.NewInt(100),
-					Settled: big.NewInt(10),
-				},
-				lastPromise: crypto.Promise{
-					Amount: big.NewInt(15),
-				},
-			},
-		},
-	}
-	assert.Equal(t, big.NewInt(110), s.hermeses[common.Address{}].availableBalance())
-	assert.Equal(t, big.NewInt(95), s.hermeses[common.Address{}].balance())
-	assert.Equal(t, big.NewInt(5), s.hermeses[common.Address{}].unsettledBalance())
-
-	s = settlementState{
-		hermeses: map[common.Address]hermesState{
-			{}: {
-				channel: client.ProviderChannel{
-					Balance: big.NewInt(100),
-					Settled: big.NewInt(10),
-				},
-				lastPromise: crypto.Promise{
-					Amount: big.NewInt(16),
-				},
-			},
-		},
-	}
-	assert.Equal(t, big.NewInt(110), s.hermeses[common.Address{}].availableBalance())
-	assert.Equal(t, big.NewInt(94), s.hermeses[common.Address{}].balance())
-	assert.Equal(t, big.NewInt(6), s.hermeses[common.Address{}].unsettledBalance())
 }
 
 // mocks start here

--- a/session/pingpong/hermes_promise_settler_test.go
+++ b/session/pingpong/hermes_promise_settler_test.go
@@ -142,6 +142,8 @@ func TestPromiseSettler_loadInitialState(t *testing.T) {
 		registered: true,
 		hermeses: map[common.Address]HermesChannel{
 			cfg.HermesAddress: {
+				Identity: mockID,
+				HermesID: cfg.HermesAddress,
 				channel: client.ProviderChannel{
 					Balance: big.NewInt(1000000000000),
 					Settled: big.NewInt(9000000),

--- a/session/pingpong/hermes_promise_storage.go
+++ b/session/pingpong/hermes_promise_storage.go
@@ -18,6 +18,7 @@
 package pingpong
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -27,7 +28,6 @@ import (
 	"github.com/mysteriumnetwork/node/core/storage/boltdb"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/payments/crypto"
-	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
 
@@ -66,7 +66,7 @@ func (aps *HermesPromiseStorage) Store(promise HermesPromise) error {
 	defer aps.lock.Unlock()
 
 	previousPromise, err := aps.get(promise.ChannelID)
-	if err != nil && err != ErrNotFound {
+	if err != nil && !errors.Is(err, ErrNotFound) {
 		return err
 	}
 

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -804,6 +804,10 @@ func (maps *mockHermesPromiseStorage) Get(_ string) (HermesPromise, error) {
 	return maps.toReturn, maps.errToReturn
 }
 
+func (maps *mockHermesPromiseStorage) List(_ HermesPromiseFilter) ([]HermesPromise, error) {
+	return []HermesPromise{maps.toReturn}, maps.errToReturn
+}
+
 type mockBlockchainHelper struct {
 	feeToReturn   uint16
 	errorToReturn error

--- a/session/pingpong/noop/hermes_promise_settler.go
+++ b/session/pingpong/noop/hermes_promise_settler.go
@@ -20,21 +20,10 @@ package noop
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/identity"
-	"github.com/mysteriumnetwork/node/session/pingpong/event"
 )
 
 // NoopHermesPromiseSettler doesn't do much.
 type NoopHermesPromiseSettler struct {
-}
-
-// Subscribe does nothing.
-func (n *NoopHermesPromiseSettler) Subscribe() error {
-	return nil
-}
-
-// GetEarnings returns an empty state.
-func (n *NoopHermesPromiseSettler) GetEarnings(_ identity.Identity) event.Earnings {
-	return event.Earnings{}
 }
 
 // ForceSettle does nothing.


### PR DESCRIPTION
Updates: #2527

This introduces `PaymentChannel` model, which earnings balance with of some hermes instance.

Also earning balances decoupled to `HermesChannelRepository`, reasons:
- Until now you needed to get earnings balances from settler component even if no settling will be done.
- And settler synced only balances of currently started service, while `HermesChannelRepository` syncs channels all previously touched hermeses.