### PR TITLE
Make stake optional when registering

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -167,7 +167,7 @@ func (c *cliApp) registerIdentity(actionArgs []string) {
 	}
 
 	var address = actionArgs[0]
-	var stake *big.Int
+	stake := new(big.Int).SetInt64(0)
 	if len(actionArgs) >= 2 {
 		s, ok := new(big.Int).SetString(actionArgs[1], 10)
 		if !ok {
@@ -203,7 +203,7 @@ func (c *cliApp) registerIdentity(actionArgs []string) {
 	}
 
 	clio.Info(msg)
-	clio.Info(fmt.Sprintf("To explore additional inforamtion about the identity use: %s", usageGetIdentity))
+	clio.Info(fmt.Sprintf("To explore additional information about the identity use: %s", usageGetIdentity))
 }
 
 const usageSettle = "settle <providerIdentity>"


### PR DESCRIPTION
Removes the need to do `identities register 0xab60bc6a3d33264bf8537dab2d44c73482ad1447 0`