### PR TITLE
Expose provider payments channels to SSE state

### DIFF
--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/node/money"
+	"github.com/mysteriumnetwork/node/session/pingpong"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/payments/crypto"
 )
@@ -37,11 +38,12 @@ const AppTopicState = "State change"
 
 // State represents the node state at the current moment. It's a read only object, used only to display data.
 type State struct {
-	NATStatus  contract.NATStatusDTO
-	Services   []contract.ServiceInfoDTO
-	Sessions   []session.History
-	Connection Connection
-	Identities []Identity
+	NATStatus       contract.NATStatusDTO
+	Services        []contract.ServiceInfoDTO
+	Sessions        []session.History
+	Connection      Connection
+	Identities      []Identity
+	PaymentChannels []pingpong.HermesChannel
 }
 
 // Identity represents identity and its status.

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -38,12 +38,12 @@ const AppTopicState = "State change"
 
 // State represents the node state at the current moment. It's a read only object, used only to display data.
 type State struct {
-	NATStatus       contract.NATStatusDTO
-	Services        []contract.ServiceInfoDTO
-	Sessions        []session.History
-	Connection      Connection
-	Identities      []Identity
-	PaymentChannels []pingpong.HermesChannel
+	NATStatus        contract.NATStatusDTO
+	Services         []contract.ServiceInfoDTO
+	Sessions         []session.History
+	Connection       Connection
+	Identities       []Identity
+	ProviderChannels []pingpong.HermesChannel
 }
 
 // Identity represents identity and its status.

--- a/core/state/state.go
+++ b/core/state/state.go
@@ -125,7 +125,7 @@ func NewKeeper(deps KeeperDeps, debounceDuration time.Duration) *Keeper {
 		deps: deps,
 	}
 	k.state.Identities = k.fetchIdentities()
-	k.state.PaymentChannels = k.deps.EarningsProvider.List()
+	k.state.ProviderChannels = k.deps.EarningsProvider.List()
 
 	// provider
 	k.consumeServiceStateEvent = debounce(k.updateServiceState, debounceDuration)
@@ -480,7 +480,7 @@ func (k *Keeper) consumeEarningsChangedEvent(e interface{}) {
 		return
 	}
 
-	k.state.PaymentChannels = k.deps.EarningsProvider.List()
+	k.state.ProviderChannels = k.deps.EarningsProvider.List()
 
 	var id *stateEvent.Identity
 	for i := range k.state.Identities {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -526,8 +526,8 @@ func Test_ConsumesEarningsChangeEvent(t *testing.T) {
 	err := keeper.Subscribe(eventBus)
 	assert.NoError(t, err)
 	assert.Zero(t, keeper.GetState().Identities[0].Balance.Uint64())
-	assert.Len(t, keeper.GetState().PaymentChannels, 1)
-	assert.Equal(t, channelsProvider.Channels, keeper.GetState().PaymentChannels)
+	assert.Len(t, keeper.GetState().ProviderChannels, 1)
+	assert.Equal(t, channelsProvider.Channels, keeper.GetState().ProviderChannels)
 
 	// when
 	channelsProvider.Channels = []pingpong.HermesChannel{
@@ -544,8 +544,8 @@ func Test_ConsumesEarningsChangeEvent(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return keeper.GetState().Identities[0].Earnings.Cmp(big.NewInt(10)) == 0 && keeper.GetState().Identities[0].EarningsTotal.Cmp(big.NewInt(100)) == 0
 	}, 2*time.Second, 10*time.Millisecond)
-	assert.Len(t, keeper.GetState().PaymentChannels, 2)
-	assert.Equal(t, channelsProvider.Channels, keeper.GetState().PaymentChannels)
+	assert.Len(t, keeper.GetState().ProviderChannels, 2)
+	assert.Equal(t, channelsProvider.Channels, keeper.GetState().ProviderChannels)
 }
 
 func Test_ConsumesIdentityRegistrationEvent(t *testing.T) {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -148,6 +148,7 @@ func Test_ConsumesNATEvents(t *testing.T) {
 		Publisher:         publisher,
 		ServiceLister:     sl,
 		IdentityProvider:  &mocks.IdentityProvider{},
+		EarningsProvider:  &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, duration)
 
@@ -182,6 +183,7 @@ func Test_ConsumesSessionEvents(t *testing.T) {
 	deps := KeeperDeps{
 		Publisher:        eventBus,
 		IdentityProvider: &mocks.IdentityProvider{},
+		EarningsProvider: &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	keeper.Subscribe(eventBus)
@@ -236,6 +238,7 @@ func Test_ConsumesSessionAcknowledgeEvents(t *testing.T) {
 	deps := KeeperDeps{
 		Publisher:        eventBus,
 		IdentityProvider: &mocks.IdentityProvider{},
+		EarningsProvider: &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	keeper.Subscribe(eventBus)
@@ -269,6 +272,7 @@ func Test_consumeServiceSessionEarningsEvent(t *testing.T) {
 	deps := KeeperDeps{
 		Publisher:        eventBus,
 		IdentityProvider: &mocks.IdentityProvider{},
+		EarningsProvider: &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	keeper.Subscribe(eventBus)
@@ -301,6 +305,7 @@ func Test_consumeServiceSessionStatisticsEvent(t *testing.T) {
 	deps := KeeperDeps{
 		Publisher:        eventBus,
 		IdentityProvider: &mocks.IdentityProvider{},
+		EarningsProvider: &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	keeper.Subscribe(eventBus)
@@ -348,6 +353,7 @@ func Test_ConsumesServiceEvents(t *testing.T) {
 		Publisher:         publisher,
 		ServiceLister:     sl,
 		IdentityProvider:  &mocks.IdentityProvider{},
+		EarningsProvider:  &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, duration)
 
@@ -376,6 +382,7 @@ func Test_ConsumesConnectionStateEvents(t *testing.T) {
 		Publisher:         eventBus,
 		ServiceLister:     &serviceListerMock{},
 		IdentityProvider:  &mocks.IdentityProvider{},
+		EarningsProvider:  &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	err := keeper.Subscribe(eventBus)
@@ -408,6 +415,7 @@ func Test_ConsumesConnectionStatisticsEvents(t *testing.T) {
 		Publisher:         eventBus,
 		ServiceLister:     &serviceListerMock{},
 		IdentityProvider:  &mocks.IdentityProvider{},
+		EarningsProvider:  &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	err := keeper.Subscribe(eventBus)
@@ -438,6 +446,7 @@ func Test_ConsumesConnectionInvoiceEvents(t *testing.T) {
 		Publisher:         eventBus,
 		ServiceLister:     &serviceListerMock{},
 		IdentityProvider:  &mocks.IdentityProvider{},
+		EarningsProvider:  &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	err := keeper.Subscribe(eventBus)
@@ -493,6 +502,12 @@ func Test_ConsumesBalanceChangeEvent(t *testing.T) {
 func Test_ConsumesEarningsChangeEvent(t *testing.T) {
 	// given
 	eventBus := eventbus.New()
+	channelsProvider := &mockEarningsProvider{
+		Channels: []pingpong.HermesChannel{
+			{ChannelID: "1"},
+		},
+	}
+
 	deps := KeeperDeps{
 		NATStatusProvider: &natStatusProviderMock{statusToReturn: mockNATStatus},
 		Publisher:         eventBus,
@@ -505,14 +520,20 @@ func Test_ConsumesEarningsChangeEvent(t *testing.T) {
 		IdentityRegistry:          &mocks.IdentityRegistry{Status: registry.Registered},
 		IdentityChannelCalculator: pingpong.NewChannelAddressCalculator("", "", ""),
 		BalanceProvider:           &mockBalanceProvider{Balance: big.NewInt(0)},
-		EarningsProvider:          &mockEarningsProvider{},
+		EarningsProvider:          channelsProvider,
 	}
 	keeper := NewKeeper(deps, time.Millisecond)
 	err := keeper.Subscribe(eventBus)
 	assert.NoError(t, err)
 	assert.Zero(t, keeper.GetState().Identities[0].Balance.Uint64())
+	assert.Len(t, keeper.GetState().PaymentChannels, 1)
+	assert.Equal(t, channelsProvider.Channels, keeper.GetState().PaymentChannels)
 
 	// when
+	channelsProvider.Channels = []pingpong.HermesChannel{
+		{ChannelID: "1"},
+		{ChannelID: "2"},
+	}
 	eventBus.Publish(pingpongEvent.AppTopicEarningsChanged, pingpongEvent.AppEventEarningsChanged{
 		Identity: identity.Identity{Address: "0x000000000000000000000000000000000000000a"},
 		Previous: pingpongEvent.Earnings{},
@@ -523,6 +544,8 @@ func Test_ConsumesEarningsChangeEvent(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return keeper.GetState().Identities[0].Earnings.Cmp(big.NewInt(10)) == 0 && keeper.GetState().Identities[0].EarningsTotal.Cmp(big.NewInt(100)) == 0
 	}, 2*time.Second, 10*time.Millisecond)
+	assert.Len(t, keeper.GetState().PaymentChannels, 2)
+	assert.Equal(t, channelsProvider.Channels, keeper.GetState().PaymentChannels)
 }
 
 func Test_ConsumesIdentityRegistrationEvent(t *testing.T) {
@@ -575,6 +598,7 @@ func Test_getServiceByID(t *testing.T) {
 		Publisher:         publisher,
 		ServiceLister:     sl,
 		IdentityProvider:  &mocks.IdentityProvider{},
+		EarningsProvider:  &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, duration)
 	myID := "test"
@@ -612,6 +636,7 @@ func Test_incrementConnectionCount(t *testing.T) {
 		Publisher:         publisher,
 		ServiceLister:     sl,
 		IdentityProvider:  &mocks.IdentityProvider{},
+		EarningsProvider:  &mockEarningsProvider{},
 	}
 	keeper := NewKeeper(deps, duration)
 	myID := "test"
@@ -652,6 +677,12 @@ func (mbp *mockBalanceProvider) GetBalance(_ identity.Identity) *big.Int {
 
 type mockEarningsProvider struct {
 	Earnings pingpongEvent.Earnings
+	Channels []pingpong.HermesChannel
+}
+
+// List retrieves identity's channels with all known hermeses.
+func (mep *mockEarningsProvider) List() []pingpong.HermesChannel {
+	return mep.Channels
 }
 
 // GetEarnings returns a pre-defined settlement state.

--- a/session/pingpong/hermes_channel.go
+++ b/session/pingpong/hermes_channel.go
@@ -45,16 +45,16 @@ type HermesChannel struct {
 	lastPromise HermesPromise
 }
 
-// lifetimeBalance returns earnings of all history.
-func (hc HermesChannel) lifetimeBalance() *big.Int {
+// LifetimeBalance returns earnings of all history.
+func (hc HermesChannel) LifetimeBalance() *big.Int {
 	if hc.lastPromise.Promise.Amount == nil {
 		return new(big.Int)
 	}
 	return hc.lastPromise.Promise.Amount
 }
 
-// unsettledBalance returns current unsettled earnings.
-func (hc HermesChannel) unsettledBalance() *big.Int {
+// UnsettledBalance returns current unsettled earnings.
+func (hc HermesChannel) UnsettledBalance() *big.Int {
 	settled := new(big.Int)
 	if hc.channel.Settled != nil {
 		settled = hc.channel.Settled

--- a/session/pingpong/hermes_channel.go
+++ b/session/pingpong/hermes_channel.go
@@ -26,8 +26,9 @@ import (
 )
 
 // NewHermesChannel creates HermesChannel model.
-func NewHermesChannel(id identity.Identity, hermesID common.Address, channel client.ProviderChannel, promise HermesPromise) HermesChannel {
+func NewHermesChannel(channelID string, id identity.Identity, hermesID common.Address, channel client.ProviderChannel, promise HermesPromise) HermesChannel {
 	return HermesChannel{
+		ChannelID:   channelID,
 		Identity:    id,
 		HermesID:    hermesID,
 		channel:     channel,
@@ -37,6 +38,7 @@ func NewHermesChannel(id identity.Identity, hermesID common.Address, channel cli
 
 // HermesChannel represents opened payment channel between identity and hermes.
 type HermesChannel struct {
+	ChannelID   string
 	Identity    identity.Identity
 	HermesID    common.Address
 	channel     client.ProviderChannel

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -121,8 +121,8 @@ func (hcr *HermesChannelRepository) sumChannels(id identity.Identity) event.Earn
 	var unsettledBalance = new(big.Int)
 	for _, channel := range hcr.channels {
 		if channel.Identity == id {
-			lifetimeBalance = new(big.Int).Add(lifetimeBalance, channel.lifetimeBalance())
-			unsettledBalance = new(big.Int).Add(unsettledBalance, channel.unsettledBalance())
+			lifetimeBalance = new(big.Int).Add(lifetimeBalance, channel.LifetimeBalance())
+			unsettledBalance = new(big.Int).Add(unsettledBalance, channel.UnsettledBalance())
 		}
 	}
 
@@ -200,7 +200,7 @@ func (hcr *HermesChannelRepository) updateChannel(new HermesChannel) {
 		new.HermesID.Hex(),
 		new.balance(),
 		new.availableBalance(),
-		new.unsettledBalance(),
+		new.UnsettledBalance(),
 	)
 
 	earningsNew := hcr.sumChannels(new.Identity)

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -78,7 +78,7 @@ func (hcr *HermesChannelRepository) Fetch(id identity.Identity, hermesID common.
 		return HermesChannel{}, fmt.Errorf("could not get hermes promise for provider %v, hermes %v: %w", id, hermesID.Hex(), err)
 	}
 
-	channel, err := hcr.fetchChannel(id, hermesID, promise)
+	channel, err := hcr.fetchChannel(promise.ChannelID, id, hermesID, promise)
 	if err != nil {
 		return HermesChannel{}, err
 	}
@@ -159,13 +159,13 @@ func (hcr *HermesChannelRepository) fetchKnownChannels() {
 	}
 
 	for _, promise := range promises {
-		if _, err := hcr.fetchChannel(promise.Identity, promise.HermesID, promise); err != nil {
+		if _, err := hcr.fetchChannel(promise.ChannelID, promise.Identity, promise.HermesID, promise); err != nil {
 			log.Error().Err(err).Msg("could not load initial earnings state")
 		}
 	}
 }
 
-func (hcr *HermesChannelRepository) fetchChannel(id identity.Identity, hermesID common.Address, promise HermesPromise) (HermesChannel, error) {
+func (hcr *HermesChannelRepository) fetchChannel(channelID string, id identity.Identity, hermesID common.Address, promise HermesPromise) (HermesChannel, error) {
 	// TODO Should call GetProviderChannelByID() but can't pass pending=false
 	// This will get retried so we do not need to explicitly retry
 	// TODO: maybe add a sane limit of retries
@@ -174,7 +174,7 @@ func (hcr *HermesChannelRepository) fetchChannel(id identity.Identity, hermesID 
 		return HermesChannel{}, fmt.Errorf("could not get provider channel for %v, hermes %v: %w", id, hermesID.Hex(), err)
 	}
 
-	hermesChannel := NewHermesChannel(id, hermesID, channel, promise)
+	hermesChannel := NewHermesChannel(channelID, id, hermesID, channel, promise)
 	hcr.updateChannel(hermesChannel)
 
 	return hermesChannel, nil

--- a/session/pingpong/hermes_channel_repository_test.go
+++ b/session/pingpong/hermes_channel_repository_test.go
@@ -169,8 +169,8 @@ func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
 					UnsettledBalance: big.NewInt(0),
 				},
 				Current: event.Earnings{
-					LifetimeBalance:  expectedChannel1.lifetimeBalance(),
-					UnsettledBalance: expectedChannel1.unsettledBalance(),
+					LifetimeBalance:  expectedChannel1.LifetimeBalance(),
+					UnsettledBalance: expectedChannel1.UnsettledBalance(),
 				},
 			},
 			lastEvent,
@@ -197,12 +197,12 @@ func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
 			event.AppEventEarningsChanged{
 				Identity: id,
 				Previous: event.Earnings{
-					LifetimeBalance:  expectedChannel1.lifetimeBalance(),
-					UnsettledBalance: expectedChannel1.unsettledBalance(),
+					LifetimeBalance:  expectedChannel1.LifetimeBalance(),
+					UnsettledBalance: expectedChannel1.UnsettledBalance(),
 				},
 				Current: event.Earnings{
-					LifetimeBalance:  expectedChannel2.lifetimeBalance(),
-					UnsettledBalance: expectedChannel2.unsettledBalance(),
+					LifetimeBalance:  expectedChannel2.LifetimeBalance(),
+					UnsettledBalance: expectedChannel2.UnsettledBalance(),
 				},
 			},
 			lastEvent,

--- a/session/pingpong/hermes_channel_repository_test.go
+++ b/session/pingpong/hermes_channel_repository_test.go
@@ -123,10 +123,12 @@ func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
 	id := identity.FromAddress("0x0000000000000000000000000000000000000001")
 	hermesID = common.HexToAddress("0x00000000000000000000000000000000000000002")
 	expectedPromise1 := HermesPromise{
-		Promise: crypto.Promise{Amount: big.NewInt(7000000)},
+		ChannelID: "1",
+		Promise:   crypto.Promise{Amount: big.NewInt(7000000)},
 	}
 	expectedPromise2 := HermesPromise{
-		Promise: crypto.Promise{Amount: big.NewInt(8000000)},
+		ChannelID: "1",
+		Promise:   crypto.Promise{Amount: big.NewInt(8000000)},
 	}
 	expectedChannelStatus1 := client.ProviderChannel{
 		Balance: big.NewInt(1000000000000),
@@ -151,7 +153,7 @@ func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
 	assert.NoError(t, err)
 
 	// then
-	expectedChannel1 := NewHermesChannel(id, hermesID, expectedChannelStatus1, expectedPromise1)
+	expectedChannel1 := NewHermesChannel("1", id, hermesID, expectedChannelStatus1, expectedPromise1)
 	assert.Equal(t, expectedChannel1, channel)
 	assert.Eventually(t, func() bool {
 		lastEvent, ok := publisher.Pop().(event.AppEventEarningsChanged)
@@ -183,7 +185,7 @@ func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
 	assert.NoError(t, err)
 
 	// then
-	expectedChannel2 := NewHermesChannel(id, hermesID, expectedChannelStatus2, expectedPromise2)
+	expectedChannel2 := NewHermesChannel("1", id, hermesID, expectedChannelStatus2, expectedPromise2)
 	assert.Equal(t, expectedChannel2, channel)
 	assert.Eventually(t, func() bool {
 		lastEvent, ok := publisher.Pop().(event.AppEventEarningsChanged)

--- a/session/pingpong/hermes_channel_test.go
+++ b/session/pingpong/hermes_channel_test.go
@@ -38,7 +38,7 @@ func TestHermesChannel_balance(t *testing.T) {
 	}
 	assert.Equal(t, big.NewInt(110), channel.availableBalance())
 	assert.Equal(t, big.NewInt(95), channel.balance())
-	assert.Equal(t, big.NewInt(5), channel.unsettledBalance())
+	assert.Equal(t, big.NewInt(5), channel.UnsettledBalance())
 
 	channel = HermesChannel{
 		channel: client.ProviderChannel{
@@ -51,5 +51,5 @@ func TestHermesChannel_balance(t *testing.T) {
 	}
 	assert.Equal(t, big.NewInt(110), channel.availableBalance())
 	assert.Equal(t, big.NewInt(94), channel.balance())
-	assert.Equal(t, big.NewInt(6), channel.unsettledBalance())
+	assert.Equal(t, big.NewInt(6), channel.UnsettledBalance())
 }

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -521,14 +521,14 @@ func (ss settlementState) needsSettling(threshold float64, channel HermesChannel
 
 	if channel.channel.Stake.Cmp(big.NewInt(0)) == 0 {
 		// if starting with zero stake, only settle one myst or more.
-		if channel.unsettledBalance().Cmp(big.NewInt(0).SetUint64(crypto.Myst)) == -1 {
+		if channel.UnsettledBalance().Cmp(big.NewInt(0).SetUint64(crypto.Myst)) == -1 {
 			return false
 		}
 	}
 
 	floated := new(big.Float).SetInt(channel.availableBalance())
 	calculatedThreshold := new(big.Float).Mul(big.NewFloat(threshold), floated)
-	possibleEarnings := channel.unsettledBalance()
+	possibleEarnings := channel.UnsettledBalance()
 	i, _ := calculatedThreshold.Int(nil)
 	if possibleEarnings.Cmp(i) == -1 {
 		return false

--- a/session/pingpong/hermes_promise_settler_test.go
+++ b/session/pingpong/hermes_promise_settler_test.go
@@ -140,7 +140,7 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 	settler := NewHermesPromiseSettler(&mockTransactor{}, channelProvider, channelStatusProvider, mrsp, ks, &settlementHistoryStorageMock{}, cfg)
 
 	// no receive on unknown provider
-	channelProvider.channelToReturn = NewHermesChannel(mockID, hermesID, mockProviderChannel, HermesPromise{})
+	channelProvider.channelToReturn = NewHermesChannel("1", mockID, hermesID, mockProviderChannel, HermesPromise{})
 	settler.handleHermesPromiseReceived(event.AppEventHermesPromise{
 		HermesID:   hermesID,
 		ProviderID: mockID,
@@ -151,7 +151,7 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 	settler.currentState[mockID] = settlementState{
 		registered: false,
 	}
-	channelProvider.channelToReturn = NewHermesChannel(mockID, hermesID, mockProviderChannel, HermesPromise{})
+	channelProvider.channelToReturn = NewHermesChannel("1", mockID, hermesID, mockProviderChannel, HermesPromise{})
 	settler.handleHermesPromiseReceived(event.AppEventHermesPromise{
 		HermesID:   hermesID,
 		ProviderID: mockID,
@@ -164,7 +164,7 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 	settler.currentState[mockID] = settlementState{
 		registered: true,
 	}
-	channelProvider.channelToReturn = NewHermesChannel(mockID, hermesID, expectedChannel, HermesPromise{Promise: expectedPromise})
+	channelProvider.channelToReturn = NewHermesChannel("1", mockID, hermesID, expectedChannel, HermesPromise{Promise: expectedPromise})
 	settler.handleHermesPromiseReceived(event.AppEventHermesPromise{
 		HermesID:   hermesID,
 		ProviderID: mockID,
@@ -181,7 +181,7 @@ func TestPromiseSettler_handleHermesPromiseReceived(t *testing.T) {
 		registered:       true,
 		settleInProgress: false,
 	}
-	channelProvider.channelToReturn = NewHermesChannel(mockID, hermesID, mockProviderChannel, HermesPromise{Promise: expectedPromise})
+	channelProvider.channelToReturn = NewHermesChannel("1", mockID, hermesID, mockProviderChannel, HermesPromise{Promise: expectedPromise})
 	settler.handleHermesPromiseReceived(event.AppEventHermesPromise{
 		HermesID:   hermesID,
 		ProviderID: mockID,
@@ -239,6 +239,7 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 		registered: true,
 	}
 	channel := NewHermesChannel(
+		"1",
 		mockID,
 		hermesID,
 		client.ProviderChannel{Balance: big.NewInt(100), Stake: big.NewInt(1000)},
@@ -250,6 +251,7 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 		registered: true,
 	}
 	channel = NewHermesChannel(
+		"1",
 		mockID,
 		hermesID,
 		client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},
@@ -267,6 +269,7 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 		registered: true,
 	}
 	channel = NewHermesChannel(
+		"1",
 		mockID,
 		hermesID,
 		client.ProviderChannel{Balance: big.NewInt(10000), Stake: big.NewInt(1000)},

--- a/tequilapi/contract/channel.go
+++ b/tequilapi/contract/channel.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package contract
+
+import (
+	"math/big"
+
+	"github.com/mysteriumnetwork/node/session/pingpong"
+)
+
+// NewPaymentChannelDTO maps to API payment channel.
+func NewPaymentChannelDTO(channel pingpong.HermesChannel) PaymentChannelDTO {
+	return PaymentChannelDTO{
+		ID:            channel.ChannelID,
+		OwnerID:       channel.Identity.Address,
+		HermesID:      channel.HermesID.Hex(),
+		Earnings:      channel.UnsettledBalance(),
+		EarningsTotal: channel.LifetimeBalance(),
+	}
+}
+
+// PaymentChannelDTO represents represents opened payment channel between identity and hermes.
+// swagger:model SettlementDTO
+type PaymentChannelDTO struct {
+	// Unique identifier of payment channel
+	// example: 0x8fc5f7a1794dc39c6837df10613bddf1ec9810503a50306a8667f702457a739a
+	ID string `json:"id"`
+
+	// example: 0x0000000000000000000000000000000000000001
+	OwnerID string `json:"owner_id"`
+
+	// example: 0x42a537D649d6853C0a866470f2d084DA0f73b5E4
+	HermesID string `json:"hermes_id"`
+
+	// Current unsettled earnings
+	// example: 19449034049997187
+	Earnings *big.Int `json:"earnings"`
+
+	// Earnings of all history
+	// example: 19449034049997187
+	EarningsTotal *big.Int `json:"earnings_total"`
+}

--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -207,12 +207,13 @@ func (h *Handler) ConsumeNodeEvent(e nodeEvent.Payload) {
 }
 
 type stateRes struct {
-	NATStatus     contract.NATStatusDTO     `json:"nat_status"`
-	Services      []contract.ServiceInfoDTO `json:"service_info"`
-	Sessions      []contract.SessionDTO     `json:"sessions"`
-	SessionsStats contract.SessionStatsDTO  `json:"sessions_stats"`
-	Consumer      consumerStateRes          `json:"consumer"`
-	Identities    []contract.IdentityDTO    `json:"identities"`
+	NATStatus     contract.NATStatusDTO        `json:"nat_status"`
+	Services      []contract.ServiceInfoDTO    `json:"service_info"`
+	Sessions      []contract.SessionDTO        `json:"sessions"`
+	SessionsStats contract.SessionStatsDTO     `json:"sessions_stats"`
+	Consumer      consumerStateRes             `json:"consumer"`
+	Identities    []contract.IdentityDTO       `json:"identities"`
+	Channels      []contract.PaymentChannelDTO `json:"channels"`
 }
 
 type consumerStateRes struct {
@@ -233,6 +234,11 @@ func mapState(event stateEvent.State) stateRes {
 		}
 	}
 
+	channelsRes := make([]contract.PaymentChannelDTO, len(event.ProviderChannels))
+	for idx, channel := range event.ProviderChannels {
+		channelsRes[idx] = contract.NewPaymentChannelDTO(channel)
+	}
+
 	sessionsRes := make([]contract.SessionDTO, len(event.Sessions))
 	sessionsStats := session.NewStats()
 	for idx, se := range event.Sessions {
@@ -249,6 +255,7 @@ func mapState(event stateEvent.State) stateRes {
 			Connection: contract.NewConnectionDTO(event.Connection.Session, event.Connection.Statistics, event.Connection.Throughput, event.Connection.Invoice),
 		},
 		Identities: identitiesRes,
+		Channels:   channelsRes,
 	}
 	return res
 }

--- a/tequilapi/endpoints/sse_handler_test.go
+++ b/tequilapi/endpoints/sse_handler_test.go
@@ -151,7 +151,8 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
         "status": ""
       }
     },
-    "identities": []
+    "identities": [],
+    "channels": []
   },
   "type": "state-change"
 }`
@@ -189,7 +190,8 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
         "status": ""
       }
     },
-    "identities": []
+    "identities": [],
+	"channels": []
   },
   "type": "state-change"
 }`
@@ -244,7 +246,8 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
 		"earnings_total": 100,
 		"stake": 0
       }
-    ]
+    ],
+    "channels": []
   },
   "type": "state-change"
 }`


### PR DESCRIPTION
Updates: #2527

This exposes `PaymentChannel` model to Tequilapi (just SSE for now)

```
curl http://localhost:4050/events/state

{
  "payload": {
    "nat_status": {
      "status": "not_finished",
      "error": ""
    },
    "service_info": null,
    "sessions": [],
    "sessions_stats": {
      "count": 0,
      "count_consumers": 0,
      "sum_bytes_received": 0,
      "sum_bytes_sent": 0,
      "sum_duration": 0,
      "sum_tokens": 0
    },
    "consumer": {
      "connection": {
        "status": "NotConnected"
      }
    },
    "identities": [
      {
        "id": "0x8a51dd417d80a2e046bb9fb6496ab22b97f49c49",
        "registration_status": "Registered",
        "channel_address": "0x719D074145157e1c7764176B0e5a61CD18e38AD6",
        "balance": 0,
        "earnings": 19449034049997187,
        "earnings_total": 19449034049997187,
        "stake": 0
      }
    ],
    "channels": [
      {
        "address": "0x8fc5f7a1794dc39c6837df10613bddf1ec9810503a50306a8667f702457a739a",
        "owner_id": "0x8a51dd417d80a2e046bb9fb6496ab22b97f49c49",
        "hermes_id": "0x42a537D649d6853C0a866470f2d084DA0f73b5E4",
        "earnings": 19449034049997187,
        "earnings_total": 19449034049997187
      }
    ]
  },
  "type": "state-change"
}
```