### PR TITLE
Include an info subcommand

### DIFF
--- a/cmd/commands/connection/info.go
+++ b/cmd/commands/connection/info.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connection
+
+import (
+	"github.com/mysteriumnetwork/node/cmd/commands/cli/clio"
+)
+
+type connInfo struct {
+	fields      map[infoKey]string
+	isConnected bool
+}
+
+type infoKey string
+
+const (
+	infIP          infoKey = "ip"
+	infStatus      infoKey = "status"
+	infLocation    infoKey = "location"
+	infSessionID   infoKey = "sessionID"
+	infProposal    infoKey = "proposal"
+	infDuration    infoKey = "duration"
+	infTransferred infoKey = "transfered"
+	infThroughput  infoKey = "throughput"
+	infSpent       infoKey = "spent"
+	infIdentity    infoKey = "identity"
+)
+
+func newConnInfo() *connInfo {
+	return &connInfo{
+		fields:      make(map[infoKey]string),
+		isConnected: false,
+	}
+}
+
+func (i *connInfo) printAll() {
+	i.printSingle("IP:", infIP)
+	i.printSingle("Status:", infStatus)
+	i.printSingle("Location:", infLocation)
+	i.printSingle("Using Identity:", infIdentity)
+
+	if !i.isConnected {
+		return
+	}
+
+	i.printSingle("Session ID:", infSessionID)
+	i.printSingle("Proposal:", infProposal)
+	i.printSingle("Duration:", infDuration)
+	i.printSingle("Transfered:", infTransferred)
+	i.printSingle("Throughput:", infThroughput)
+	i.printSingle("Spent:", infSpent)
+}
+
+func (i *connInfo) set(k infoKey, v string) {
+	i.fields[k] = v
+}
+
+func (i *connInfo) printSingle(prefix string, k infoKey) {
+	v, ok := i.fields[k]
+	if !ok {
+		clio.Warn(prefix, "No data retrieved")
+		return
+	}
+	clio.Info(prefix, v)
+}


### PR DESCRIPTION
Added a command which shows your current connection information.
Current output if everything goes right is this:
```
[INFO] IP: 78.157.74.92
[INFO] Status: Connected
[INFO] Location: Vilnius, LT (residential - Penki)
[INFO] Using Identity: 0xe158f8bd585619a6f2f74527df6518074acde542
[INFO] Session ID: 9ac86d32-9e69-4a0d-bef1-08d57462b294
[INFO] Proposal: Id: 1 , Provider: 0x7a856876bb6fcc8765261e9a7e29463824bd6742, Country: CA
[INFO] Duration: 21m0s
[INFO] Transfered: 0b/0b
[INFO] Throughput: 0bs/0bs
[INFO] Spent: 0.000200MYST
```

My reasoning for the complicated data setting and printing: We want to shows a similar output to the user every singe time he runs the command, even if something fails. So now if something fails we just replace it with an `error`:
```
[WARNING] IP: No data retrieved
[INFO] Status: Connected
[INFO] Location: Vilnius, LT (residential - Penki)
[WARNING] Using Identity: No data retrieved
.....
```

This was the easiest way I found to do it with the least amount of code repetition.

Updates: https://github.com/mysteriumnetwork/node/issues/2837