### PR TITLE
Introduce API client which bypasses DNS lookups

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -610,6 +610,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 	//override defined values one by one from options
 	if optionsNetwork.MysteriumAPIAddress != metadata.DefaultNetwork.MysteriumAPIAddress {
 		network.MysteriumAPIAddress = optionsNetwork.MysteriumAPIAddress
+		network.DNSMap = nil
 	}
 
 	if optionsNetwork.BrokerAddress != metadata.DefaultNetwork.BrokerAddress {
@@ -622,7 +623,9 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 
 	di.NetworkDefinition = network
 
-	di.MysteriumAPI = mysterium.NewClient(di.HTTPClient, network.MysteriumAPIAddress)
+	httpTransport := requests.NewTransport(requests.NewDialerBypassDNS(options.BindAddress, network.DNSMap))
+	httpClient := requests.NewHTTPClientWith(httpTransport, requests.DefaultTimeout)
+	di.MysteriumAPI = mysterium.NewClient(httpClient, network.MysteriumAPIAddress)
 
 	brokerURL, err := nats.ParseServerURI(di.NetworkDefinition.BrokerAddress)
 	if err != nil {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -624,7 +624,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 	di.NetworkDefinition = network
 
 	httpTransport := requests.NewTransport(requests.NewDialerBypassDNS(options.BindAddress, network.DNSMap))
-	httpClient := requests.NewHTTPClientWith(httpTransport, requests.DefaultTimeout)
+	httpClient := requests.NewHTTPClientWithTransport(httpTransport, requests.DefaultTimeout)
 	di.MysteriumAPI = mysterium.NewClient(httpClient, network.MysteriumAPIAddress)
 
 	brokerURL, err := nats.ParseServerURI(di.NetworkDefinition.BrokerAddress)

--- a/core/node/options_network.go
+++ b/core/node/options_network.go
@@ -27,6 +27,6 @@ type OptionsNetwork struct {
 
 	MysteriumAPIAddress string
 	BrokerAddress       string
-
-	EtherClientRPC string
+	EtherClientRPC      string
+	DNSMap              map[string]string
 }

--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -74,7 +74,7 @@ func NewMorqaClient(srcIP, baseURL string, signer identity.SignerFactory, timeou
 		clientFactory: func() *http.Client {
 			return &http.Client{
 				Timeout:   timeout,
-				Transport: requests.GetDefaultTransport(srcIP),
+				Transport: requests.NewTransport(requests.NewDialer(srcIP)),
 			}
 		},
 	}

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -31,6 +31,7 @@ type NetworkDefinition struct {
 	MMNAPIAddress             string
 	DAIAddress                string
 	WETHAddress               string
+	DNSMap                    map[string]string
 }
 
 // TestnetDefinition defines parameters for test network (currently default network)
@@ -47,6 +48,9 @@ var TestnetDefinition = NetworkDefinition{
 	MMNAPIAddress:             "https://my.mysterium.network/api/v1",
 	DAIAddress:                "0xC496Bae7780C92281F19626F233b1B11f52D38A3",
 	WETHAddress:               "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+	DNSMap: map[string]string{
+		"testnet-api.mysterium.network:443": "78.47.176.149",
+	},
 }
 
 // BetanetDefinition defines parameters for Betanet network (currently default network)
@@ -63,6 +67,9 @@ var BetanetDefinition = NetworkDefinition{
 	MMNAPIAddress:             "https://betanet.mysterium.network/api/v1",
 	DAIAddress:                "0xC496Bae7780C92281F19626F233b1B11f52D38A3",
 	WETHAddress:               "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+	DNSMap: map[string]string{
+		"betanet-api.mysterium.network:443": "78.47.55.197",
+	},
 }
 
 // LocalnetDefinition defines parameters for local network
@@ -74,6 +81,9 @@ var LocalnetDefinition = NetworkDefinition{
 	EtherClientRPC:            "http://localhost:8545",
 	MMNAddress:                "http://localhost/",
 	MMNAPIAddress:             "http://localhost/api/v1",
+	DNSMap: map[string]string{
+		"localhost:8001": "127.0.0.1",
+	},
 }
 
 // DefaultNetwork defines default network values when no runtime parameters are given

--- a/requests/client.go
+++ b/requests/client.go
@@ -33,8 +33,8 @@ const (
 	DefaultTimeout = 20 * time.Second
 )
 
-// NewHTTPClientWith creates a new HTTP client with custom transport.
-func NewHTTPClientWith(transport *http.Transport, timeout time.Duration) *HTTPClient {
+// NewHTTPClientWithTransport creates a new HTTP client with custom transport.
+func NewHTTPClientWithTransport(transport *http.Transport, timeout time.Duration) *HTTPClient {
 	c := &HTTPClient{
 		clientFactory: func() *http.Client {
 			return &http.Client{
@@ -51,7 +51,7 @@ func NewHTTPClientWith(transport *http.Transport, timeout time.Duration) *HTTPCl
 
 // NewHTTPClient creates a new HTTP client.
 func NewHTTPClient(srcIP string, timeout time.Duration) *HTTPClient {
-	return NewHTTPClientWith(NewTransport(NewDialer(srcIP)), timeout)
+	return NewHTTPClientWithTransport(NewTransport(NewDialer(srcIP)), timeout)
 }
 
 // HTTPClient describes a client for performing HTTP requests.

--- a/requests/client.go
+++ b/requests/client.go
@@ -33,19 +33,25 @@ const (
 	DefaultTimeout = 20 * time.Second
 )
 
-// NewHTTPClient creates a new HTTP client.
-func NewHTTPClient(srcIP string, timeout time.Duration) *HTTPClient {
+// NewHTTPClientWith creates a new HTTP client with custom transport.
+func NewHTTPClientWith(transport *http.Transport, timeout time.Duration) *HTTPClient {
 	c := &HTTPClient{
 		clientFactory: func() *http.Client {
 			return &http.Client{
 				Timeout:   timeout,
-				Transport: NewTransport(NewDialer(srcIP)),
+				Transport: transport,
 			}
 		},
 	}
 	// Create initial clean before any HTTP request is made.
 	c.client = c.clientFactory()
+
 	return c
+}
+
+// NewHTTPClient creates a new HTTP client.
+func NewHTTPClient(srcIP string, timeout time.Duration) *HTTPClient {
+	return NewHTTPClientWith(NewTransport(NewDialer(srcIP)), timeout)
 }
 
 // HTTPClient describes a client for performing HTTP requests.

--- a/requests/client.go
+++ b/requests/client.go
@@ -39,7 +39,7 @@ func NewHTTPClient(srcIP string, timeout time.Duration) *HTTPClient {
 		clientFactory: func() *http.Client {
 			return &http.Client{
 				Timeout:   timeout,
-				Transport: GetDefaultTransport(srcIP),
+				Transport: NewTransport(NewDialer(srcIP)),
 			}
 		},
 	}

--- a/requests/dialer.go
+++ b/requests/dialer.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package requests
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+)
+
+// Dialer wraps default go dialer with extra features.
+type Dialer struct {
+	zeroDialer *net.Dialer
+	addrToIP   map[string]string
+}
+
+// DialContext connects to the address on the named network using the provided context.
+func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if d.addrToIP != nil {
+		_, addrPort, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid dial address: %w", err)
+		}
+
+		addrIP, exist := d.addrToIP[addr]
+		if !exist {
+			return nil, &net.DNSError{Err: "unmapped address", Name: addr, Server: "localmap", IsNotFound: true}
+		}
+
+		addr = addrIP + ":" + addrPort
+	}
+
+	return d.zeroDialer.DialContext(ctx, network, addr)
+}
+
+// NewDialer creates dialer with default configuration.
+func NewDialer(srcIP string) *Dialer {
+	return &Dialer{
+		zeroDialer: &net.Dialer{
+			Timeout:   60 * time.Second,
+			KeepAlive: 30 * time.Second,
+			LocalAddr: &net.TCPAddr{IP: net.ParseIP(srcIP)},
+		},
+	}
+}
+
+// NewDialerBypassDNS creates dialer which avoids DNS lookups.
+func NewDialerBypassDNS(srcIP string, addrToIP map[string]string) *Dialer {
+	dialer := NewDialer(srcIP)
+	dialer.addrToIP = addrToIP
+
+	return dialer
+}

--- a/requests/dialer.go
+++ b/requests/dialer.go
@@ -26,8 +26,8 @@ import (
 
 // Dialer wraps default go dialer with extra features.
 type Dialer struct {
-	zeroDialer *net.Dialer
-	addrToIP   map[string]string
+	dialer   *net.Dialer
+	addrToIP map[string]string
 }
 
 // DialContext connects to the address on the named network using the provided context.
@@ -46,13 +46,13 @@ func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Con
 		addr = addrIP + ":" + addrPort
 	}
 
-	return d.zeroDialer.DialContext(ctx, network, addr)
+	return d.dialer.DialContext(ctx, network, addr)
 }
 
 // NewDialer creates dialer with default configuration.
 func NewDialer(srcIP string) *Dialer {
 	return &Dialer{
-		zeroDialer: &net.Dialer{
+		dialer: &net.Dialer{
 			Timeout:   60 * time.Second,
 			KeepAlive: 30 * time.Second,
 			LocalAddr: &net.TCPAddr{IP: net.ParseIP(srcIP)},

--- a/requests/transport.go
+++ b/requests/transport.go
@@ -18,25 +18,17 @@
 package requests
 
 import (
-	"net"
 	"net/http"
 	"time"
 )
 
-// GetDefaultTransport returns default HTTP transport which
+// NewTransport returns default HTTP transport which
 // should be reused as it caches underlying TCP connections.
 // If connections pooling is not needed consider to set
 // DisableKeepAlives=false and MaxIdleConnsPerHost=-1.
-func GetDefaultTransport(srcIP string) *http.Transport {
-	ipAddress := net.ParseIP(srcIP)
-	localIPAddress := &net.TCPAddr{IP: ipAddress}
-
+func NewTransport(dialer *Dialer) *http.Transport {
 	return &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout:   60 * time.Second,
-			KeepAlive: 30 * time.Second,
-			LocalAddr: localIPAddress,
-		}).DialContext,
+		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
This performs HTTP client requests to by dialling directly to IP instead of doing DNS resolution before dial.

For now changes just for API client (DiscoveryService) in order to conduct tests how it performs.
Planning to introduce failover transport (DNS dial -> IP dial) for all of our services in upcoming PRs.