### PR TITLE
Fixes session package

### DIFF
--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/datasize"
@@ -178,6 +179,7 @@ func ExchangeFactoryFunc(
 			EventBus:                  eventBus,
 			HermesAddress:             hermes,
 			DataLeeway:                datasize.MiB * datasize.BitSize(dataLeewayMegabytes),
+			ChainID:                   config.GetInt64(config.FlagChainID),
 		}
 		return NewInvoicePayer(deps), nil
 	}

--- a/session/pingpong/hermes_caller.go
+++ b/session/pingpong/hermes_caller.go
@@ -244,7 +244,6 @@ type ConsumerData struct {
 	Beneficiary      string        `json:"Beneficiary"`
 	ChannelID        string        `json:"ChannelID"`
 	Balance          *big.Int      `json:"Balance"`
-	Promised         *big.Int      `json:"Promised"`
 	Settled          *big.Int      `json:"Settled"`
 	Stake            *big.Int      `json:"Stake"`
 	LatestPromise    LatestPromise `json:"LatestPromise"`
@@ -253,12 +252,12 @@ type ConsumerData struct {
 
 // LatestPromise represents the latest promise
 type LatestPromise struct {
-	ChannelID string      `json:"ChannelID"`
-	Amount    *big.Int    `json:"Amount"`
-	Fee       *big.Int    `json:"Fee"`
-	Hashlock  string      `json:"Hashlock"`
-	R         interface{} `json:"R"`
-	Signature string      `json:"Signature"`
+	ChainID   int64    `json:"ChainID"`
+	ChannelID string   `json:"ChannelID"`
+	Amount    *big.Int `json:"Amount"`
+	Fee       *big.Int `json:"Fee"`
+	Hashlock  string   `json:"Hashlock"`
+	Signature string   `json:"Signature"`
 }
 
 // isValid checks if the promise is really issued by the given identity
@@ -283,6 +282,7 @@ func (lp LatestPromise) isValid(id string) error {
 	}
 
 	p := crypto.Promise{
+		ChainID:   lp.ChainID,
 		ChannelID: decodedChannelID,
 		Amount:    lp.Amount,
 		Fee:       lp.Fee,

--- a/session/pingpong/hermes_caller_test.go
+++ b/session/pingpong/hermes_caller_test.go
@@ -133,14 +133,14 @@ func TestHermesCaller_UnmarshalsErrors(t *testing.T) {
 func TestHermesGetConsumerData_OK(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		bytes := []byte(mockConsumerData)
+		bytes := []byte(mockConsumerDataResponse)
 		w.Write(bytes)
 	}))
 	defer server.Close()
 
 	c := requests.NewHTTPClient("0.0.0.0", time.Second)
 	caller := NewHermesCaller(c, server.URL)
-	data, err := caller.GetConsumerData(defaultChainID, "0x75C2067Ca5B42467FD6CD789d785aafb52a6B95b")
+	data, err := caller.GetConsumerData(defaultChainID, "0x74CbcbBfEd45D7836D270068116440521033EDc7")
 	assert.Nil(t, err)
 	res, err := json.Marshal(data)
 	assert.Nil(t, err)
@@ -150,27 +150,8 @@ func TestHermesGetConsumerData_OK(t *testing.T) {
 
 const defaultChainID = 1
 
-var mockConsumerData = fmt.Sprintf(`
-{
-  %d: {
-	"Identity": "0x75C2067Ca5B42467FD6CD789d785aafb52a6B95b",
-	"Beneficiary": "0x0000000000000000000000000000000000000000",
-	"ChannelID": "0x6295502615e5dDfd1FC7bD22EA5b78d65751A835",
-	"Balance": 12185543791,
-	"Promised": 217345248,
-	"Settled": 0,
-	"Stake": 0,
-	"LatestPromise": {
-	"ChannelID": "0x6295502615e5ddfd1fc7bd22ea5b78d65751a835",
-	"Amount": 461730032,
-	"Fee": 0,
-	"R": null,
-	"Hashlock": "0x31c88b635e72755012289cd04bf9b34a11a95f5962f8f1b15dc4b6b80d4af34a",
-	"Signature": "0x28d4f2a8c1e2a6b8943e3e110b1d5f66cacaee0841dd7e60ed89e02096419b27188b7c74a9fa1e30e29b4fd75877f503c5d2b193d1d64d7d56232a67b0a102261b"
-	},
-	"LatestSettlement": "0001-01-01T00:00:00Z"
-	}
-}`, defaultChainID)
+var mockConsumerData = `{"Identity":"0x74CbcbBfEd45D7836D270068116440521033EDc7","Beneficiary":"0x0000000000000000000000000000000000000000","ChannelID":"0xc80A1758A36cf9a0903a9FE37f98B51AEC978CB6","Balance":133,"Settled":0,"Stake":0,"LatestPromise":{"ChannelID":"0xc80a1758a36cf9a0903a9fe37f98b51aec978cb6","Amount":1077,"Fee":0,"Hashlock":"0x528a7340eb740124306c25c53ac7fa27c0d038ac4ab0bb09c0894487b8d1bc5f","Signature":"0xaf3f9e23336513fa75b5a03cb81dbecf8e4b5c61ce14a9479b8d5728970eab1f1d2cf4d22d14f6441d0ae8db06b5ce34eb18000aae9aeedc013e449fc1ced8a31b","ChainID":1},"LatestSettlement":"0001-01-01T00:00:00Z"}`
+var mockConsumerDataResponse = fmt.Sprintf(`{"%d":%v}`, defaultChainID, mockConsumerData)
 
 func TestLatestPromise_isValid(t *testing.T) {
 	type fields struct {
@@ -178,8 +159,8 @@ func TestLatestPromise_isValid(t *testing.T) {
 		Amount    *big.Int
 		Fee       *big.Int
 		Hashlock  string
-		R         interface{}
 		Signature string
+		ChainID   int64
 	}
 	tests := []struct {
 		name    string
@@ -190,25 +171,27 @@ func TestLatestPromise_isValid(t *testing.T) {
 		{
 			name:    "returns no error for a valid promise",
 			wantErr: false,
-			id:      "0x75C2067Ca5B42467FD6CD789d785aafb52a6B95b",
+			id:      "0xF53aCDd584ccb85eE4EC1590007aD3c16FDFF057",
 			fields: fields{
-				ChannelID: "0x6295502615e5ddfd1fc7bd22ea5b78d65751a835",
-				Amount:    big.NewInt(461730032),
+				ChainID:   1,
+				ChannelID: "0xfd34a0a135b9ed5dc11a4780926efccaedb5e50b",
+				Amount:    big.NewInt(4030),
 				Fee:       new(big.Int),
-				Hashlock:  "0x31c88b635e72755012289cd04bf9b34a11a95f5962f8f1b15dc4b6b80d4af34a",
-				Signature: "0x28d4f2a8c1e2a6b8943e3e110b1d5f66cacaee0841dd7e60ed89e02096419b27188b7c74a9fa1e30e29b4fd75877f503c5d2b193d1d64d7d56232a67b0a102261b",
+				Hashlock:  "0xbcfee24a3f12e1b2f37a560b2bf52fedd3a1f1795844229495711fd4405f139e",
+				Signature: "0xf12c79560a9a9463ffdf5a5f12ff2d33c26345ce62cd7b1d324d897f9f6ce65d7eaf113897b48c2e7ae3d38325db68f212d1dd601c36a608ec24ed3d5f94f9171b",
 			},
 		},
 		{
 			name:    "returns no error for a valid promise with no prefix on identity",
 			wantErr: false,
-			id:      "75C2067Ca5B42467FD6CD789d785aafb52a6B95b",
+			id:      "F53aCDd584ccb85eE4EC1590007aD3c16FDFF057",
 			fields: fields{
-				ChannelID: "0x6295502615e5ddfd1fc7bd22ea5b78d65751a835",
-				Amount:    big.NewInt(461730032),
+				ChainID:   1,
+				ChannelID: "0xfd34a0a135b9ed5dc11a4780926efccaedb5e50b",
+				Amount:    big.NewInt(4030),
 				Fee:       new(big.Int),
-				Hashlock:  "0x31c88b635e72755012289cd04bf9b34a11a95f5962f8f1b15dc4b6b80d4af34a",
-				Signature: "0x28d4f2a8c1e2a6b8943e3e110b1d5f66cacaee0841dd7e60ed89e02096419b27188b7c74a9fa1e30e29b4fd75877f503c5d2b193d1d64d7d56232a67b0a102261b",
+				Hashlock:  "0xbcfee24a3f12e1b2f37a560b2bf52fedd3a1f1795844229495711fd4405f139e",
+				Signature: "0xf12c79560a9a9463ffdf5a5f12ff2d33c26345ce62cd7b1d324d897f9f6ce65d7eaf113897b48c2e7ae3d38325db68f212d1dd601c36a608ec24ed3d5f94f9171b",
 			},
 		},
 		{
@@ -243,8 +226,8 @@ func TestLatestPromise_isValid(t *testing.T) {
 				Amount:    tt.fields.Amount,
 				Fee:       tt.fields.Fee,
 				Hashlock:  tt.fields.Hashlock,
-				R:         tt.fields.R,
 				Signature: tt.fields.Signature,
+				ChainID:   tt.fields.ChainID,
 			}
 			err := lp.isValid(tt.id)
 			if (err != nil) != tt.wantErr {

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -133,7 +133,10 @@ func (hcr *HermesChannelRepository) sumChannels(chainID int64, id identity.Ident
 	var unsettledBalance = new(big.Int)
 	v, ok := hcr.channels[chainID]
 	if !ok {
-		return event.Earnings{}
+		return event.Earnings{
+			LifetimeBalance:  new(big.Int),
+			UnsettledBalance: new(big.Int),
+		}
 	}
 
 	for _, channel := range v {
@@ -204,12 +207,7 @@ func (hcr *HermesChannelRepository) updateChannel(chainID int64, new HermesChann
 
 	updated := false
 
-	v, ok := hcr.channels[chainID]
-	if !ok {
-		log.Debug().Msgf("unknown chain %v", chainID)
-		return
-	}
-
+	v := hcr.channels[chainID]
 	for i, channel := range v {
 		if channel.Identity == new.Identity && channel.HermesID == new.HermesID {
 			updated = true

--- a/session/pingpong/hermes_promise_handler.go
+++ b/session/pingpong/hermes_promise_handler.go
@@ -236,7 +236,6 @@ func (aph *HermesPromiseHandler) requestPromise(er enqueuedRequest) {
 		R:           hex.EncodeToString(er.r),
 		Revealed:    false,
 		AgreementID: er.em.AgreementID,
-		ChainID:     promise.ChainID,
 	}
 
 	err = aph.deps.HermesPromiseStorage.Store(ap)

--- a/session/pingpong/hermes_promise_settler_test.go
+++ b/session/pingpong/hermes_promise_settler_test.go
@@ -243,7 +243,7 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 		mockID,
 		hermesID,
 		client.ProviderChannel{Stake: big.NewInt(1000)},
-		HermesPromise{Promise: crypto.Promise{Amount: big.NewInt(100)}},
+		HermesPromise{Promise: crypto.Promise{Amount: big.NewInt(1000)}},
 	)
 	assert.True(t, s.needsSettling(0.1, channel), "should be true with zero balance left")
 
@@ -272,7 +272,7 @@ func TestPromiseSettlerState_needsSettling(t *testing.T) {
 		"1",
 		mockID,
 		hermesID,
-		client.ProviderChannel{Stake: big.NewInt(1000)},
+		client.ProviderChannel{Stake: big.NewInt(10000)},
 		HermesPromise{Promise: crypto.Promise{Amount: big.NewInt(8999)}},
 	)
 	assert.False(t, s.needsSettling(0.1, channel), "should be false with 10.01% missing")

--- a/session/pingpong/hermes_promise_storage.go
+++ b/session/pingpong/hermes_promise_storage.go
@@ -58,7 +58,6 @@ type HermesPromise struct {
 	R           string
 	Revealed    bool
 	AgreementID *big.Int
-	ChainID     int64
 }
 
 // Store stores the given promise.
@@ -66,7 +65,7 @@ func (aps *HermesPromiseStorage) Store(promise HermesPromise) error {
 	aps.lock.Lock()
 	defer aps.lock.Unlock()
 
-	previousPromise, err := aps.get(promise.ChainID, promise.ChannelID)
+	previousPromise, err := aps.get(promise.Promise.ChainID, promise.ChannelID)
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return err
 	}
@@ -79,7 +78,7 @@ func (aps *HermesPromiseStorage) Store(promise HermesPromise) error {
 		return ErrAttemptToOverwrite
 	}
 
-	if err := aps.bolt.SetValue(aps.getBucketName(promise.ChainID), promise.ChannelID, promise); err != nil {
+	if err := aps.bolt.SetValue(aps.getBucketName(promise.Promise.ChainID), promise.ChannelID, promise); err != nil {
 		return fmt.Errorf("could not store hermes promise: %w", err)
 	}
 	return nil
@@ -113,6 +112,7 @@ type HermesPromiseFilter struct {
 }
 
 func (aps *HermesPromiseStorage) getBucketName(chainID int64) string {
+	fmt.Println(fmt.Sprintf("%v_%v", hermesPromiseBucketName, chainID))
 	return fmt.Sprintf("%v_%v", hermesPromiseBucketName, chainID)
 }
 

--- a/session/pingpong/hermes_promise_storage_test.go
+++ b/session/pingpong/hermes_promise_storage_test.go
@@ -46,21 +46,19 @@ func TestHermesPromiseStorage(t *testing.T) {
 	secondHermes := common.HexToAddress("0x000000acc2")
 
 	firstPromise := HermesPromise{
-		ChainID:     1,
 		ChannelID:   "1",
 		Identity:    id,
 		HermesID:    firstHermes,
-		Promise:     crypto.Promise{Amount: big.NewInt(1), Fee: big.NewInt(1)},
+		Promise:     crypto.Promise{Amount: big.NewInt(1), Fee: big.NewInt(1), ChainID: 1},
 		R:           "some r",
 		AgreementID: big.NewInt(123),
 	}
 
 	secondPromise := HermesPromise{
-		ChainID:     1,
 		ChannelID:   "2",
 		Identity:    id,
 		HermesID:    secondHermes,
-		Promise:     crypto.Promise{Amount: big.NewInt(2), Fee: big.NewInt(2)},
+		Promise:     crypto.Promise{Amount: big.NewInt(2), Fee: big.NewInt(2), ChainID: 1},
 		R:           "some other r",
 		AgreementID: big.NewInt(1234),
 	}
@@ -81,7 +79,9 @@ func TestHermesPromiseStorage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, firstPromise, promise)
 
-	promises, err = hermesStorage.List(HermesPromiseFilter{})
+	promises, err = hermesStorage.List(HermesPromiseFilter{
+		ChainID: 1,
+	})
 	assert.Equal(t, []HermesPromise{firstPromise}, promises)
 	assert.NoError(t, err)
 
@@ -93,7 +93,9 @@ func TestHermesPromiseStorage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, secondPromise, promise)
 
-	promises, err = hermesStorage.List(HermesPromiseFilter{})
+	promises, err = hermesStorage.List(HermesPromiseFilter{
+		ChainID: 1,
+	})
 	assert.Equal(t, []HermesPromise{firstPromise, secondPromise}, promises)
 	assert.NoError(t, err)
 

--- a/session/pingpong/invoice_payer.go
+++ b/session/pingpong/invoice_payer.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/connection/connectionstate"
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/eventbus"
@@ -102,6 +101,7 @@ type InvoicePayerDeps struct {
 	EventBus                  eventbus.EventBus
 	HermesAddress             common.Address
 	DataLeeway                datasize.BitSize
+	ChainID                   int64
 }
 
 // NewInvoicePayer returns a new instance of exchange message tracker.
@@ -246,7 +246,7 @@ func (ip *InvoicePayer) calculateAmountToPromise(invoice crypto.Invoice) (toProm
 }
 
 func (ip *InvoicePayer) chainID() int64 {
-	return config.GetInt64(config.FlagChainID)
+	return ip.deps.ChainID
 }
 
 func (ip *InvoicePayer) issueExchangeMessage(invoice crypto.Invoice) error {

--- a/session/pingpong/invoice_payer_test.go
+++ b/session/pingpong/invoice_payer_test.go
@@ -130,6 +130,7 @@ func Test_InvoicePayer_SendsMessage(t *testing.T) {
 		ConsumerTotalsStorage:     totalsStorage,
 		TimeTracker:               &tracker,
 		EventBus:                  mocks.NewEventBus(),
+		ChainID:                   1,
 		Ks:                        ks,
 		ChannelAddressCalculator:  NewChannelAddressCalculator(acc.Address.Hex(), acc.Address.Hex(), acc.Address.Hex()),
 		Identity:                  identity.FromAddress(acc.Address.Hex()),
@@ -594,6 +595,7 @@ func TestInvoicePayer_issueExchangeMessage_publishesEvents(t *testing.T) {
 			EventBus: mp,
 			Identity: identity.FromAddress(acc.Address.Hex()),
 			Peer:     peerID,
+			ChainID:  1,
 		},
 	}
 	emt.lastInvoice = crypto.Invoice{


### PR DESCRIPTION
Also injects the chain id into invoice payer. This prevents issues where promises of incorrect value might get issued, overpaying the provider. Mid-session consumer side chainID switch is no longer possible for this reason.