### PR TITLE
HTTP clients with failover transport

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -625,8 +625,9 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 
 	di.NetworkDefinition = network
 
-	httpTransport := requests.NewTransport(requests.NewDialerBypassDNS(options.BindAddress, network.DNSMap))
-	httpClient := requests.NewHTTPClientWithTransport(httpTransport, requests.DefaultTimeout)
+	httpDialer := requests.NewDialer(options.BindAddress)
+	httpDialer.ResolveContext = requests.NewResolverMap(network.DNSMap)
+	httpClient := requests.NewHTTPClientWithTransport(requests.NewTransport(httpDialer), requests.DefaultTimeout)
 	di.MysteriumAPI = mysterium.NewClient(httpClient, network.MysteriumAPIAddress)
 
 	brokerURLs := make([]string, len(di.NetworkDefinition.BrokerAddresses))

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -611,7 +611,6 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 	// override defined values one by one from options
 	if optionsNetwork.MysteriumAPIAddress != metadata.DefaultNetwork.MysteriumAPIAddress {
 		network.MysteriumAPIAddress = optionsNetwork.MysteriumAPIAddress
-		network.DNSMap = nil
 	}
 
 	if !reflect.DeepEqual(optionsNetwork.BrokerAddresses, metadata.DefaultNetwork.BrokerAddresses) {
@@ -620,6 +619,11 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 
 	if optionsNetwork.EtherClientRPC != metadata.DefaultNetwork.EtherClientRPC {
 		network.EtherClientRPC = optionsNetwork.EtherClientRPC
+	}
+
+	dnsMap := optionsNetwork.DNSMap
+	for host, hostIPs := range network.DNSMap {
+		dnsMap[host] = append(dnsMap[host], hostIPs...)
 	}
 
 	di.NetworkDefinition = network

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -97,7 +98,8 @@ type UIServer interface {
 type Dependencies struct {
 	Node *Node
 
-	HTTPClient *requests.HTTPClient
+	HTTPTransport *http.Transport
+	HTTPClient    *requests.HTTPClient
 
 	NetworkDefinition metadata.NetworkDefinition
 	MysteriumAPI      *mysterium.MysteriumAPI
@@ -119,8 +121,7 @@ type Dependencies struct {
 	ProposalRepository proposal.Repository
 	DiscoveryWorker    discovery.Worker
 
-	QualityHttpClient *requests.HTTPClient
-	QualityClient     *quality.MysteriumMORQA
+	QualityClient *quality.MysteriumMORQA
 
 	IPResolver       ip.Resolver
 	LocationResolver *location.Cache
@@ -187,8 +188,6 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 
 	log.Info().Msg("Starting Mysterium Node " + metadata.VersionAsString())
 
-	di.HTTPClient = requests.NewHTTPClient(nodeOptions.BindAddress, requests.DefaultTimeout)
-
 	// Check early for presence of an already running node
 	tequilaListener, err := di.createTequilaListener(nodeOptions)
 	if err != nil {
@@ -250,7 +249,7 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 		return err
 	}
 
-	if err := di.bootstrapQualityComponents(nodeOptions.BindAddress, nodeOptions.Quality); err != nil {
+	if err := di.bootstrapQualityComponents(nodeOptions.Quality); err != nil {
 		return err
 	}
 
@@ -625,10 +624,11 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 
 	di.NetworkDefinition = network
 
-	httpDialer := requests.NewDialer(options.BindAddress)
+	httpDialer := requests.NewDialerSwarm(options.BindAddress)
 	httpDialer.ResolveContext = requests.NewResolverMap(network.DNSMap)
-	httpClient := requests.NewHTTPClientWithTransport(requests.NewTransport(httpDialer), requests.DefaultTimeout)
-	di.MysteriumAPI = mysterium.NewClient(httpClient, network.MysteriumAPIAddress)
+	di.HTTPTransport = requests.NewTransport(httpDialer.DialContext)
+	di.HTTPClient = requests.NewHTTPClientWithTransport(di.HTTPTransport, requests.DefaultTimeout)
+	di.MysteriumAPI = mysterium.NewClient(di.HTTPClient, network.MysteriumAPIAddress)
 
 	brokerURLs := make([]string, len(di.NetworkDefinition.BrokerAddresses))
 	for i, brokerAddress := range di.NetworkDefinition.BrokerAddresses {
@@ -717,15 +717,19 @@ func (di *Dependencies) bootstrapIdentityComponents(options node.Options) {
 
 }
 
-func (di *Dependencies) bootstrapQualityComponents(bindAddress string, options node.OptionsQuality) (err error) {
+func (di *Dependencies) bootstrapQualityComponents(options node.OptionsQuality) (err error) {
 	if _, err := firewall.AllowURLAccess(options.Address); err != nil {
 		return err
 	}
 	if _, err := di.ServiceFirewall.AllowURLAccess(options.Address); err != nil {
 		return err
 	}
-	di.QualityHttpClient = requests.NewHTTPClient(bindAddress, 10*time.Second)
-	di.QualityClient = quality.NewMorqaClient(di.QualityHttpClient, options.Address, di.SignerFactory)
+
+	di.QualityClient = quality.NewMorqaClient(
+		requests.NewHTTPClientWithTransport(di.HTTPTransport, 10*time.Second),
+		options.Address,
+		di.SignerFactory,
+	)
 	go di.QualityClient.Start()
 
 	var transport quality.Transport
@@ -880,8 +884,7 @@ func (di *Dependencies) handleConnStateChange() error {
 			netutil.LogNetworkStats()
 
 			log.Info().Msg("Reconnecting HTTP clients due to VPN connection state change")
-			di.HTTPClient.Reconnect()
-			di.QualityHttpClient.Reconnect()
+			di.HTTPTransport.CloseIdleConnections()
 
 			if err := di.EtherClient.Reconnect(); err != nil {
 				log.Warn().Err(err).Msg("Ethereum client failed to reconnect, will retry one more time")

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -92,6 +92,18 @@ func GetOptions() *Options {
 		MysteriumAPIAddress:   config.GetString(config.FlagAPIAddress),
 		BrokerAddresses:       config.GetStringSlice(config.FlagBrokerAddress),
 		EtherClientRPC:        config.GetString(config.FlagEtherRPC),
+		DNSMap: map[string][]string{
+			"testnet-location.mysterium.network": {"82.196.15.9"},
+			"betanet-location.mysterium.network": {"95.216.204.232"},
+			"betanet-quality.mysterium.network":  {"116.202.100.246"},
+			"feedback.mysterium.network":         {"116.203.17.150"},
+			"api.ipify.org": {
+				"54.204.14.42", "54.225.153.147", "54.235.83.248", "54.243.161.145",
+				"23.21.109.69", "23.21.126.66",
+				"50.19.252.36",
+				"174.129.214.20",
+			},
+		},
 	}
 	return &Options{
 		Directories:      *GetOptionsDirectory(&network),

--- a/core/node/options_network.go
+++ b/core/node/options_network.go
@@ -28,5 +28,5 @@ type OptionsNetwork struct {
 	MysteriumAPIAddress string
 	BrokerAddresses     []string
 	EtherClientRPC      string
-	DNSMap              map[string]string
+	DNSMap              map[string][]string
 }

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -49,7 +49,10 @@ var TestnetDefinition = NetworkDefinition{
 	DAIAddress:                "0xC496Bae7780C92281F19626F233b1B11f52D38A3",
 	WETHAddress:               "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
 	DNSMap: map[string][]string{
-		"testnet-api.mysterium.network": {"78.47.176.149"},
+		"testnet-api.mysterium.network":        {"78.47.176.149"},
+		"testnet-trust.mysterium.network":      {"82.196.15.9"},
+		"testnet-transactor.mysterium.network": {"116.203.17.150"},
+		"my.mysterium.network":                 {"157.245.73.218"},
 	},
 }
 
@@ -68,7 +71,10 @@ var BetanetDefinition = NetworkDefinition{
 	DAIAddress:                "0xC496Bae7780C92281F19626F233b1B11f52D38A3",
 	WETHAddress:               "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
 	DNSMap: map[string][]string{
-		"betanet-api.mysterium.network": {"78.47.55.197"},
+		"betanet-api.mysterium.network":        {"78.47.55.197"},
+		"betanet-trust.mysterium.network":      {"95.216.204.232"},
+		"betanet-transactor.mysterium.network": {"135.181.82.67"},
+		"betanet.mysterium.network":            {"138.201.244.63"},
 	},
 }
 

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -31,7 +31,7 @@ type NetworkDefinition struct {
 	MMNAPIAddress             string
 	DAIAddress                string
 	WETHAddress               string
-	DNSMap                    map[string]string
+	DNSMap                    map[string][]string
 }
 
 // TestnetDefinition defines parameters for test network (currently default network)
@@ -48,8 +48,8 @@ var TestnetDefinition = NetworkDefinition{
 	MMNAPIAddress:             "https://my.mysterium.network/api/v1",
 	DAIAddress:                "0xC496Bae7780C92281F19626F233b1B11f52D38A3",
 	WETHAddress:               "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
-	DNSMap: map[string]string{
-		"testnet-api.mysterium.network:443": "78.47.176.149",
+	DNSMap: map[string][]string{
+		"testnet-api.mysterium.network": {"78.47.176.149"},
 	},
 }
 
@@ -67,8 +67,8 @@ var BetanetDefinition = NetworkDefinition{
 	MMNAPIAddress:             "https://betanet.mysterium.network/api/v1",
 	DAIAddress:                "0xC496Bae7780C92281F19626F233b1B11f52D38A3",
 	WETHAddress:               "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
-	DNSMap: map[string]string{
-		"betanet-api.mysterium.network:443": "78.47.55.197",
+	DNSMap: map[string][]string{
+		"betanet-api.mysterium.network": {"78.47.55.197"},
 	},
 }
 
@@ -81,8 +81,8 @@ var LocalnetDefinition = NetworkDefinition{
 	EtherClientRPC:            "http://localhost:8545",
 	MMNAddress:                "http://localhost/",
 	MMNAPIAddress:             "http://localhost/api/v1",
-	DNSMap: map[string]string{
-		"localhost:8001": "127.0.0.1",
+	DNSMap: map[string][]string{
+		"localhost": {"127.0.0.1"},
 	},
 }
 

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -52,7 +52,7 @@ var TestnetDefinition = NetworkDefinition{
 		"testnet-api.mysterium.network":        {"78.47.176.149"},
 		"testnet-trust.mysterium.network":      {"82.196.15.9"},
 		"testnet-transactor.mysterium.network": {"116.203.17.150"},
-		"my.mysterium.network":                 {"157.245.73.218"},
+		"my.mysterium.network":                 {"168.119.183.173"},
 	},
 }
 

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -134,6 +134,7 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		MysteriumAPIAddress:   options.MysteriumAPIAddress,
 		BrokerAddresses:       options.BrokerAddresses,
 		EtherClientRPC:        options.EtherClientRPC,
+		DNSMap:                map[string][]string{},
 	}
 	logOptions := logconfig.LogOptions{
 		LogLevel: zerolog.DebugLevel,

--- a/requests/client.go
+++ b/requests/client.go
@@ -51,7 +51,7 @@ func NewHTTPClientWithTransport(transport *http.Transport, timeout time.Duration
 
 // NewHTTPClient creates a new HTTP client.
 func NewHTTPClient(srcIP string, timeout time.Duration) *HTTPClient {
-	return NewHTTPClientWithTransport(NewTransport(NewDialer(srcIP)), timeout)
+	return NewHTTPClientWithTransport(NewTransport(NewDialer(srcIP).DialContext), timeout)
 }
 
 // HTTPClient describes a client for performing HTTP requests.
@@ -93,14 +93,6 @@ func (c *HTTPClient) DoRequestAndParseResponse(req *http.Request, resp interface
 	}
 
 	return ParseResponseJSON(response, &resp)
-}
-
-// Reconnect creates new instance of underlying HTTP client.
-func (c *HTTPClient) Reconnect() {
-	c.clientMu.Lock()
-	defer c.clientMu.Unlock()
-	c.client.CloseIdleConnections()
-	c.client = c.clientFactory()
 }
 
 func (c *HTTPClient) resolveClient() *http.Client {

--- a/requests/client_test.go
+++ b/requests/client_test.go
@@ -72,7 +72,8 @@ func TestHTTPClientRecreateUnderlyingHTTPClientInstance(t *testing.T) {
 	}))
 	defer server.Close()
 
-	httpClient := NewHTTPClient("0.0.0.0", 50*time.Millisecond)
+	httpTransport := NewTransport(NewDialer("0.0.0.0").DialContext)
+	httpClient := NewHTTPClientWithTransport(httpTransport, 50*time.Millisecond)
 
 	var wg sync.WaitGroup
 	wg.Add(3)
@@ -87,7 +88,7 @@ func TestHTTPClientRecreateUnderlyingHTTPClientInstance(t *testing.T) {
 		}()
 
 		go func() {
-			httpClient.Reconnect()
+			httpTransport.CloseIdleConnections()
 		}()
 	}
 

--- a/requests/dialer_swarm.go
+++ b/requests/dialer_swarm.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package requests
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// DialerSwarm is a connects to multiple addresses in parallel and first successful connection wins.
+type DialerSwarm struct {
+	resolver *net.Resolver
+	dialer   *net.Dialer
+
+	// ResolveContext specifies the dial function for doing custom DNS lookup.
+	// If ResolveContext is nil, then the transport dials using package net.
+	ResolveContext func(ctx context.Context, network, host string) (addrs []string, err error)
+}
+
+// NewDialerSwarm creates swarm dialer with default configuration.
+func NewDialerSwarm(srcIP string) *DialerSwarm {
+	return &DialerSwarm{
+		resolver: net.DefaultResolver,
+		dialer: &net.Dialer{
+			Timeout:   60 * time.Second,
+			KeepAlive: 30 * time.Second,
+			LocalAddr: &net.TCPAddr{IP: net.ParseIP(srcIP)},
+		},
+	}
+}
+
+// DialContext connects to the address on the named network using the provided context.
+func (ds *DialerSwarm) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if ds.ResolveContext != nil {
+		return ds.lookupAndDial(ctx, network, addr)
+	}
+
+	return ds.dialer.DialContext(ctx, network, addr)
+}
+
+func (ds *DialerSwarm) lookupAndDial(ctx context.Context, network, addr string) (conn net.Conn, err error) {
+	addrHost, addrPort, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, &net.OpError{Op: "dial", Net: network, Source: nil, Addr: nil, Err: err}
+	}
+
+	addrIPs, err := ds.ResolveContext(ctx, network, addrHost)
+	if err != nil {
+		return nil, &net.OpError{Op: "dial", Net: network, Source: nil, Addr: nil, Err: err}
+	}
+
+	for _, addrIP := range addrIPs {
+		conn, err = ds.dialer.DialContext(ctx, network, net.JoinHostPort(addrIP, addrPort))
+		if err != nil {
+			return nil, &net.OpError{Op: "dial", Net: network, Source: ds.dialer.LocalAddr, Addr: &net.IPAddr{IP: net.ParseIP(addrIP)}, Err: err}
+		}
+		break
+	}
+
+	return conn, nil
+}

--- a/requests/dialer_swarm_test.go
+++ b/requests/dialer_swarm_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package requests
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_DialerSwarm_UsesDefaultResolver(t *testing.T) {
+	// given
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// when
+	dialer := NewDialerSwarm("127.0.0.1")
+	conn, err := dialer.DialContext(context.Background(), ln.Addr().Network(), ln.Addr().String())
+
+	// then
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+}
+
+func Test_DialerSwarm_CustomResolverSuccessfully(t *testing.T) {
+	// given
+	ln, err := net.Listen("tcp", "127.0.0.1:12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	dialer := NewDialerSwarm("127.0.0.1")
+	dialer.ResolveContext = func(_ context.Context, _, host string) ([]string, error) {
+		if host == "dns-is-faked.golang" {
+			return []string{"127.0.0.1", "2001:db8::a3"}, nil
+		}
+
+		return nil, &net.DNSError{Err: "unmapped address", Name: host, IsNotFound: true}
+	}
+
+	// when
+	conn, err := dialer.DialContext(context.Background(), "tcp", "dns-is-faked.golang:12345")
+
+	// then
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+}
+
+func Test_DialerSwarm_CustomResolverWithUnreachableIP(t *testing.T) {
+	// given
+	ln, err := net.Listen("tcp", "127.0.0.1:12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	dialer := NewDialerSwarm("127.0.0.1")
+	dialer.ResolveContext = func(_ context.Context, _, host string) ([]string, error) {
+		if host == "dns-is-faked.golang" {
+			return []string{"127.0.0.1", "2001:db8::a3"}, nil
+		}
+
+		return nil, &net.DNSError{Err: "unmapped address", Name: host, IsNotFound: true}
+	}
+
+	// when
+	conn, err := dialer.DialContext(context.Background(), "tcp", "dns-is-faked.golang:12345")
+
+	// then
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+}

--- a/requests/dialer_swarm_test.go
+++ b/requests/dialer_swarm_test.go
@@ -20,7 +20,9 @@ package requests
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -38,8 +40,8 @@ func Test_DialerSwarm_UsesDefaultResolver(t *testing.T) {
 	conn, err := dialer.DialContext(context.Background(), ln.Addr().Network(), ln.Addr().String())
 
 	// then
-	assert.NoError(t, err)
 	assert.NotNil(t, conn)
+	assert.NoError(t, err)
 }
 
 func Test_DialerSwarm_CustomResolverSuccessfully(t *testing.T) {
@@ -63,11 +65,11 @@ func Test_DialerSwarm_CustomResolverSuccessfully(t *testing.T) {
 	conn, err := dialer.DialContext(context.Background(), "tcp", "dns-is-faked.golang:12345")
 
 	// then
-	assert.NoError(t, err)
 	assert.NotNil(t, conn)
+	assert.NoError(t, err)
 }
 
-func Test_DialerSwarm_CustomResolverWithUnreachableIP(t *testing.T) {
+func Test_DialerSwarm_CustomResolverWithSomeUnreachableIPs(t *testing.T) {
 	// given
 	ln, err := net.Listen("tcp", "127.0.0.1:12345")
 	if err != nil {
@@ -77,17 +79,72 @@ func Test_DialerSwarm_CustomResolverWithUnreachableIP(t *testing.T) {
 
 	dialer := NewDialerSwarm("127.0.0.1")
 	dialer.ResolveContext = func(_ context.Context, _, host string) ([]string, error) {
-		if host == "dns-is-faked.golang" {
-			return []string{"127.0.0.1", "2001:db8::a3"}, nil
-		}
-
-		return nil, &net.DNSError{Err: "unmapped address", Name: host, IsNotFound: true}
+		return []string{"2001:db8::a3", "127.0.0.1"}, nil
 	}
 
 	// when
 	conn, err := dialer.DialContext(context.Background(), "tcp", "dns-is-faked.golang:12345")
 
 	// then
-	assert.NoError(t, err)
 	assert.NotNil(t, conn)
+	assert.NoError(t, err)
+}
+
+func Test_DialerSwarm_CustomResolverWithAllUnreachableIPs(t *testing.T) {
+	dialer := NewDialerSwarm("127.0.0.1")
+	dialer.ResolveContext = func(_ context.Context, _, host string) ([]string, error) {
+		return []string{"2001:db8::a1", "2001:db8::a3"}, nil
+	}
+
+	// when
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, err := dialer.DialContext(ctx, "tcp", "dns-is-faked.golang:12345")
+
+	// then
+	assert.Nil(t, conn)
+	assert.Error(t, err)
+
+	if dialErr, ok := err.(*ErrorSwarmDial); ok {
+		assert.Equal(t, "dns-is-faked.golang:12345", dialErr.OriginalAddr)
+		assert.Equal(t, ErrAllDialsFailed, dialErr.Cause)
+		assert.Len(t, dialErr.DialErrors, 3)
+	} else {
+		assert.Fail(t, "expected to fail with ErrorSwarmDial")
+	}
+}
+
+func Test_DialerSwarm_CustomResolverIsCancelable(t *testing.T) {
+	dialer := NewDialerSwarm("127.0.0.1")
+	dialer.ResolveContext = func(_ context.Context, _, host string) ([]string, error) {
+		return []string{}, nil
+	}
+
+	// when
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		cancel()
+		wg.Done()
+	}()
+
+	conn, err := dialer.DialContext(ctx, "tcp", "dns-is-faked.golang:12345")
+
+	// then
+	assert.Nil(t, conn)
+	assert.Error(t, err)
+
+	if dialErr, ok := err.(*ErrorSwarmDial); ok {
+		assert.Equal(t, "dns-is-faked.golang:12345", dialErr.OriginalAddr)
+		assert.Equal(t, context.Canceled, dialErr.Cause)
+		assert.Len(t, dialErr.DialErrors, 0)
+	} else {
+		assert.Fail(t, "expected to fail with ErrorSwarmDial")
+	}
+
+	wg.Wait()
 }

--- a/requests/resolver.go
+++ b/requests/resolver.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package requests
+
+import (
+	"context"
+	"net"
+)
+
+// ResolveContext specifies the dial function for doing custom DNS lookup.
+type ResolveContext func(ctx context.Context, network, addr string) (addrs []string, err error)
+
+// NewResolverMap creates resolver with predefined host -> IP map.
+func NewResolverMap(hostToIP map[string][]string) ResolveContext {
+	return func(ctx context.Context, network, addr string) ([]string, error) {
+		addrHost, addrPort, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, &net.DNSError{Err: "invalid dial address", Name: addr, Server: "localmap", IsNotFound: true}
+		}
+
+		addrs := []string{addr}
+		for _, addrIP := range hostToIP[addrHost] {
+			addrs = append(addrs, net.JoinHostPort(addrIP, addrPort))
+		}
+
+		return addrs, nil
+	}
+}

--- a/requests/transport.go
+++ b/requests/transport.go
@@ -18,17 +18,22 @@
 package requests
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"time"
 )
+
+// DialContext specifies the dial function for creating unencrypted TCP connections.
+type DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 // NewTransport returns default HTTP transport which
 // should be reused as it caches underlying TCP connections.
 // If connections pooling is not needed consider to set
 // DisableKeepAlives=false and MaxIdleConnsPerHost=-1.
-func NewTransport(dialer *Dialer) *http.Transport {
+func NewTransport(dialFunc DialContext) *http.Transport {
 	return &http.Transport{
-		DialContext:           dialer.DialContext,
+		DialContext:           dialFunc,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
Updates: #2777 

This introduces HTTP client failover transport (DNS dial -> IP dial) and runs both in parallel to find earliest successfully established connection.
All our HTTP clients changed to this dialling behaviour.

Lets say `dig api.ipify.org` -> resolves to 50.19.252.36 and 174.129.214.20, so this is diagram how 
`DialerSwarm.DialContext(ctx, "tcp", "api.ipify.org:443")` would act:

```
      call to DialContext()
  ---api.ipify.org:443-----------> 1. ResolveContext("api.ipify.org:443")
                                   2. dials many addrs
                                       use earliest
                                   ---api.ipify.org:443----------->x
                                   ---174.129.214.20:443--------------> conn established
  conn<----------------------------------------------------------------
                                   ---50.19.252.36:443--------->x
                                         any may fail
```