### PR TITLE
Remake logging in end user products

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -44,7 +44,8 @@ import (
 	"github.com/mysteriumnetwork/node/utils"
 )
 
-const cliCommandName = "cli"
+// CliCommandName is the name which is used to call this command
+const CliCommandName = "cli"
 
 const serviceHelp = `service <action> [args]
 	start	<ProviderID> <ServiceType> [options]
@@ -58,7 +59,7 @@ const serviceHelp = `service <action> [args]
 // NewCommand constructs CLI based Mysterium UI with possibility to control quiting
 func NewCommand() *cli.Command {
 	return &cli.Command{
-		Name:   cliCommandName,
+		Name:   CliCommandName,
 		Usage:  "Starts a CLI client with a Tequilapi",
 		Before: clicontext.LoadUserConfigQuietly,
 		Action: func(ctx *cli.Context) error {


### PR DESCRIPTION
Now in compiled `myst cli` and future applications, logging to terminal will be disabled.
This is required in order to move along with the user friendly CLI apps.

The end user does not need to see the 50 lines of debugging messages printed when they launch `myst cli`, nor does he need the `zerolog` messages.

Now instead of:

```sh
» identities register 0x5d370ab418179d7de9410899249604d54485b860
2020-11-19T13:47:03.522 ERR tequilapi/client/http_client.go:123      >  error="server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x5d370ab418179d7de9410899249604d54485b860/register). Possible error: failed identity registration request: server response invalid: 400 Bad Request (https://testnet-transactor.mysterium.network/api/v1/identity/register){\"error\":{}}"
[WARNING] could not register identity: server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x5d370ab418179d7de9410899249604d54485b860/register). Possible error: failed identity registration request: server response invalid: 400 Bad Request (https://testnet-transactor.mysterium.network/api/v1/identity/register){"error":{}}
```

The end user sees this:
```sh
» identities register 0x5d370ab418179d7de9410899249604d54485b867
[WARNING] could not register identity: server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x5d370ab418179d7de9410899249604d54485b867/register). Possible error: failed identity registration request: server response invalid: 400 Bad Request (https://testnet-transactor.mysterium.network/api/v1/identity/register){"error":{}}
```

It's not perfect, but better.

Closes: https://github.com/mysteriumnetwork/node/issues/2840