### PR TITLE
Remake logging in end user commands

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -44,7 +44,8 @@ import (
 	"github.com/mysteriumnetwork/node/utils"
 )
 
-const cliCommandName = "cli"
+// CommandName is the name which is used to call this command
+const CommandName = "cli"
 
 const serviceHelp = `service <action> [args]
 	start	<ProviderID> <ServiceType> [options]
@@ -58,7 +59,7 @@ const serviceHelp = `service <action> [args]
 // NewCommand constructs CLI based Mysterium UI with possibility to control quiting
 func NewCommand() *cli.Command {
 	return &cli.Command{
-		Name:   cliCommandName,
+		Name:   CommandName,
 		Usage:  "Starts a CLI client with a Tequilapi",
 		Before: clicontext.LoadUserConfigQuietly,
 		Action: func(ctx *cli.Context) error {

--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -130,6 +130,12 @@ var (
 		}(),
 		Value: zerolog.DebugLevel.String(),
 	}
+	// FlagVerbose enables verbose logging.
+	FlagVerbose = cli.BoolFlag{
+		Name:  "verbose",
+		Usage: "If provided loggin becomes more verbose",
+		Value: false,
+	}
 	// FlagOpenvpnBinary openvpn binary to use for OpenVPN connections.
 	FlagOpenvpnBinary = cli.StringFlag{
 		Name:  "openvpn.binary",
@@ -257,6 +263,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		&FlagKeystoreLightweight,
 		&FlagLogHTTP,
 		&FlagLogLevel,
+		&FlagVerbose,
 		&FlagOpenvpnBinary,
 		&FlagQualityType,
 		&FlagQualityAddress,
@@ -304,6 +311,7 @@ func ParseFlagsNode(ctx *cli.Context) {
 	Current.ParseBoolFlag(ctx, FlagShaperEnabled)
 	Current.ParseBoolFlag(ctx, FlagKeystoreLightweight)
 	Current.ParseBoolFlag(ctx, FlagLogHTTP)
+	Current.ParseBoolFlag(ctx, FlagVerbose)
 	Current.ParseStringFlag(ctx, FlagLogLevel)
 	Current.ParseStringFlag(ctx, FlagOpenvpnBinary)
 	Current.ParseStringFlag(ctx, FlagQualityAddress)

--- a/logconfig/config.go
+++ b/logconfig/config.go
@@ -62,6 +62,12 @@ func Bootstrap() {
 	setGlobalLogger(&logger)
 }
 
+// SetLogLevel sets global log level to the given one.
+func SetLogLevel(level zerolog.Level) {
+	CurrentLogOptions.LogLevel = level
+	log.Logger = log.Logger.Level(level)
+}
+
 // Configure configures logger using app config (console + file, level).
 func Configure(opts *LogOptions) {
 	CurrentLogOptions = *opts


### PR DESCRIPTION
Before:
```sh
» identities register 0x5d370ab418179d7de9410899249604d54485b860
2020-11-19T13:47:03.522 ERR tequilapi/client/http_client.go:123      >  error="server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x5d370ab418179d7de9410899249604d54485b860/register). Possible error: failed identity registration request: server response invalid: 400 Bad Request (https://testnet-transactor.mysterium.network/api/v1/identity/register){\"error\":{}}"
[WARNING] could not register identity: server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x5d370ab418179d7de9410899249604d54485b860/register). Possible error: failed identity registration request: server response invalid: 400 Bad Request (https://testnet-transactor.mysterium.network/api/v1/identity/register){"error":{}}
```

Now:
```sh
» identities register 0x5d370ab418179d7de9410899249604d54485b867
[WARNING] could not register identity: server response invalid: 500 Internal Server Error (http://127.0.0.1:4050/identities/0x5d370ab418179d7de9410899249604d54485b867/register). Possible error: failed identity registration request: server response invalid: 400 Bad Request (https://testnet-transactor.mysterium.network/api/v1/identity/register){"error":{}}
```

You can still force the verbose logging with `log-verbose` flag.
Logging is configured per command.

Updates: https://github.com/mysteriumnetwork/node/issues/2837
Is sort of required for later new commands