### PR TITLE
Fix flag name for Hermes RPC endpoint for ethereum

### DIFF
--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -126,7 +126,7 @@ services:
     command: >
       -identityPassphrase ""
       -myst 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
-      -rpcEndpoint ws://ganache:8545
+      -Chain1RPCEndpoint ws://ganache:8545
       -registry 0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       -operator 0x354bd098b4ef8c9e70b7f21be2d455df559705d7
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75
@@ -155,7 +155,7 @@ services:
     command: >
       -identityPassphrase ""
       -myst 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
-      -rpcEndpoint ws://ganache:8545
+      -Chain1RPCEndpoint ws://ganache:8545
       -registry 0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       -operator 0x761f2bb3e7ad6385a4c7833c5a26a8ddfdabf9f3
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75

--- a/docker-compose.e2e-compatibility.yml
+++ b/docker-compose.e2e-compatibility.yml
@@ -109,7 +109,7 @@ services:
     command: >
       -identityPassphrase ""
       -myst 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
-      -rpcEndpoint ws://ganache:8545
+      -Chain1RPCEndpoint ws://ganache:8545
       -registry 0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       -operator 0x354bd098b4ef8c9e70b7f21be2d455df559705d7
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -223,7 +223,7 @@ services:
     command: >
       -identityPassphrase ""
       -myst 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
-      -rpcEndpoint ws://ganache:8545
+      -Chain1RPCEndpoint ws://ganache:8545
       -registry 0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       -operator 0x354bd098b4ef8c9e70b7f21be2d455df559705d7
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75
@@ -340,7 +340,7 @@ services:
     command: >
       -identityPassphrase ""
       -myst 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
-      -rpcEndpoint ws://ganache:8545
+      -Chain1RPCEndpoint ws://ganache:8545
       -registry 0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       -operator 0x761f2bb3e7ad6385a4c7833c5a26a8ddfdabf9f3
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75

--- a/docker-compose.localnet.yml
+++ b/docker-compose.localnet.yml
@@ -194,7 +194,7 @@ services:
     command: >
       -identityPassphrase ""
       -myst 0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
-      -rpcEndpoint ws://ganache:8545
+      -Chain1RPCEndpoint ws://ganache:8545
       -registry 0xbe180c8CA53F280C7BE8669596fF7939d933AA10
       -operator 0x354bd098b4ef8c9e70b7f21be2d455df559705d7
       -chImplementation 0x599d43715DF3070f83355D9D90AE62c159E62A75


### PR DESCRIPTION
Fix E2E tests crashes such as:

```
 [36;1mhermes_1                   |[0m flag provided but not defined: -rpcEndpoint
[36;1mhermes_1                   |[0m Usage of /usr/bin/hermes:
[36;1mhermes_1                   |[0m   -Chain1ChainID int
[36;1mhermes_1                   |[0m     	the ethereum chain ID (default 5)
[36;1mhermes_1                   |[0m   -Chain1RPCEndpoint string
[36;1mhermes_1                   |[0m     	rpc endpoint for ethereum (default "ws://localhost:8545")
[36;1mhermes_1                   |[0m   -Chain2ChainID int
[36;1mhermes_1                   |[0m     	determines the l2 chain id (default 80001)
[36;1mhermes_1                   |[0m   -Chain2RPCEndpoint string
[36;1mhermes_1                   |[0m     	rpc endpoint for l2 chain
```