### PR TITLE
Dns map check

### DIFF
--- a/ci/check/check.go
+++ b/ci/check/check.go
@@ -100,7 +100,7 @@ func CheckDNSMaps() error {
 
 	}
 
-	if len(ipMissmatches) >= 0 {
+	if len(ipMissmatches) > 0 {
 		for _, v := range ipMissmatches {
 			fmt.Println(v)
 		}

--- a/ci/check/check.go
+++ b/ci/check/check.go
@@ -35,7 +35,7 @@ import (
 func Check() {
 	mg.Deps(CheckGenerate)
 	mg.Deps(CheckSwagger)
-	mg.Deps(CheckGoImports, CheckGoLint, CheckGoVet, CheckCopyright)
+	mg.Deps(CheckGoImports, CheckDNSMaps, CheckGoLint, CheckGoVet, CheckCopyright)
 }
 
 // CheckCopyright checks for copyright headers in files.

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -83,7 +83,7 @@ var Testnet2Definition = NetworkDefinition{
 		"testnet2-trust.mysterium.network":      {"95.216.204.232"},
 		"testnet2-broker.mysterium.network":     {"95.216.204.232"},
 		"testnet2-transactor.mysterium.network": {"135.181.82.67"},
-		"testnet2.mysterium.network":            {"138.201.244.63"},
+		"testnet2.mysterium.network":            {"138.201.174.94"},
 	},
 	DefaultChainID: 5,
 }


### PR DESCRIPTION
Noticed a mismatch between the given DNS entries and actual IPs so wrote a check if we had any more.

Question is, do we want it to be checked by default by CI?

```
➜  node git:(dns-map-check) ✗ time mage CheckDNSMaps
mage CheckDNSMaps  8.91s user 7.93s system 448% cpu 3.752 total
```