### PR TITLE
Fix setting beneficiary address

### DIFF
--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -357,7 +357,7 @@ func (aps *hermesPromiseSettler) ForceSettle(providerID identity.Identity, herme
 }
 
 // ForceSettle forces the settlement for a provider
-func (aps *hermesPromiseSettler) SettleWithBeneficiary(providerID identity.Identity, hermesID, beneficiary common.Address) error {
+func (aps *hermesPromiseSettler) SettleWithBeneficiary(providerID identity.Identity, beneficiary, hermesID common.Address) error {
 	channel, found := aps.channelProvider.Get(providerID, hermesID)
 	if !found {
 		return ErrNothingToSettle


### PR DESCRIPTION
This fixes an issue that prevents changing a beneficiary address for registered identity:

```
» identities beneficiary 0x0bfbd84282e83d574bd8b9f383bebf719ea9e7d6 0x0bfbd84282e83d574bd8b9f383bebf719ea9e7d6
2020-10-28T03:26:52.704 DBG config/config.go:196                     > Returning default value hermes.hermes-id:0x42a537D649d6853C0a866470f2d084DA0f73b5E4
2020-10-28T03:26:52.705 ERR tequilapi/client/http_client.go:123      >  error="server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x0bfbd84282e83d574bd8b9f383bebf719ea9e7d6/beneficiary). Possible error: failed set beneficiary request: nothing to settle for the given provider"
[WARNING] could not set beneficiary: server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x0bfbd84282e83d574bd8b9f383bebf719ea9e7d6/beneficiary). Possible error: failed set beneficiary request: nothing to settle for the given provider
```