### PR TITLE
Fix panic on morqa stop

### DIFF
--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -59,7 +59,9 @@ type MysteriumMORQA struct {
 	batch    metrics.Batch
 	eventsMu sync.Mutex
 	metrics  chan metric
-	stop     chan struct{}
+
+	once sync.Once
+	stop chan struct{}
 }
 
 // NewMorqaClient creates Mysterium Morqa client with a real communication
@@ -136,7 +138,9 @@ func (m *MysteriumMORQA) signMetric(metric metric) (*metrics.Event, error) {
 
 // Stop sends the final metrics to the MORQA and stops the sending process.
 func (m *MysteriumMORQA) Stop() {
-	close(m.stop)
+	m.once.Do(func() {
+		close(m.stop)
+	})
 
 	if err := m.sendMetrics(); err != nil {
 		log.Error().Err(err).Msg("Failed to sent batch metrics request on close")


### PR DESCRIPTION
```
panic: close of closed channel
goroutine 338 [running]:
github.com/mysteriumnetwork/node/core/quality.(*MysteriumMORQA).Stop(0xc0000f30e0)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/core/quality/mysterium_morqa.go:139 +0x36
github.com/mysteriumnetwork/node/cmd.(*Dependencies).Shutdown(0xc0002c2900, 0x0, 0x0)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/cmd/di.go:377 +0x2ae
github.com/mysteriumnetwork/node/utils.stop(0xc000b330b0, 0x5562d68)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/utils/stopper.go:52 +0x2b
github.com/mysteriumnetwork/node/utils.newStopper.func1()
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/utils/stopper.go:47 +0x33
github.com/mysteriumnetwork/node/tequilapi/endpoints.callStopWhenNotified(0xc000bee420, 0xc000b3f120)
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/tequilapi/endpoints/stop.go:52 +0x3e
created by github.com/mysteriumnetwork/node/tequilapi/endpoints.newStopHandler.func1
	/Users/soffokl/go/src/github.com/mysteriumnetwork/node/tequilapi/endpoints/stop.go:46 +0xa5
```