### PR TITLE
Broker connection bypasses DNS lookups

### DIFF
--- a/config/flags_network.go
+++ b/config/flags_network.go
@@ -45,10 +45,10 @@ var (
 		Value: metadata.DefaultNetwork.MysteriumAPIAddress,
 	}
 	// FlagBrokerAddress message broker URI.
-	FlagBrokerAddress = cli.StringFlag{
+	FlagBrokerAddress = cli.StringSliceFlag{
 		Name:  "broker-address",
 		Usage: "URI of message broker",
-		Value: metadata.DefaultNetwork.BrokerAddress,
+		Value: cli.NewStringSlice(metadata.DefaultNetwork.BrokerAddresses...),
 	}
 	// FlagEtherRPC URL or IPC socket to connect to Ethereum node.
 	FlagEtherRPC = cli.StringFlag{
@@ -105,7 +105,7 @@ func ParseFlagsNetwork(ctx *cli.Context) {
 	Current.ParseBoolFlag(ctx, FlagLocalnet)
 	Current.ParseBoolFlag(ctx, FlagBetanet)
 	Current.ParseStringFlag(ctx, FlagAPIAddress)
-	Current.ParseStringFlag(ctx, FlagBrokerAddress)
+	Current.ParseStringSliceFlag(ctx, FlagBrokerAddress)
 	Current.ParseStringFlag(ctx, FlagEtherRPC)
 	Current.ParseBoolFlag(ctx, FlagPortMapping)
 	Current.ParseBoolFlag(ctx, FlagNATPunching)

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -90,7 +90,7 @@ func GetOptions() *Options {
 		Betanet:               config.GetBool(config.FlagBetanet),
 		ExperimentNATPunching: config.GetBool(config.FlagNATPunching),
 		MysteriumAPIAddress:   config.GetString(config.FlagAPIAddress),
-		BrokerAddress:         config.GetString(config.FlagBrokerAddress),
+		BrokerAddresses:       config.GetStringSlice(config.FlagBrokerAddress),
 		EtherClientRPC:        config.GetString(config.FlagEtherRPC),
 	}
 	return &Options{

--- a/core/node/options_network.go
+++ b/core/node/options_network.go
@@ -26,7 +26,7 @@ type OptionsNetwork struct {
 	ExperimentNATPunching bool
 
 	MysteriumAPIAddress string
-	BrokerAddress       string
+	BrokerAddresses     []string
 	EtherClientRPC      string
 	DNSMap              map[string]string
 }

--- a/e2e/mobile_entrypoint_test.go
+++ b/e2e/mobile_entrypoint_test.go
@@ -38,7 +38,7 @@ func TestMobileNodeConsumer(t *testing.T) {
 		Betanet:                         true,
 		ExperimentNATPunching:           true,
 		MysteriumAPIAddress:             "http://mysterium-api:8001/v1",
-		BrokerAddress:                   "broker",
+		BrokerAddresses:                 []string{"broker"},
 		EtherClientRPC:                  "ws://ganache:8545",
 		FeedbackURL:                     "TODO",
 		QualityOracleURL:                "http://morqa:8085/api/v1",

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -21,7 +21,7 @@ package metadata
 type NetworkDefinition struct {
 	MysteriumAPIAddress       string
 	AccessPolicyOracleAddress string
-	BrokerAddress             string
+	BrokerAddresses           []string
 	EtherClientRPC            string
 	TransactorAddress         string
 	RegistryAddress           string
@@ -38,7 +38,7 @@ type NetworkDefinition struct {
 var TestnetDefinition = NetworkDefinition{
 	MysteriumAPIAddress:       "https://testnet-api.mysterium.network/v1",
 	AccessPolicyOracleAddress: "https://testnet-trust.mysterium.network/api/v1/access-policies/",
-	BrokerAddress:             "nats://testnet-broker.mysterium.network",
+	BrokerAddresses:           []string{"nats://testnet-broker.mysterium.network", "nats://82.196.15.9"},
 	EtherClientRPC:            "wss://goerli.infura.io/ws/v3/c2c7da73fcc84ec5885a7bb0eb3c3637",
 	TransactorAddress:         "https://testnet-transactor.mysterium.network/api/v1",
 	RegistryAddress:           "0x3dD81545F3149538EdCb6691A4FfEE1898Bd2ef0",
@@ -57,7 +57,7 @@ var TestnetDefinition = NetworkDefinition{
 var BetanetDefinition = NetworkDefinition{
 	MysteriumAPIAddress:       "https://betanet-api.mysterium.network/v1",
 	AccessPolicyOracleAddress: "https://betanet-trust.mysterium.network/api/v1/access-policies/",
-	BrokerAddress:             "nats://betanet-broker.mysterium.network",
+	BrokerAddresses:           []string{"nats://betanet-broker.mysterium.network", "nats://95.216.204.232"},
 	EtherClientRPC:            "wss://goerli.infura.io/ws/v3/c2c7da73fcc84ec5885a7bb0eb3c3637",
 	TransactorAddress:         "https://betanet-transactor.mysterium.network/api/v1",
 	RegistryAddress:           "0xc82Cc5B0bAe95F443e33FF053aAa70F1Eb7d312A",
@@ -77,7 +77,7 @@ var BetanetDefinition = NetworkDefinition{
 var LocalnetDefinition = NetworkDefinition{
 	MysteriumAPIAddress:       "http://localhost:8001/v1",
 	AccessPolicyOracleAddress: "https://localhost:8081/api/v1/access-policies/",
-	BrokerAddress:             "localhost",
+	BrokerAddresses:           []string{"localhost"},
 	EtherClientRPC:            "http://localhost:8545",
 	MMNAddress:                "http://localhost/",
 	MMNAPIAddress:             "http://localhost/api/v1",

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -83,7 +83,7 @@ type MobileNodeOptions struct {
 	Localnet                        bool
 	ExperimentNATPunching           bool
 	MysteriumAPIAddress             string
-	BrokerAddress                   string
+	BrokerAddresses                 []string
 	EtherClientRPC                  string
 	FeedbackURL                     string
 	QualityOracleURL                string
@@ -103,7 +103,7 @@ func DefaultNodeOptions() *MobileNodeOptions {
 		Betanet:                         true,
 		ExperimentNATPunching:           true,
 		MysteriumAPIAddress:             metadata.BetanetDefinition.MysteriumAPIAddress,
-		BrokerAddress:                   metadata.BetanetDefinition.BrokerAddress,
+		BrokerAddresses:                 metadata.BetanetDefinition.BrokerAddresses,
 		EtherClientRPC:                  metadata.BetanetDefinition.EtherClientRPC,
 		FeedbackURL:                     "https://feedback.mysterium.network",
 		QualityOracleURL:                "https://betanet-quality.mysterium.network/api/v1",
@@ -132,7 +132,7 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		Localnet:              options.Localnet,
 		ExperimentNATPunching: options.ExperimentNATPunching,
 		MysteriumAPIAddress:   options.MysteriumAPIAddress,
-		BrokerAddress:         options.BrokerAddress,
+		BrokerAddresses:       options.BrokerAddresses,
 		EtherClientRPC:        options.EtherClientRPC,
 	}
 	logOptions := logconfig.LogOptions{


### PR DESCRIPTION
This performs NATS connection by dialling directly to IP instead of doing DNS resolution before dial.