### PR TITLE
Mobile payment bindings' fixes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1025,6 +1025,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20161007143504-f4b625ec9b21/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pilvytis/event.go
+++ b/pilvytis/event.go
@@ -17,10 +17,10 @@
 
 package pilvytis
 
-// AppTopicOrderStatusChanged is an topic when payment order status changes.
-const AppTopicOrderStatusChanged = "order_status_changed"
+// AppTopicOrderUpdated is an topic when the payment order is updated.
+const AppTopicOrderUpdated = "order_updated"
 
-// AppEventOrderStatusChanged is an order status changed event payload.
-type AppEventOrderStatusChanged struct {
+// AppEventOrderUpdated is the event payload for AppTopicOrderUpdated topic.
+type AppEventOrderUpdated struct {
 	OrderSummary
 }

--- a/pilvytis/order_status_tracker_test.go
+++ b/pilvytis/order_status_tracker_test.go
@@ -103,7 +103,7 @@ func EventPublished(bus *mocks.EventBus, orderID uint64, status OrderStatus) fun
 		if pop == nil {
 			return false
 		}
-		evt, ok := pop.(AppEventOrderStatusChanged)
+		evt, ok := pop.(AppEventOrderUpdated)
 		return ok && evt.ID == orderID && evt.Status == status
 	}
 }


### PR DESCRIPTION
Finalizes mobile bindings for pilvytis.
- Fix gobind-incompatible types (change to JSON serialized as []byte where it's not possible to use compatible types)
- Fix a bug where orders are not updated by the status tracker (wrong reference used)
- Change OrderStatusUpdatedEvent to OrderUpdatedEvent (PayAmount/PayCurrency may come back later as a callback)
- Added error handling for uint64 → int64 shrinking (not likely to be reached, but still a possibility/ gobind supports only signed types https://godoc.org/golang.org/x/mobile/cmd/gobind#hdr-Type_restrictions)

Fixes: #2784