### PR TITLE
Remove type matching from config merge

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -143,6 +143,28 @@ func TestConfig_ParseStringSliceFlag(t *testing.T) {
 	}
 }
 
+// this can happen when updating config via tequilapi - json unmarshal
+// translates json number to float64 by default if target type is interface{}
+func TestSimilarTypeMerge(t *testing.T) {
+	// given
+	cfg := NewConfig()
+	cfg.SetDefault("openvpn.port", 1001)
+
+	// when
+	cfg.SetUser("openvpn.port", 55.00)
+
+	// then
+	assert.Equal(t, 55, cfg.GetInt("openvpn.port"))
+
+	actual, ok := cfg.GetConfig()["openvpn"]
+	assert.True(t, ok)
+
+	actual, ok = actual.(map[string]interface{})["port"]
+	assert.True(t, ok)
+
+	assert.Equal(t, 55.0, actual)
+}
+
 func TestUserConfig_Get(t *testing.T) {
 	cfg := NewConfig()
 

--- a/config/viper.go
+++ b/config/viper.go
@@ -43,7 +43,6 @@ package config
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/spf13/cast"
@@ -156,12 +155,6 @@ func mergeMaps(
 			if itgt != nil {
 				itgt[sk] = sv
 			}
-			continue
-		}
-
-		svType := reflect.TypeOf(sv)
-		tvType := reflect.TypeOf(tv)
-		if svType != tvType {
 			continue
 		}
 


### PR DESCRIPTION
The way I see it - it does not matter what type the config value is stored in a `map[string]interface{}` hierarchy. 
The `config.Config` has receivers for fetching a value in any suitable type. However this introduces a possibility to break config although I have already broken it by consuming tequilapi.

In my case the problem is with json unmarshal converting JSON `number` to `float64` when target type is interface{}