### PR TITLE
Broker connection bypasses DNS lookups in consumer mode

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -642,13 +643,13 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 	di.HTTPClient = requests.NewHTTPClientWithTransport(di.HTTPTransport, requests.DefaultTimeout)
 	di.MysteriumAPI = mysterium.NewClient(di.HTTPClient, network.MysteriumAPIAddress)
 
-	brokerURLs := make([]string, len(di.NetworkDefinition.BrokerAddresses))
+	brokerURLs := make([]*url.URL, len(di.NetworkDefinition.BrokerAddresses))
 	for i, brokerAddress := range di.NetworkDefinition.BrokerAddresses {
-		brokerURL, err := nats.ParseServerURI(brokerAddress)
+		brokerURL, err := nats.ParseServerURL(brokerAddress)
 		if err != nil {
 			return err
 		}
-		brokerURLs[i] = brokerURL.String()
+		brokerURLs[i] = brokerURL
 	}
 
 	if di.BrokerConnection, err = di.BrokerConnector.Connect(brokerURLs...); err != nil {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -648,11 +648,6 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 		if err != nil {
 			return err
 		}
-
-		if _, err := di.ServiceFirewall.AllowURLAccess(brokerURL.String()); err != nil {
-			return err
-		}
-
 		brokerURLs[i] = brokerURL.String()
 	}
 

--- a/communication/nats/connection_wrap.go
+++ b/communication/nats/connection_wrap.go
@@ -77,19 +77,10 @@ func newConnection(serverURIs ...string) (*ConnectionWrap, error) {
 	}, nil
 }
 
-func newConnectionWith(dialer nats_lib.CustomDialer, serverURIs ...string) *ConnectionWrap {
-	return &ConnectionWrap{
-		dialer:  dialer,
-		servers: serverURIs,
-		onClose: func() {},
-	}
-}
-
 // ConnectionWrap defines wrapped connection to NATS server(s).
 type ConnectionWrap struct {
 	*nats_lib.Conn
 
-	dialer  nats_lib.CustomDialer
 	servers []string
 	onClose func()
 }
@@ -103,7 +94,6 @@ func (c *ConnectionWrap) connectOptions() nats_lib.Options {
 	options.ClosedCB = func(conn *nats_lib.Conn) { log.Warn().Msg("NATS: connection closed") }
 	options.DisconnectedCB = func(nc *nats_lib.Conn) { log.Warn().Msg("NATS: disconnected") }
 	options.ReconnectedCB = func(nc *nats_lib.Conn) { log.Warn().Msg("NATS: reconnected") }
-	options.CustomDialer = c.dialer
 
 	return options
 }

--- a/communication/nats/connection_wrap.go
+++ b/communication/nats/connection_wrap.go
@@ -29,21 +29,24 @@ import (
 )
 
 const (
+	// DefaultBrokerScheme broker scheme.
+	DefaultBrokerScheme = "nats"
 	// DefaultBrokerPort broker port.
 	DefaultBrokerPort = 4222
 )
 
-// ParseServerURI validates given NATS server address.
-func ParseServerURI(serverURI string) (*url.URL, error) {
+// ParseServerURL validates given NATS server address.
+func ParseServerURL(serverURI string) (*url.URL, error) {
 	// Add scheme first otherwise serverURL.Parse() fails.
-	if !strings.HasPrefix(serverURI, "nats:") {
-		serverURI = fmt.Sprintf("nats://%s", serverURI)
+	if !strings.HasPrefix(serverURI, DefaultBrokerScheme) {
+		serverURI = fmt.Sprintf("%s://%s", DefaultBrokerScheme, serverURI)
 	}
 
 	serverURL, err := url.Parse(serverURI)
 	if err != nil {
 		return nil, errors.Wrapf(err, `failed to parse NATS server URI "%s"`, serverURI)
 	}
+
 	if serverURL.Port() == "" {
 		serverURL.Host = fmt.Sprintf("%s:%d", serverURL.Host, DefaultBrokerPort)
 	}
@@ -51,21 +54,27 @@ func ParseServerURI(serverURI string) (*url.URL, error) {
 	return serverURL, nil
 }
 
-func newConnection(serverURIs ...string) (*ConnectionWrap, error) {
-	connection := &ConnectionWrap{
-		servers: make([]string, len(serverURIs)),
-		onClose: func() {},
-	}
+// ParseServerURIs validates given list of NATS server addresses.
+func ParseServerURIs(serverURIs []string) ([]*url.URL, error) {
+	serverURLs := make([]*url.URL, len(serverURIs))
 
 	for i, server := range serverURIs {
-		natsURL, err := ParseServerURI(server)
+		natsURL, err := ParseServerURL(server)
 		if err != nil {
 			return nil, err
 		}
-		connection.servers[i] = natsURL.String()
+
+		serverURLs[i] = natsURL
 	}
 
-	return connection, nil
+	return serverURLs, nil
+}
+
+func newConnection(serverURIs ...string) (*ConnectionWrap, error) {
+	return &ConnectionWrap{
+		servers: serverURIs,
+		onClose: func() {},
+	}, nil
 }
 
 // ConnectionWrap defines wrapped connection to NATS server(s).

--- a/communication/nats/connection_wrap.go
+++ b/communication/nats/connection_wrap.go
@@ -77,9 +77,19 @@ func newConnection(serverURIs ...string) (*ConnectionWrap, error) {
 	}, nil
 }
 
+func newConnectionWith(dialer nats_lib.CustomDialer, serverURIs ...string) *ConnectionWrap {
+	return &ConnectionWrap{
+		dialer:  dialer,
+		servers: serverURIs,
+		onClose: func() {},
+	}
+}
+
 // ConnectionWrap defines wrapped connection to NATS server(s).
 type ConnectionWrap struct {
 	*nats_lib.Conn
+
+	dialer  nats_lib.CustomDialer
 	servers []string
 	onClose func()
 }
@@ -89,11 +99,12 @@ func (c *ConnectionWrap) connectOptions() nats_lib.Options {
 	options.Servers = c.servers
 	options.MaxReconnect = -1
 	options.ReconnectWait = 1 * time.Second
-	options.Timeout = 5 * time.Second
 	options.PingInterval = 10 * time.Second
 	options.ClosedCB = func(conn *nats_lib.Conn) { log.Warn().Msg("NATS: connection closed") }
 	options.DisconnectedCB = func(nc *nats_lib.Conn) { log.Warn().Msg("NATS: disconnected") }
 	options.ReconnectedCB = func(nc *nats_lib.Conn) { log.Warn().Msg("NATS: reconnected") }
+	options.CustomDialer = c.dialer
+
 	return options
 }
 

--- a/communication/nats/connection_wrap_test.go
+++ b/communication/nats/connection_wrap_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseServerURI(t *testing.T) {
+func TestParseServerURL(t *testing.T) {
 	var tests = []struct {
 		uri         string
 		wantAddress *url.URL
@@ -44,7 +44,7 @@ func TestParseServerURI(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		address, err := ParseServerURI(tc.uri)
+		address, err := ParseServerURL(tc.uri)
 		if tc.wantError != nil {
 			assert.EqualError(t, err, tc.wantError.Error())
 		} else {
@@ -58,16 +58,11 @@ func TestConnectionWrap_NewConnection(t *testing.T) {
 	connection, err := newConnection("nats://127.0.0.1:4222")
 	assert.NoError(t, err)
 	assert.Nil(t, connection.Conn)
-	assert.Equal(t, []string{"nats://127.0.0.1:4222"}, connection.servers)
+	assert.Equal(t, []string{"nats://127.0.0.1:4222"}, connection.Servers())
 
-	connection, err = newConnection("nats://127.0.0.1")
-	assert.NoError(t, err)
+	connection, err = newConnection("nats://127.0.0.1:4222", "nats://example.com:4222")
 	assert.Nil(t, connection.Conn)
-	assert.Equal(t, []string{"nats://127.0.0.1:4222"}, connection.servers)
-
-	connection, err = newConnection("nats:// example.com")
-	assert.EqualError(t, err, `failed to parse NATS server URI "nats:// example.com": parse nats:// example.com: invalid character " " in host name`)
-	assert.Nil(t, connection)
+	assert.Equal(t, []string{"nats://127.0.0.1:4222", "nats://example.com:4222"}, connection.Servers())
 }
 
 func TestConnectionWrap_Close_AfterFailedOpen(t *testing.T) {

--- a/communication/nats/connector.go
+++ b/communication/nats/connector.go
@@ -54,7 +54,7 @@ func (b *BrokerConnector) Connect(serverURLs ...*url.URL) (Connection, error) {
 
 	conn := newConnectionWith(b.Dialer, servers...)
 	if err := conn.Open(); err != nil {
-		return nil, errors.Wrapf(err, `failed to connect to NATS servers "%v"`, servers)
+		return nil, err
 	}
 
 	conn.onClose = removeFirewallRule

--- a/communication/nats/connector_test.go
+++ b/communication/nats/connector_test.go
@@ -18,6 +18,7 @@
 package nats
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
@@ -37,7 +38,10 @@ func TestBrokerConnector(t *testing.T) {
 	connector := NewBrokerConnector()
 
 	// when
-	conn, err := connector.Connect(srv.Addr().String())
+	conn, err := connector.Connect(&url.URL{
+		Scheme: DefaultBrokerScheme,
+		Host:   srv.Addr().String(),
+	})
 	// then
 	assert.NoError(err)
 	defer conn.Close()

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -39,7 +39,7 @@ type NetworkDefinition struct {
 var TestnetDefinition = NetworkDefinition{
 	MysteriumAPIAddress:       "https://testnet-api.mysterium.network/v1",
 	AccessPolicyOracleAddress: "https://testnet-trust.mysterium.network/api/v1/access-policies/",
-	BrokerAddresses:           []string{"nats://testnet-broker.mysterium.network", "nats://82.196.15.9"},
+	BrokerAddresses:           []string{"nats://testnet-broker.mysterium.network"},
 	EtherClientRPC:            "wss://goerli.infura.io/ws/v3/c2c7da73fcc84ec5885a7bb0eb3c3637",
 	TransactorAddress:         "https://testnet-transactor.mysterium.network/api/v1",
 	RegistryAddress:           "0x3dD81545F3149538EdCb6691A4FfEE1898Bd2ef0",
@@ -52,6 +52,7 @@ var TestnetDefinition = NetworkDefinition{
 	DNSMap: map[string][]string{
 		"testnet-api.mysterium.network":        {"78.47.176.149"},
 		"testnet-trust.mysterium.network":      {"82.196.15.9"},
+		"testnet-broker.mysterium.network":     {"82.196.15.9"},
 		"testnet-transactor.mysterium.network": {"116.203.17.150"},
 		"my.mysterium.network":                 {"168.119.183.173"},
 	},
@@ -61,7 +62,7 @@ var TestnetDefinition = NetworkDefinition{
 var BetanetDefinition = NetworkDefinition{
 	MysteriumAPIAddress:       "https://betanet-api.mysterium.network/v1",
 	AccessPolicyOracleAddress: "https://betanet-trust.mysterium.network/api/v1/access-policies/",
-	BrokerAddresses:           []string{"nats://betanet-broker.mysterium.network", "nats://95.216.204.232"},
+	BrokerAddresses:           []string{"nats://betanet-broker.mysterium.network"},
 	EtherClientRPC:            "wss://goerli.infura.io/ws/v3/c2c7da73fcc84ec5885a7bb0eb3c3637",
 	TransactorAddress:         "https://betanet-transactor.mysterium.network/api/v1",
 	RegistryAddress:           "0xc82Cc5B0bAe95F443e33FF053aAa70F1Eb7d312A",
@@ -75,6 +76,7 @@ var BetanetDefinition = NetworkDefinition{
 	DNSMap: map[string][]string{
 		"betanet-api.mysterium.network":        {"78.47.55.197"},
 		"betanet-trust.mysterium.network":      {"95.216.204.232"},
+		"betanet-broker.mysterium.network":     {"95.216.204.232"},
 		"betanet-transactor.mysterium.network": {"135.181.82.67"},
 		"betanet.mysterium.network":            {"138.201.244.63"},
 	},

--- a/p2p/common.go
+++ b/p2p/common.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 
 	"github.com/mysteriumnetwork/node/communication/nats"
 	"github.com/mysteriumnetwork/node/core/port"
@@ -38,7 +39,7 @@ const (
 )
 
 type brokerConnector interface {
-	Connect(serverURIs ...string) (nats.Connection, error)
+	Connect(serverURIs ...*url.URL) (nats.Connection, error)
 }
 
 type natConsumerPinger interface {

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -144,7 +144,12 @@ func (m *dialer) connect(contactDef ContactDefinition, tracer *trace.Tracer) (co
 
 	// broker connect might fail due to reconfiguration of network routes in progress
 	for i := 0; i < maxBrokerConnectAttempts; i++ {
-		conn, err = m.broker.Connect(contactDef.BrokerAddresses...)
+		serverURLs, err := nats.ParseServerURIs(contactDef.BrokerAddresses)
+		if err != nil {
+			return nil, err
+		}
+
+		conn, err = m.broker.Connect(serverURLs...)
 		if err != nil {
 			log.Warn().Msgf("broker connect failed - attempting again in 1sec: %s", err)
 			time.Sleep(time.Second)

--- a/p2p/dialer_test.go
+++ b/p2p/dialer_test.go
@@ -20,6 +20,7 @@ package p2p
 import (
 	"context"
 	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -142,7 +143,7 @@ type mockBroker struct {
 	conn nats.Connection
 }
 
-func (m *mockBroker) Connect(serverURIs ...string) (nats.Connection, error) {
+func (m *mockBroker) Connect(serverURLs ...*url.URL) (nats.Connection, error) {
 	return m.conn, nil
 }
 

--- a/requests/dialer.go
+++ b/requests/dialer.go
@@ -41,6 +41,11 @@ func NewDialer(srcIP string) *Dialer {
 	}
 }
 
+// Dial connects to the address on the named network.
+func (d *Dialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
 // DialContext connects to the address on the named network using the provided context.
 func (d *Dialer) DialContext(ctx context.Context, network, addr string) (conn net.Conn, err error) {
 	if d.ResolveContext != nil {

--- a/requests/dialer.go
+++ b/requests/dialer.go
@@ -41,11 +41,6 @@ func NewDialer(srcIP string) *Dialer {
 	}
 }
 
-// Dial connects to the address on the named network.
-func (d *Dialer) Dial(network, address string) (net.Conn, error) {
-	return d.DialContext(context.Background(), network, address)
-}
-
 // DialContext connects to the address on the named network using the provided context.
 func (d *Dialer) DialContext(ctx context.Context, network, addr string) (conn net.Conn, err error) {
 	if d.ResolveContext != nil {

--- a/requests/dialer_swarm.go
+++ b/requests/dialer_swarm.go
@@ -49,11 +49,6 @@ func NewDialerSwarm(srcIP string) *DialerSwarm {
 	}
 }
 
-// Dial connects to the address on the named network.
-func (ds *DialerSwarm) Dial(network, address string) (net.Conn, error) {
-	return ds.DialContext(context.Background(), network, address)
-}
-
 // DialContext connects to the address on the named network using the provided context.
 func (ds *DialerSwarm) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	if ds.ResolveContext != nil {

--- a/requests/dialer_swarm.go
+++ b/requests/dialer_swarm.go
@@ -31,7 +31,7 @@ var ErrAllDialsFailed = errors.New("all dials failed")
 
 // DialerSwarm is a dials to multiple addresses in parallel and earliest successful connection wins.
 type DialerSwarm struct {
-	// ResolveContext specifies the dial function for doing custom DNS lookup.
+	// ResolveContext specifies the resolve function for doing custom DNS lookup.
 	// If ResolveContext is nil, then the transport dials using package net.
 	ResolveContext ResolveContext
 
@@ -47,6 +47,11 @@ func NewDialerSwarm(srcIP string) *DialerSwarm {
 			LocalAddr: &net.TCPAddr{IP: net.ParseIP(srcIP)},
 		},
 	}
+}
+
+// Dial connects to the address on the named network.
+func (ds *DialerSwarm) Dial(network, address string) (net.Conn, error) {
+	return ds.DialContext(context.Background(), network, address)
 }
 
 // DialContext connects to the address on the named network using the provided context.


### PR DESCRIPTION
Updates: #2793

Consumer in proposal can find broker contact with DNS name e.g. 
```
ProviderContacts:[{Type:nats/p2p/v1 Definition:{BrokerAddresses:[nats://server1.com:4222]}}]
```

This changes forces consumers perform NATS connection by dialling directly to IP instead of doing DNS resolution before dial. And dial is done to multiple addresses e.g.
```
server1.com:4222
1.2.3.4:4222
```