### PR TITLE
Fix openvpn check for newer versions of openvpn(>=2.5.0)

### DIFF
--- a/services/openvpn/core/options_node.go
+++ b/services/openvpn/core/options_node.go
@@ -43,8 +43,9 @@ func (options *NodeOptions) Check() error {
 	if err != nil {
 		return err
 	}
-	//openvpn returns exit code 1 in case of --version parameter, if anything else is returned - treat as error
-	if exitCode != 1 {
+	// openvpn returns exit code 1 in case of --version parameter, if anything else is returned - treat as error
+	// with newer versions openvpn seems to have fixed the exit code 1 mistake, they now return a zero as they should.
+	if exitCode != 1 || exitCode == 0 {
 		log.Error().Msg("Check failed. Output of executed command: " + string(outputBuffer))
 		return errors.New("unexpected openvpn exit code: " + strconv.Itoa(exitCode))
 	}


### PR DESCRIPTION
Closes #2830 

We'll need to backport this to testnet.