### PR TITLE
Allow default iptables FORWARD policy to be DROP

### DIFF
--- a/nat/service_iptables.go
+++ b/nat/service_iptables.go
@@ -161,6 +161,10 @@ func makeIPTablesRules(opts Options) (rules []iptables.Rule) {
 		"--table", "nat")
 	rules = append(rules, rule)
 
+	// ACCEPT forwarding rules
+	rules = append(rules, iptables.AppendTo(chainForward).RuleSpec("--source", vpnNetwork, "--jump", "ACCEPT"))
+	rules = append(rules, iptables.AppendTo(chainForward).RuleSpec("--destination", vpnNetwork, "--jump", "ACCEPT"))
+
 	return rules
 }
 


### PR DESCRIPTION
We were requesting users to do a manual configuration to change the default policy.
This change allows us to keep the default policy as DROP and we are adding only smaller IP-ranges to ACCEPT.

Closes https://github.com/mysteriumnetwork/node/issues/2751