### PR TITLE
Mobile bypasses DNS lookups for all HTTP clients

### DIFF
--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -141,7 +141,18 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		BrokerAddresses:       options.BrokerAddresses,
 		EtherClientRPC:        options.EtherClientRPC,
 		ChainID:               options.ChainID,
-		DNSMap:                map[string][]string{},
+		DNSMap: map[string][]string{
+			"testnet-location.mysterium.network": {"82.196.15.9"},
+			"betanet-location.mysterium.network": {"95.216.204.232"},
+			"betanet-quality.mysterium.network":  {"116.202.100.246"},
+			"feedback.mysterium.network":         {"116.203.17.150"},
+			"api.ipify.org": {
+				"54.204.14.42", "54.225.153.147", "54.235.83.248", "54.243.161.145",
+				"23.21.109.69", "23.21.126.66",
+				"50.19.252.36",
+				"174.129.214.20",
+			},
+		},
 	}
 	logOptions := logconfig.LogOptions{
 		LogLevel: zerolog.DebugLevel,


### PR DESCRIPTION
Updates: #2792

This enables HTTP client failover transport (DNS dial -> IP dial) for mobile node.