### PR TITLE
Command to show current config

### DIFF
--- a/cmd/commands/config/command.go
+++ b/cmd/commands/config/command.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mysteriumnetwork/node/cmd/commands/cli/clio"
+	"github.com/mysteriumnetwork/node/config"
+	"github.com/mysteriumnetwork/node/config/urfavecli/clicontext"
+
+	"github.com/urfave/cli/v2"
+)
+
+// CommandName is the name which is used to call this command
+const CommandName = "config"
+
+// NewCommand function creates license command.
+func NewCommand() *cli.Command {
+	cmd := &command{}
+	return &cli.Command{
+		Name:        CommandName,
+		Usage:       "Manage your node config",
+		Description: "Using config subcommands you can view and manage your current node config",
+		Before: func(ctx *cli.Context) error {
+			if err := clicontext.LoadUserConfigQuietly(ctx); err != nil {
+				return err
+			}
+
+			config.ParseFlagsServiceStart(ctx)
+			config.ParseFlagsServiceOpenvpn(ctx)
+			config.ParseFlagsServiceWireguard(ctx)
+			config.ParseFlagsServiceNoop(ctx)
+			config.ParseFlagsNode(ctx)
+			return nil
+		},
+		Subcommands: []*cli.Command{
+			{
+				Name:  "show",
+				Usage: "Show current config",
+				Action: func(ctx *cli.Context) error {
+					cmd.show()
+					return nil
+				},
+			},
+		},
+	}
+}
+
+type command struct{}
+
+func (c *command) show() {
+	dest := map[string]string{}
+	squishMap(config.Current.GetConfig(), dest)
+
+	if len(dest) == 0 {
+		clio.Error("Config is empty or impossible to parse")
+		return
+	}
+
+	printMapOrdered(dest)
+}
+
+// Orders keys alphabetically and prints a given map.
+func printMapOrdered(m map[string]string) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Println(k+":", m[k])
+	}
+}
+
+// squishMap squishMap a given `source` map by checking every map
+// value and converting it to a string.
+// If a map value is another map, it will also be parsed and will gain
+// a key which is equal to both map keys joined with a `.` symbol.
+func squishMap(source map[string]interface{}, dest map[string]string, prefix ...string) {
+	keyPrefix := ""
+	if len(prefix) != 0 {
+		keyPrefix = strings.Join(prefix, ".")
+	}
+
+	for k, v := range source {
+		if nm, ok := v.(map[string]interface{}); ok {
+			squishMap(nm, dest, k)
+		} else {
+			if keyPrefix != "" {
+				k = keyPrefix + "." + k
+			}
+
+			dest[k] = fmt.Sprint(v)
+		}
+	}
+}

--- a/cmd/commands/config/command_test.go
+++ b/cmd/commands/config/command_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_squishMap(t *testing.T) {
+	for _, test := range []struct {
+		give map[string]interface{}
+		get  map[string]string
+	}{
+		{
+			give: map[string]interface{}{
+				"test1": 1,
+				"test2": "1",
+			},
+			get: map[string]string{
+				"test1": "1",
+				"test2": "1",
+			},
+		},
+		{
+			give: map[string]interface{}{
+				"test1": map[string]interface{}{
+					"test2": 1,
+				},
+				"test3": "1",
+				"test4": map[string]interface{}{
+					"test5": 7.5,
+				},
+			},
+			get: map[string]string{
+				"test1.test2": "1",
+				"test3":       "1",
+				"test4.test5": "7.5",
+			},
+		},
+	} {
+		dest := map[string]string{}
+		squishMap(test.give, dest)
+		assert.Len(t, dest, len(test.get))
+
+		for k, v := range test.get {
+			got, ok := dest[k]
+			assert.True(t, ok)
+			assert.Equal(t, v, got)
+		}
+	}
+}

--- a/cmd/mysterium_node/mysterium_node.go
+++ b/cmd/mysterium_node/mysterium_node.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/mysteriumnetwork/node/cmd/commands/account"
 	command_cli "github.com/mysteriumnetwork/node/cmd/commands/cli"
+	command_cfg "github.com/mysteriumnetwork/node/cmd/commands/config"
 	"github.com/mysteriumnetwork/node/cmd/commands/connection"
 	"github.com/mysteriumnetwork/node/cmd/commands/daemon"
 	"github.com/mysteriumnetwork/node/cmd/commands/license"
@@ -51,6 +52,7 @@ var (
 	resetCommand      = reset.NewCommand()
 	accountCommand    = account.NewCommand()
 	connectionCommand = connection.NewCommand()
+	configCommand     = command_cfg.NewCommand()
 )
 
 func main() {
@@ -96,6 +98,7 @@ func NewCommand() (*cli.App, error) {
 		resetCommand,
 		accountCommand,
 		connectionCommand,
+		configCommand,
 	}
 
 	return app, nil
@@ -112,6 +115,7 @@ var uiCommands = map[string]struct{}{
 	command_cli.CommandName: {},
 	account.CommandName:     {},
 	connection.CommandName:  {},
+	command_cfg.CommandName: {},
 }
 
 // configureLogging returns a func which configures global


### PR DESCRIPTION
Parses most config flags and show them to the user.
Values are always sorted alphabetically, inner map values are squished, example:
```
tomas@pop-os:~/go/src/github.com/mysteriumnetwork/node$ build/myst/myst config show
access-policy.address: https://testnet2-trust.mysterium.network/api/v1/access-policies/
access-policy.fetch: 10m0s
access-policy.list: 
agreed-terms-and-conditions: false
allowed.subnet: 10.182.0.0/16
api.address: https://testnet2-api.mysterium.network/v1
auth.password: mm
auth.username: mm
....
``` 

Updates: https://github.com/mysteriumnetwork/node/issues/2878