### PR TITLE
Hermes chain ID - unlock

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -20,6 +20,7 @@ package cli
 import (
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -133,7 +134,7 @@ func (c *cliApp) newIdentity(args []string) {
 	success("New identity created:", id.Address)
 }
 
-const usageUnlockIdentity = "unlock <identity> [passphrase]"
+const usageUnlockIdentity = "unlock <identity> [passphrase] [chainID]"
 
 func (c *cliApp) unlockIdentity(actionArgs []string) {
 	if len(actionArgs) < 1 {
@@ -146,9 +147,18 @@ func (c *cliApp) unlockIdentity(actionArgs []string) {
 	if len(actionArgs) >= 2 {
 		passphrase = actionArgs[1]
 	}
+	chainID := config.GetInt64(config.FlagChainID)
+	if len(actionArgs) == 3 {
+		var err error
+		chainID, err = strconv.ParseInt(actionArgs[2], 10, 64)
+		if err != nil {
+			warn(errors.Wrap(err, "could not parse chainID argument"))
+			return
+		}
+	}
 
 	info("Unlocking", address)
-	err := c.tequilapi.Unlock(address, passphrase)
+	err := c.tequilapi.Unlock(address, passphrase, chainID)
 	if err != nil {
 		warn(err)
 		return

--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -57,6 +57,7 @@ func NewCommand(licenseCommandName string) *cli.Command {
 			config.ParseFlagsServiceWireguard(ctx)
 			config.ParseFlagsServiceNoop(ctx)
 			config.ParseFlagsNode(ctx)
+			config.ParseFlagsNetwork(ctx)
 
 			nodeOptions := node.GetOptions()
 			nodeOptions.Discovery.FetchEnabled = false
@@ -86,6 +87,7 @@ func NewCommand(licenseCommandName string) *cli.Command {
 	config.RegisterFlagsServiceOpenvpn(&command.Flags)
 	config.RegisterFlagsServiceWireguard(&command.Flags)
 	config.RegisterFlagsServiceNoop(&command.Flags)
+	config.RegisterFlagsNetwork(&command.Flags)
 
 	return command
 }
@@ -116,6 +118,7 @@ func (sc *serviceCommand) Run(ctx *cli.Context) (err error) {
 	providerID := sc.unlockIdentity(
 		ctx.String(config.FlagIdentity.Name),
 		ctx.String(config.FlagIdentityPassphrase.Name),
+		ctx.Int64(config.FlagChainID.Name),
 	)
 	log.Info().Msgf("Unlocked identity: %v", providerID)
 
@@ -141,10 +144,10 @@ func (sc *serviceCommand) Run(ctx *cli.Context) (err error) {
 	return <-sc.errorChannel
 }
 
-func (sc *serviceCommand) unlockIdentity(id, passphrase string) string {
+func (sc *serviceCommand) unlockIdentity(id, passphrase string, chainID int64) string {
 	const retryRate = 10 * time.Second
 	for {
-		id, err := sc.tequilapi.CurrentIdentity(id, passphrase)
+		id, err := sc.tequilapi.CurrentIdentity(id, passphrase, chainID)
 		if err == nil {
 			return id.Address
 		}

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -45,15 +45,16 @@ import (
 )
 
 var (
-	consumerPassphrase    = "localconsumer"
-	providerID            = "0xd1a23227bd5ad77f36ba62badcb78a410a1db6c5"
-	providerPassphrase    = "localprovider"
-	hermesID              = "0xf2e2c77D2e7207d8341106E6EfA469d1940FD0d8"
-	hermes2ID             = "0x55fB2d361DE2aED0AbeaBfD77cA7DC8516225771"
-	mystAddress           = "0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665"
-	registryAddress       = "0xbe180c8CA53F280C7BE8669596fF7939d933AA10"
-	channelImplementation = "0x599d43715DF3070f83355D9D90AE62c159E62A75"
-	addressForTopups      = "0xa29fb77b25181df094908b027821a7492ca4245b"
+	consumerPassphrase          = "localconsumer"
+	providerID                  = "0xd1a23227bd5ad77f36ba62badcb78a410a1db6c5"
+	providerPassphrase          = "localprovider"
+	chainID               int64 = 5
+	hermesID                    = "0xf2e2c77D2e7207d8341106E6EfA469d1940FD0d8"
+	hermes2ID                   = "0x55fB2d361DE2aED0AbeaBfD77cA7DC8516225771"
+	mystAddress                 = "0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665"
+	registryAddress             = "0xbe180c8CA53F280C7BE8669596fF7939d933AA10"
+	channelImplementation       = "0x599d43715DF3070f83355D9D90AE62c159E62A75"
+	addressForTopups            = "0xa29fb77b25181df094908b027821a7492ca4245b"
 )
 
 var ethClient *ethclient.Client
@@ -122,7 +123,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 
 	tequilapiProvider := newTequilapiProvider()
 	t.Run("Provider has a registered identity", func(t *testing.T) {
-		providerRegistrationFlow(t, tequilapiProvider, providerID, providerPassphrase)
+		providerRegistrationFlow(t, tequilapiProvider, providerID, providerPassphrase, chainID)
 	})
 
 	t.Run("Consumer Creates And Registers Identity", func(t *testing.T) {
@@ -146,7 +147,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 				consumerID := identityCreateFlow(t, tequilapiConsumer, consumerPassphrase)
 				c.consumerID = consumerID
 				topUps <- c
-				consumerRegistrationFlow(t, tequilapiConsumer, consumerID, consumerPassphrase)
+				consumerRegistrationFlow(t, tequilapiConsumer, consumerID, consumerPassphrase, chainID)
 			}(c)
 		}
 
@@ -278,7 +279,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 
 		topUpConsumer(t, "0xc4cb9a91b8498776f6f8a0d5a2a23beec9b3cef3", common.HexToAddress(hermesID), registrationFee)
 
-		consumerRegistrationFlow(t, c.tequila(), "0xc4cb9a91b8498776f6f8a0d5a2a23beec9b3cef3", "")
+		consumerRegistrationFlow(t, c.tequila(), "0xc4cb9a91b8498776f6f8a0d5a2a23beec9b3cef3", "", chainID)
 
 		proposal := consumerPicksProposal(t, c.tequila(), "noop")
 		consumerConnectFlow(t, c.tequila(), "0xc4cb9a91b8498776f6f8a0d5a2a23beec9b3cef3", hermesID, "noop", proposal)
@@ -296,7 +297,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 			id, err := c.tequila().NewIdentity("")
 			assert.NoError(t, err)
 
-			err = c.tequila().Unlock(id.Address, "")
+			err = c.tequila().Unlock(id.Address, "", chainID)
 			assert.NoError(t, err)
 
 			err = transactorMongo.InsertRegistrationBounty(common.HexToAddress(id.Address))
@@ -322,7 +323,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 			id, err := c.tequila().NewIdentity("")
 			assert.NoError(t, err)
 
-			err = c.tequila().Unlock(id.Address, "")
+			err = c.tequila().Unlock(id.Address, "", chainID)
 			assert.NoError(t, err)
 
 			err = transactorMongo.InsertRegistrationBounty(common.HexToAddress(id.Address))
@@ -409,8 +410,8 @@ func mintMyst(t *testing.T, amount *big.Int, chid common.Address) {
 	assert.NoError(t, err)
 }
 
-func providerRegistrationFlow(t *testing.T, tequilapi *tequilapi_client.Client, id, idPassphrase string) {
-	err := tequilapi.Unlock(id, idPassphrase)
+func providerRegistrationFlow(t *testing.T, tequilapi *tequilapi_client.Client, id, idPassphrase string, chainID int64) {
+	err := tequilapi.Unlock(id, idPassphrase, chainID)
 	assert.NoError(t, err)
 
 	fees, err := tequilapi.GetTransactorFees()
@@ -451,8 +452,8 @@ func topUpConsumer(t *testing.T, id string, hermesID common.Address, registratio
 	mintMyst(t, amountToTopUp, common.HexToAddress(chid))
 }
 
-func consumerRegistrationFlow(t *testing.T, tequilapi *tequilapi_client.Client, id, idPassphrase string) {
-	err := tequilapi.Unlock(id, idPassphrase)
+func consumerRegistrationFlow(t *testing.T, tequilapi *tequilapi_client.Client, id, idPassphrase string, chainID int64) {
+	err := tequilapi.Unlock(id, idPassphrase, chainID)
 	assert.NoError(t, err)
 
 	fees, err := tequilapi.GetTransactorFees()

--- a/identity/integration_test.go
+++ b/identity/integration_test.go
@@ -33,7 +33,8 @@ var (
 	idAccount = accounts.Account{
 		Address: common.HexToAddress("53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"),
 	}
-	idKey, _ = crypto.HexToECDSA("6f88637b68ee88816e73f663aef709d7009836c98ae91ef31e3dfac7be3a1657")
+	idChainID = 1
+	idKey, _  = crypto.HexToECDSA("6f88637b68ee88816e73f663aef709d7009836c98ae91ef31e3dfac7be3a1657")
 )
 
 func Test_UnlockAndSignAndVerify(t *testing.T) {
@@ -43,7 +44,7 @@ func Test_UnlockAndSignAndVerify(t *testing.T) {
 	}
 
 	manager := NewIdentityManager(ks, eventbus.New())
-	err := manager.Unlock(idAddress, "")
+	err := manager.Unlock(idChainID, idAddress, "")
 	assert.NoError(t, err)
 
 	signer := NewSigner(ks, FromAddress(idAddress))

--- a/identity/manager_fake.go
+++ b/identity/manager_fake.go
@@ -22,6 +22,7 @@ import "github.com/pkg/errors"
 type idmFake struct {
 	LastUnlockAddress    string
 	LastUnlockPassphrase string
+	LastUnlockChainID    int64
 	existingIdentities   []Identity
 	newIdentity          Identity
 	unlockFails          bool
@@ -31,7 +32,7 @@ type idmFake struct {
 // NewIdentityManagerFake creates fake identity manager for testing purposes
 // TODO each caller should use it's own mocked manager part instead of global one
 func NewIdentityManagerFake(existingIdentities []Identity, newIdentity Identity) *idmFake {
-	return &idmFake{"", "", existingIdentities, newIdentity, false, true}
+	return &idmFake{"", "", 0, existingIdentities, newIdentity, false, true}
 }
 
 func (fakeIdm *idmFake) IsUnlocked(id string) bool {
@@ -60,9 +61,10 @@ func (fakeIdm *idmFake) HasIdentity(_ string) bool {
 	return true
 }
 
-func (fakeIdm *idmFake) Unlock(address string, passphrase string) error {
+func (fakeIdm *idmFake) Unlock(address string, passphrase string, chainID int64) error {
 	fakeIdm.LastUnlockAddress = address
 	fakeIdm.LastUnlockPassphrase = passphrase
+	fakeIdm.LastUnlockChainID = chainID
 	if fakeIdm.unlockFails {
 		return errors.New("Unlock failed")
 	}

--- a/identity/manager_interface.go
+++ b/identity/manager_interface.go
@@ -24,6 +24,6 @@ type Manager interface {
 	GetIdentities() []Identity
 	GetIdentity(address string) (Identity, error)
 	HasIdentity(address string) bool
-	Unlock(address string, passphrase string) error
+	Unlock(address string, passphrase string, chainID int64) error
 	IsUnlocked(address string) bool
 }

--- a/identity/selector/handler_interface.go
+++ b/identity/selector/handler_interface.go
@@ -21,5 +21,5 @@ import "github.com/mysteriumnetwork/node/identity"
 
 // Handler allows selecting identity to be used
 type Handler interface {
-	UseOrCreate(address, passphrase string) (identity.Identity, error)
+	UseOrCreate(address, passphrase string, chainID int64) (identity.Identity, error)
 }

--- a/identity/selector/handler_test.go
+++ b/identity/selector/handler_test.go
@@ -29,6 +29,7 @@ var fakeSignerFactory = func(id identity.Identity) identity.Signer {
 }
 var existingIdentity = identity.Identity{Address: "existing"}
 var newIdentity = identity.Identity{Address: "new"}
+var chainID int64 = 1
 
 func TestUseOrCreateSucceeds(t *testing.T) {
 	identityManager := identity.NewIdentityManagerFake([]identity.Identity{existingIdentity}, newIdentity)
@@ -37,13 +38,14 @@ func TestUseOrCreateSucceeds(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	id, err := handler.UseOrCreate(existingIdentity.Address, "pass")
+	id, err := handler.UseOrCreate(existingIdentity.Address, "pass", chainID)
 	assert.Equal(t, existingIdentity, id)
 	assert.Nil(t, err)
 	assert.Equal(t, "", registry.registeredIdentity.Address)
 
 	assert.Equal(t, existingIdentity.Address, identityManager.LastUnlockAddress)
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
+	assert.Equal(t, chainID, identityManager.LastUnlockChainID)
 }
 
 func TestUseOrCreateFailsWhenUnlockFails(t *testing.T) {
@@ -54,11 +56,12 @@ func TestUseOrCreateFailsWhenUnlockFails(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	_, err := handler.UseOrCreate(existingIdentity.Address, "pass")
+	_, err := handler.UseOrCreate(existingIdentity.Address, "pass", chainID)
 	assert.Error(t, err)
 
 	assert.Equal(t, existingIdentity.Address, identityManager.LastUnlockAddress)
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
+	assert.Equal(t, chainID, identityManager.LastUnlockChainID)
 }
 
 func TestUseOrCreateReturnsFirstIdentity(t *testing.T) {
@@ -69,7 +72,7 @@ func TestUseOrCreateReturnsFirstIdentity(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	id, err := handler.UseOrCreate("", "pass")
+	id, err := handler.UseOrCreate("", "pass", chainID)
 	assert.Equal(t, existingIdentity, id)
 	assert.Nil(t, err)
 }
@@ -80,7 +83,7 @@ func TestUseOrCreateFailsWhenIdentityNotFound(t *testing.T) {
 	cache := identity.NewIdentityCacheFake()
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
-	_, err := handler.UseOrCreate("does-not-exist", "pass")
+	_, err := handler.UseOrCreate("does-not-exist", "pass", chainID)
 	assert.NotNil(t, err)
 }
 
@@ -91,7 +94,7 @@ func TestUseFailsWhenIdentityNotFound(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	_, err := handler.UseOrCreate("does-not-exist", "pass")
+	_, err := handler.UseOrCreate("does-not-exist", "pass", chainID)
 	assert.NotNil(t, err)
 }
 
@@ -105,7 +108,7 @@ func TestUseLastSucceeds(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	id, err := handler.useLast("pass")
+	id, err := handler.useLast("pass", chainID)
 	assert.Equal(t, fakeIdentity, id)
 	assert.Nil(t, err)
 
@@ -113,6 +116,7 @@ func TestUseLastSucceeds(t *testing.T) {
 
 	assert.Equal(t, "abc", identityManager.LastUnlockAddress)
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
+	assert.Equal(t, chainID, identityManager.LastUnlockChainID)
 }
 
 func TestUseLastFailsWhenUnlockFails(t *testing.T) {
@@ -126,13 +130,14 @@ func TestUseLastFailsWhenUnlockFails(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	_, err := handler.useLast("pass")
+	_, err := handler.useLast("pass", chainID)
 	assert.Error(t, err)
 
 	assert.Equal(t, "", registry.registeredIdentity.Address)
 
 	assert.Equal(t, "abc", identityManager.LastUnlockAddress)
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
+	assert.Equal(t, chainID, identityManager.LastUnlockChainID)
 }
 
 func TestUseNewSucceeds(t *testing.T) {
@@ -142,7 +147,7 @@ func TestUseNewSucceeds(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	id, err := handler.useNew("pass")
+	id, err := handler.useNew("pass", chainID)
 	assert.Equal(t, newIdentity, id)
 	assert.Nil(t, err)
 
@@ -150,6 +155,7 @@ func TestUseNewSucceeds(t *testing.T) {
 
 	assert.Equal(t, newIdentity.Address, identityManager.LastUnlockAddress)
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
+	assert.Equal(t, chainID, identityManager.LastUnlockChainID)
 }
 
 func TestUseNewFailsWhenUnlockFails(t *testing.T) {
@@ -160,11 +166,12 @@ func TestUseNewFailsWhenUnlockFails(t *testing.T) {
 
 	handler := NewHandler(identityManager, registry, cache, fakeSignerFactory)
 
-	_, err := handler.useNew("pass")
+	_, err := handler.useNew("pass", chainID)
 	assert.Error(t, err)
 
 	assert.Equal(t, newIdentity.Address, identityManager.LastUnlockAddress)
 	assert.Equal(t, "pass", identityManager.LastUnlockPassphrase)
+	assert.Equal(t, chainID, identityManager.LastUnlockChainID)
 }
 
 type fakeSigner struct {

--- a/identity/signer_test.go
+++ b/identity/signer_test.go
@@ -34,7 +34,8 @@ var (
 	signerAccount = accounts.Account{
 		Address: common.HexToAddress("53a835143c0ef3bbcbfa796d7eb738ca7dd28f68"),
 	}
-	signerKey, _ = crypto.HexToECDSA("6f88637b68ee88816e73f663aef709d7009836c98ae91ef31e3dfac7be3a1657")
+	signerChainID = 1
+	signerKey, _  = crypto.HexToECDSA("6f88637b68ee88816e73f663aef709d7009836c98ae91ef31e3dfac7be3a1657")
 )
 
 func TestSigningMessageWithUnlockedAccount(t *testing.T) {
@@ -44,7 +45,7 @@ func TestSigningMessageWithUnlockedAccount(t *testing.T) {
 	}
 
 	manager := NewIdentityManager(ks, eventbus.New())
-	err := manager.Unlock(signerAddress, "")
+	err := manager.Unlock(signerChainID, signerAddress, "")
 	assert.NoError(t, err)
 
 	signer := NewSigner(ks, FromAddress(signerAddress))

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -423,6 +423,7 @@ func (mb *MobileNode) Disconnect() error {
 type GetIdentityRequest struct {
 	Address    string
 	Passphrase string
+	ChainID    int64
 }
 
 // GetIdentityResponse represents identity response.
@@ -438,7 +439,7 @@ func (mb *MobileNode) GetIdentity(req *GetIdentityRequest) (*GetIdentityResponse
 	if req == nil {
 		req = &GetIdentityRequest{}
 	}
-	id, err := mb.identitySelector.UseOrCreate(req.Address, req.Passphrase)
+	id, err := mb.identitySelector.UseOrCreate(req.Address, req.Passphrase, req.ChainID)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not unlock identity")
 	}

--- a/session/pingpong/consumer_balance_tracker_test.go
+++ b/session/pingpong/consumer_balance_tracker_test.go
@@ -83,7 +83,10 @@ func TestConsumerBalanceTracker_Fresh_Registration(t *testing.T) {
 		return cbt.GetBalance(id2).Uint64() == 0
 	}, defaultWaitTime, defaultWaitInterval)
 
-	bus.Publish(identity.AppTopicIdentityUnlock, id2.Address)
+	bus.Publish(identity.AppTopicIdentityUnlock, identity.AppEventIdentityUnlock{
+		ChainID: 1,
+		ID:      id2.Address,
+	})
 
 	assert.Eventually(t, func() bool {
 		return cbt.GetBalance(id2).Cmp(initialBalance) == 0
@@ -193,7 +196,10 @@ func TestConsumerBalanceTracker_Handles_GrandTotalChanges(t *testing.T) {
 
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
-	bus.Publish(identity.AppTopicIdentityUnlock, id1.Address)
+	bus.Publish(identity.AppTopicIdentityUnlock, identity.AppEventIdentityUnlock{
+		ChainID: 1,
+		ID:      id1.Address,
+	})
 	assert.Eventually(t, func() bool {
 		return cbt.GetBalance(id1).Cmp(new(big.Int).Sub(initialBalance, grandTotalPromised)) == 0
 	}, defaultWaitTime, defaultWaitInterval)
@@ -255,7 +261,10 @@ func TestConsumerBalanceTracker_FallsBackToTransactorIfInProgress(t *testing.T) 
 
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
-	bus.Publish(identity.AppTopicIdentityUnlock, id1.Address)
+	bus.Publish(identity.AppTopicIdentityUnlock, identity.AppEventIdentityUnlock{
+		ChainID: 1,
+		ID:      id1.Address,
+	})
 	assert.Eventually(t, func() bool {
 		return cbt.GetBalance(id1).Uint64() == 100
 	}, defaultWaitTime, defaultWaitInterval)
@@ -290,7 +299,10 @@ func TestConsumerBalanceTracker_ForceUpdatesOnSuccessfulSubscription(t *testing.
 
 	err := cbt.Subscribe(bus)
 	assert.NoError(t, err)
-	bus.Publish(identity.AppTopicIdentityUnlock, id1.Address)
+	bus.Publish(identity.AppTopicIdentityUnlock, identity.AppEventIdentityUnlock{
+		ChainID: 1,
+		ID:      id1.Address,
+	})
 
 	time.Sleep(time.Millisecond * 20)
 	bc.setError(nil)
@@ -378,7 +390,7 @@ type mockconsumerInfoGetter struct {
 	amount *big.Int
 }
 
-func (mcig *mockconsumerInfoGetter) GetConsumerData(_ string) (ConsumerData, error) {
+func (mcig *mockconsumerInfoGetter) GetConsumerData(_ int64, _ string) (ConsumerData, error) {
 	return ConsumerData{
 		LatestPromise: LatestPromise{
 			Amount: mcig.amount,

--- a/session/pingpong/hermes_caller_test.go
+++ b/session/pingpong/hermes_caller_test.go
@@ -106,7 +106,7 @@ func TestHermesGetConsumerData_Error(t *testing.T) {
 
 	c := requests.NewHTTPClient("0.0.0.0", time.Second)
 	caller := NewHermesCaller(c, server.URL)
-	_, err := caller.GetConsumerData("something")
+	_, err := caller.GetConsumerData(-1, "something")
 	assert.NotNil(t, err)
 }
 
@@ -140,7 +140,7 @@ func TestHermesGetConsumerData_OK(t *testing.T) {
 
 	c := requests.NewHTTPClient("0.0.0.0", time.Second)
 	caller := NewHermesCaller(c, server.URL)
-	data, err := caller.GetConsumerData("0x75C2067Ca5B42467FD6CD789d785aafb52a6B95b")
+	data, err := caller.GetConsumerData(defaultChainID, "0x75C2067Ca5B42467FD6CD789d785aafb52a6B95b")
 	assert.Nil(t, err)
 	res, err := json.Marshal(data)
 	assert.Nil(t, err)
@@ -148,8 +148,11 @@ func TestHermesGetConsumerData_OK(t *testing.T) {
 	assert.JSONEq(t, mockConsumerData, string(res))
 }
 
-var mockConsumerData = `
+const defaultChainID = 1
+
+var mockConsumerData = fmt.Sprintf(`
 {
+  %d: {
 	"Identity": "0x75C2067Ca5B42467FD6CD789d785aafb52a6B95b",
 	"Beneficiary": "0x0000000000000000000000000000000000000000",
 	"ChannelID": "0x6295502615e5dDfd1FC7bD22EA5b78d65751A835",
@@ -167,7 +170,7 @@ var mockConsumerData = `
 	},
 	"LatestSettlement": "0001-01-01T00:00:00Z"
 	}
-`
+}`, defaultChainID)
 
 func TestLatestPromise_isValid(t *testing.T) {
 	type fields struct {

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -128,10 +128,11 @@ func (client *Client) NewIdentity(passphrase string) (id contract.IdentityRefDTO
 }
 
 // CurrentIdentity unlocks and returns the last used, new or first identity
-func (client *Client) CurrentIdentity(identity, passphrase string) (id contract.IdentityRefDTO, err error) {
+func (client *Client) CurrentIdentity(identity, passphrase string, chainID int64) (id contract.IdentityRefDTO, err error) {
 	response, err := client.http.Put("identities/current", contract.IdentityCurrentRequest{
 		Address:    &identity,
 		Passphrase: &passphrase,
+		ChainID:    &chainID,
 	})
 	if err != nil {
 		return
@@ -341,10 +342,14 @@ func (client *Client) ProposalsByPrice(lowerTime, upperTime, lowerGB, upperGB *b
 }
 
 // Unlock allows using identity in following commands
-func (client *Client) Unlock(identity, passphrase string) error {
-	path := fmt.Sprintf("identities/%s/unlock", identity)
+func (client *Client) Unlock(identity, passphrase string, chainID int64) error {
+	payload := contract.IdentityUnlockRequest{
+		Passphrase: &passphrase,
+		ChainID:    &chainID,
+	}
 
-	response, err := client.http.Put(path, contract.IdentityUnlockRequest{Passphrase: &passphrase})
+	path := fmt.Sprintf("identities/%s/unlock", identity)
+	response, err := client.http.Put(path, payload)
 	if err != nil {
 		return err
 	}

--- a/tequilapi/contract/identity.go
+++ b/tequilapi/contract/identity.go
@@ -74,6 +74,7 @@ func NewIdentityListResponse(ids []identity.Identity) ListIdentitiesResponse {
 // swagger:model IdentityCreateRequestDTO
 type IdentityCreateRequest struct {
 	Passphrase *string `json:"passphrase"`
+	ChainID    *int64  `json:"chainID"`
 }
 
 // Validate validates fields in request
@@ -82,6 +83,9 @@ func (r IdentityCreateRequest) Validate() *validation.FieldErrorMap {
 	if r.Passphrase == nil {
 		errors.ForField("passphrase").AddError("required", "Field is required")
 	}
+	if r.ChainID == nil {
+		errors.ForField("chainID").AddError("required", "Field is required")
+	}
 	return errors
 }
 
@@ -89,6 +93,7 @@ func (r IdentityCreateRequest) Validate() *validation.FieldErrorMap {
 // swagger:model IdentityUnlockRequestDTO
 type IdentityUnlockRequest struct {
 	Passphrase *string `json:"passphrase"`
+	ChainID    *int64  `json:"chainID"`
 }
 
 // Validate validates fields in request
@@ -96,6 +101,9 @@ func (r IdentityUnlockRequest) Validate() *validation.FieldErrorMap {
 	errors := validation.NewErrorMap()
 	if r.Passphrase == nil {
 		errors.ForField("passphrase").AddError("required", "Field is required")
+	}
+	if r.ChainID == nil {
+		errors.ForField("chainID").AddError("required", "Field is required")
 	}
 	return errors
 }
@@ -105,6 +113,7 @@ func (r IdentityUnlockRequest) Validate() *validation.FieldErrorMap {
 type IdentityCurrentRequest struct {
 	Address    *string `json:"id"`
 	Passphrase *string `json:"passphrase"`
+	ChainID    *int64  `json:"chainID"`
 }
 
 // Validate validates fields in request
@@ -112,6 +121,9 @@ func (r IdentityCurrentRequest) Validate() *validation.FieldErrorMap {
 	errors := validation.NewErrorMap()
 	if r.Passphrase == nil {
 		errors.ForField("passphrase").AddError("required", "Field is required")
+	}
+	if r.ChainID == nil {
+		errors.ForField("chainID").AddError("required", "Field is required")
 	}
 	return errors
 }

--- a/tequilapi/endpoints/identities.go
+++ b/tequilapi/endpoints/identities.go
@@ -123,7 +123,7 @@ func (endpoint *identitiesAPI) Current(resp http.ResponseWriter, request *http.R
 	if req.Address != nil {
 		idAddress = *req.Address
 	}
-	id, err := endpoint.selector.UseOrCreate(idAddress, *req.Passphrase)
+	id, err := endpoint.selector.UseOrCreate(idAddress, *req.Passphrase, *req.ChainID)
 
 	if err != nil {
 		utils.SendError(resp, err, http.StatusInternalServerError)
@@ -234,7 +234,7 @@ func (endpoint *identitiesAPI) Unlock(resp http.ResponseWriter, httpReq *http.Re
 		return
 	}
 
-	err = endpoint.idm.Unlock(id.Address, *req.Passphrase)
+	err = endpoint.idm.Unlock(id.Address, *req.Passphrase, *req.ChainID)
 	if err != nil {
 		utils.SendError(resp, err, http.StatusForbidden)
 		return

--- a/tequilapi/endpoints/identities_test.go
+++ b/tequilapi/endpoints/identities_test.go
@@ -58,7 +58,7 @@ func TestCurrentIdentitySuccess(t *testing.T) {
 	req, err := http.NewRequest(
 		http.MethodPut,
 		identityUrl,
-		bytes.NewBufferString(`{"passphrase": "mypassphrase"}`),
+		bytes.NewBufferString(`{"passphrase": "mypassphrase", "chainID": 1}`),
 	)
 	params := httprouter.Params{{Key: "id", Value: "current"}}
 	assert.Nil(t, err)
@@ -85,7 +85,7 @@ func TestUnlockIdentitySuccess(t *testing.T) {
 	req, err := http.NewRequest(
 		http.MethodPut,
 		identityUrl,
-		bytes.NewBufferString(`{"passphrase": "mypassphrase"}`),
+		bytes.NewBufferString(`{"passphrase": "mypassphrase", "chainID": 1}`),
 	)
 	params := httprouter.Params{{Key: "id", Value: "0x000000000000000000000000000000000000000a"}}
 	assert.Nil(t, err)
@@ -97,6 +97,7 @@ func TestUnlockIdentitySuccess(t *testing.T) {
 
 	assert.Equal(t, "0x000000000000000000000000000000000000000a", mockIdm.LastUnlockAddress)
 	assert.Equal(t, "mypassphrase", mockIdm.LastUnlockPassphrase)
+	assert.Equal(t, int64(1), mockIdm.LastUnlockChainID)
 }
 
 func TestUnlockIdentityWithInvalidJSON(t *testing.T) {


### PR DESCRIPTION
This covers the unlock event as long as hermes and chain ID is concerned.

Major changes:
- Identity unlock in tequila now requires chainID
- Identity current now requires chainID (because it also calls unlock and will later register)

We need chainID to update the balance using hermes or the multichain BC. So there is no way to get out of this.

This doesn't build and it's not finished. This covers a small part of the hermes multichain usage we still need to cover other cases like: Register and Grand total change though the amount of changes is getting out of hand.