### PR TITLE
Show currency depending on the network

### DIFF
--- a/cmd/commands/account/command.go
+++ b/cmd/commands/account/command.go
@@ -267,7 +267,7 @@ func (c *command) infoGeneral(identityAddress string) {
 	clio.Info("Using identity:", identityAddress)
 	clio.Info("Registration Status:", identityStatus.RegistrationStatus)
 	clio.Info("Channel address:", identityStatus.ChannelAddress)
-	clio.Info(fmt.Sprintf("Balance: %s", money.NewMoney(identityStatus.Balance, money.CurrencyMyst)))
+	clio.Info(fmt.Sprintf("Balance: %s", money.New(identityStatus.Balance)))
 }
 
 func (c *command) infoTopUp(identityAddress string) {

--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -306,7 +306,7 @@ func (c *cliApp) serviceSessions() {
 			"ID: "+session.ID,
 			"ConsumerID: "+session.ConsumerID,
 			fmt.Sprintf("Data: %s/%s", datasize.FromBytes(session.BytesReceived).String(), datasize.FromBytes(session.BytesSent).String()),
-			fmt.Sprintf("Tokens: %s", money.NewMoney(session.Tokens, money.CurrencyMyst)),
+			fmt.Sprintf("Tokens: %s", money.New(session.Tokens)),
 		)
 	}
 }
@@ -496,7 +496,7 @@ func (c *cliApp) status() {
 			clio.Info(fmt.Sprintf("Connection duration: %s", time.Duration(statistics.Duration)*time.Second))
 			clio.Info(fmt.Sprintf("Data: %s/%s", datasize.FromBytes(statistics.BytesReceived), datasize.FromBytes(statistics.BytesSent)))
 			clio.Info(fmt.Sprintf("Throughput: %s/%s", datasize.BitSpeed(statistics.ThroughputReceived), datasize.BitSpeed(statistics.ThroughputSent)))
-			clio.Info(fmt.Sprintf("Spent: %s", money.NewMoney(statistics.TokensSpent, money.CurrencyMyst)))
+			clio.Info(fmt.Sprintf("Spent: %s", money.New(statistics.TokensSpent)))
 		}
 	}
 }

--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -109,9 +109,9 @@ func (c *cliApp) getIdentity(actionArgs []string) {
 	}
 	clio.Info("Registration Status:", identityStatus.RegistrationStatus)
 	clio.Info("Channel address:", identityStatus.ChannelAddress)
-	clio.Info(fmt.Sprintf("Balance: %s", money.NewMoney(identityStatus.Balance, money.CurrencyMyst)))
-	clio.Info(fmt.Sprintf("Earnings: %s", money.NewMoney(identityStatus.Earnings, money.CurrencyMyst)))
-	clio.Info(fmt.Sprintf("Earnings total: %s", money.NewMoney(identityStatus.EarningsTotal, money.CurrencyMyst)))
+	clio.Info(fmt.Sprintf("Balance: %s", money.New(identityStatus.Balance)))
+	clio.Info(fmt.Sprintf("Earnings: %s", money.New(identityStatus.Earnings)))
+	clio.Info(fmt.Sprintf("Earnings total: %s", money.New(identityStatus.EarningsTotal)))
 }
 
 const usageNewIdentity = "new [passphrase]"

--- a/cmd/commands/connection/command.go
+++ b/cmd/commands/connection/command.go
@@ -261,7 +261,7 @@ func (c *command) info() {
 		inf.set(infDuration, fmt.Sprint(time.Duration(statistics.Duration)*time.Second))
 		inf.set(infTransferred, fmt.Sprintf("%s/%s", datasize.FromBytes(statistics.BytesReceived), datasize.FromBytes(statistics.BytesSent)))
 		inf.set(infThroughput, fmt.Sprintf("%s/%s", datasize.BitSpeed(statistics.ThroughputReceived), datasize.BitSpeed(statistics.ThroughputSent)))
-		inf.set(infSpent, money.NewMoney(statistics.TokensSpent, money.CurrencyMyst).String())
+		inf.set(infSpent, money.New(statistics.TokensSpent).String())
 	}
 
 	inf.printAll()

--- a/cmd/commands/connection/util.go
+++ b/cmd/commands/connection/util.go
@@ -51,14 +51,14 @@ func aproxPricePerMinute(pm contract.PaymentMethodDTO) money.Money {
 	s := time.Duration(pm.Rate.PerSeconds) * time.Second
 	min := new(big.Float).SetFloat64(s.Minutes())
 	if min.Cmp(big.NewFloat(0)) == 0 {
-		return money.NewMoney(new(big.Int).SetInt64(0), pm.Price.Currency)
+		return money.New(new(big.Int).SetInt64(0), pm.Price.Currency)
 	}
 
 	price := new(big.Float).SetInt(pm.Price.Amount)
 	perMinute := new(big.Float).Quo(price, min)
 	perMinuteRounded, _ := perMinute.Int(nil)
 
-	return money.NewMoney(perMinuteRounded, pm.Price.Currency)
+	return money.New(perMinuteRounded, pm.Price.Currency)
 }
 
 func aproxPricePerGB(pm contract.PaymentMethodDTO) money.Money {
@@ -67,11 +67,11 @@ func aproxPricePerGB(pm contract.PaymentMethodDTO) money.Money {
 		new(big.Float).SetUint64(datasize.GiB.Bytes()),
 	)
 	if gb.Cmp(big.NewFloat(0)) == 0 {
-		return money.NewMoney(new(big.Int).SetInt64(0), pm.Price.Currency)
+		return money.New(new(big.Int).SetInt64(0), pm.Price.Currency)
 	}
 
 	price := new(big.Float).SetInt(pm.Price.Amount)
 	perGB := new(big.Float).Quo(price, gb)
 	perGBRounded, _ := perGB.Int(nil)
-	return money.NewMoney(perGBRounded, pm.Price.Currency)
+	return money.New(perGBRounded, pm.Price.Currency)
 }

--- a/core/discovery/proposal/filter_test.go
+++ b/core/discovery/proposal/filter_test.go
@@ -66,7 +66,7 @@ var (
 	}
 	proposalTimeExpensive = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(9999999999999), money.CurrencyMyst),
+			price: money.New(big.NewInt(9999999999999), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Minute,
 			},
@@ -74,7 +74,7 @@ var (
 	}
 	proposalTimeCheap = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(0), money.CurrencyMyst),
+			price: money.New(big.NewInt(0), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Minute,
 			},
@@ -82,7 +82,7 @@ var (
 	}
 	proposalTimeExact = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(1000000), money.CurrencyMyst),
+			price: money.New(big.NewInt(1000000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Minute,
 			},
@@ -90,7 +90,7 @@ var (
 	}
 	proposalBytesExpensive = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(7000001), money.CurrencyMyst),
+			price: money.New(big.NewInt(7000001), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: bytesInGibibyte,
 			},
@@ -98,7 +98,7 @@ var (
 	}
 	proposalBytesCheap = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(0), money.CurrencyMyst),
+			price: money.New(big.NewInt(0), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: bytesInGibibyte,
 			},
@@ -106,7 +106,7 @@ var (
 	}
 	proposalBytesExact = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(7000000), money.CurrencyMyst),
+			price: money.New(big.NewInt(7000000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: bytesInGibibyte,
 			},
@@ -114,7 +114,7 @@ var (
 	}
 	proposalBytesExactInParts = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(50000), money.CurrencyMyst),
+			price: money.New(big.NewInt(50000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: 7669584,
 			},
@@ -122,7 +122,7 @@ var (
 	}
 	proposalSupported = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(50000), money.CurrencyMyst),
+			price: money.New(big.NewInt(50000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: 7669584,
 			},

--- a/core/discovery/reducer/mocks.go
+++ b/core/discovery/reducer/mocks.go
@@ -62,7 +62,7 @@ var (
 	}
 	proposalTimeExpensive = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(9999999999999), money.CurrencyMyst),
+			price: money.New(big.NewInt(9999999999999), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Minute,
 			},
@@ -70,7 +70,7 @@ var (
 	}
 	proposalTimeCheap = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(0), money.CurrencyMyst),
+			price: money.New(big.NewInt(0), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Minute,
 			},
@@ -78,7 +78,7 @@ var (
 	}
 	proposalTimeExact = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(1000000), money.CurrencyMyst),
+			price: money.New(big.NewInt(1000000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Minute,
 			},
@@ -86,7 +86,7 @@ var (
 	}
 	proposalTimeExactSeconds = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(1000000/60), money.CurrencyMyst),
+			price: money.New(big.NewInt(1000000/60), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Second,
 			},
@@ -94,7 +94,7 @@ var (
 	}
 	proposalTimeExpensiveSeconds = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(17000), money.CurrencyMyst),
+			price: money.New(big.NewInt(17000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerTime: time.Second,
 			},
@@ -102,7 +102,7 @@ var (
 	}
 	proposalBytesExpensive = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(7000001), money.CurrencyMyst),
+			price: money.New(big.NewInt(7000001), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: datasize.GiB.Bytes(),
 			},
@@ -110,7 +110,7 @@ var (
 	}
 	proposalBytesCheap = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(0), money.CurrencyMyst),
+			price: money.New(big.NewInt(0), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: datasize.GiB.Bytes(),
 			},
@@ -118,7 +118,7 @@ var (
 	}
 	proposalBytesExact = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(7000000), money.CurrencyMyst),
+			price: money.New(big.NewInt(7000000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: datasize.GiB.Bytes(),
 			},
@@ -126,7 +126,7 @@ var (
 	}
 	proposalBytesExactInParts = market.ServiceProposal{
 		PaymentMethod: &mockPaymentMethod{
-			price: money.NewMoney(big.NewInt(50000), money.CurrencyMyst),
+			price: money.New(big.NewInt(50000), money.CurrencyMyst),
 			rate: market.PaymentRate{
 				PerByte: 7669584,
 			},

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -74,6 +74,6 @@ func (c Connection) String() string {
 		datasize.FromBytes(c.Statistics.BytesSent),
 		c.Throughput.Down,
 		c.Throughput.Up,
-		money.NewMoney(c.Invoice.AgreementTotal, money.CurrencyMyst),
+		money.New(c.Invoice.AgreementTotal),
 	)
 }

--- a/money/currency.go
+++ b/money/currency.go
@@ -28,4 +28,7 @@ var MystSize = big.NewInt(1_000_000_000_000_000_000)
 const (
 	// CurrencyMyst is the myst token currency representation
 	CurrencyMyst = Currency("MYST")
+
+	// CurrencyMystt is the test myst token currency representation
+	CurrencyMystt = Currency("MYSTT")
 )

--- a/money/money.go
+++ b/money/money.go
@@ -20,6 +20,8 @@ package money
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/mysteriumnetwork/node/config"
 )
 
 // Money holds the currency type and amount
@@ -28,14 +30,26 @@ type Money struct {
 	Currency Currency `json:"currency,omitempty"`
 }
 
-// NewMoney returns a new instance of Money.
-// The money is a representation of myst in a uint64 form, with the decimal part expanded.
-// This means, that one myst is equivalent to 10 0000 000.
-func NewMoney(amount *big.Int, currency Currency) Money {
-	return Money{amount, currency}
+// New returns a new instance of Money.
+// Expected `amount` value for 1 myst is equal to 1_000_000_000_000_000_000.
+// It also allows for an optional currency value to be passed,
+// if one is not passed, default config value is used.
+func New(amount *big.Int, currency ...Currency) Money {
+	m := Money{
+		Amount: amount,
+	}
+
+	if len(currency) > 0 {
+		m.Currency = currency[0]
+	} else {
+		m.Currency = Currency(config.GetString(config.FlagDefaultCurrency))
+	}
+
+	return m
 }
 
-// String converts struct to string
+// String converts Money struct into a string
+// which is represented by a float64 with 6 number precision.
 func (value Money) String() string {
 	amount := new(big.Float).SetInt(value.Amount)
 	size := new(big.Float).SetInt(MystSize)

--- a/services/noop/discovery_dto_test.go
+++ b/services/noop/discovery_dto_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Test_PaymentMethod_Serialize(t *testing.T) {
-	price := money.NewMoney(big.NewInt(50000000), money.CurrencyMyst)
+	price := money.New(big.NewInt(50000000), money.CurrencyMyst)
 
 	var tests = []struct {
 		model        pingpong.PaymentMethod
@@ -68,7 +68,7 @@ func Test_PaymentMethod_Serialize(t *testing.T) {
 }
 
 func Test_PaymentMethod_Unserialize(t *testing.T) {
-	price := money.NewMoney(big.NewInt(50000000), money.CurrencyMyst)
+	price := money.New(big.NewInt(50000000), money.CurrencyMyst)
 
 	var tests = []struct {
 		json          string

--- a/services/wireguard/service_config_test.go
+++ b/services/wireguard/service_config_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func Test_PaymentMethod_Serialize(t *testing.T) {
-	price := money.NewMoney(big.NewInt(50000000), money.CurrencyMyst)
+	price := money.New(big.NewInt(50000000), money.CurrencyMyst)
 
 	var tests = []struct {
 		model        pingpong.PaymentMethod
@@ -69,7 +69,7 @@ func Test_PaymentMethod_Serialize(t *testing.T) {
 }
 
 func Test_PaymentMethod_Unserialize(t *testing.T) {
-	price := money.NewMoney(big.NewInt(50000000), money.CurrencyMyst)
+	price := money.New(big.NewInt(50000000), money.CurrencyMyst)
 
 	var tests = []struct {
 		json          string

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -75,7 +75,7 @@ func NewPaymentMethod(pricePerGB, pricePerMinute *big.Int) PaymentMethod {
 	}
 
 	return PaymentMethod{
-		Price:    money.NewMoney(accuracy, money.CurrencyMyst),
+		Price:    money.New(accuracy),
 		Duration: time.Duration(pricePerMinute.Int64()),
 		Type:     PaymentForDataWithTime,
 		Bytes:    pricePerGB.Uint64(),

--- a/session/pingpong/invoice_payer_test.go
+++ b/session/pingpong/invoice_payer_test.go
@@ -84,7 +84,7 @@ func Test_InvoicePayer_Start_Stop(t *testing.T) {
 		EventBus:                  mocks.NewEventBus(),
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -137,7 +137,7 @@ func Test_InvoicePayer_SendsMessage(t *testing.T) {
 		Peer:                      identity.FromAddress("0x441Da57A51e42DAB7Daf55909Af93A9b00eEF23C"),
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -272,7 +272,7 @@ func Test_InvoicePayer_BubblesErrors(t *testing.T) {
 		Peer:                      identity.FromAddress("0x441Da57A51e42DAB7Daf55909Af93A9b00eEF23C"),
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -319,7 +319,7 @@ func TestInvoicePayer_isInvoiceOK(t *testing.T) {
 				},
 				proposal: market.ServiceProposal{
 					PaymentMethod: &mockPaymentMethod{
-						price: money.NewMoney(big.NewInt(100000), money.CurrencyMyst),
+						price: money.New(big.NewInt(100000), money.CurrencyMyst),
 						rate:  market.PaymentRate{PerTime: time.Minute},
 					},
 				},
@@ -341,7 +341,7 @@ func TestInvoicePayer_isInvoiceOK(t *testing.T) {
 				},
 				proposal: market.ServiceProposal{
 					PaymentMethod: &mockPaymentMethod{
-						price: money.NewMoney(big.NewInt(100000), money.CurrencyMyst),
+						price: money.New(big.NewInt(100000), money.CurrencyMyst),
 						rate:  market.PaymentRate{PerTime: time.Minute},
 					},
 				},

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -94,7 +94,7 @@ func Test_InvoiceTracker_Start_Stop(t *testing.T) {
 	deps := InvoiceTrackerDeps{
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -147,7 +147,7 @@ func Test_InvoiceTracker_Start_RefusesLargeFee(t *testing.T) {
 	deps := InvoiceTrackerDeps{
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -202,7 +202,7 @@ func Test_InvoiceTracker_Start_BubblesHermesCheckError(t *testing.T) {
 	deps := InvoiceTrackerDeps{
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -255,7 +255,7 @@ func Test_InvoiceTracker_BubblesErrors(t *testing.T) {
 	deps := InvoiceTrackerDeps{
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -315,7 +315,7 @@ func Test_InvoiceTracker_SendsInvoice(t *testing.T) {
 	deps := InvoiceTrackerDeps{
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(1000000000000), money.CurrencyMyst),
+				price: money.New(big.NewInt(1000000000000), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -371,7 +371,7 @@ func Test_InvoiceTracker_FirstInvoice_Has_Static_Value(t *testing.T) {
 	deps := InvoiceTrackerDeps{
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(1000000000000), money.CurrencyMyst),
+				price: money.New(big.NewInt(1000000000000), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 		},
@@ -463,7 +463,7 @@ func Test_sendsInvoiceIfThresholdReached(t *testing.T) {
 		EventBus:    mocks.NewEventBus(),
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate: market.PaymentRate{
 					PerTime: time.Minute,
 					PerByte: 1,
@@ -494,7 +494,7 @@ func Test_sendsInvoiceIfTimePassed(t *testing.T) {
 		EventBus:    mocks.NewEventBus(),
 		Proposal: market.ServiceProposal{
 			PaymentMethod: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate: market.PaymentRate{
 					PerTime: time.Minute,
 					PerByte: 1,

--- a/session/pingpong/price_calculator_test.go
+++ b/session/pingpong/price_calculator_test.go
@@ -35,7 +35,7 @@ func Test_isServiceFree(t *testing.T) {
 		{
 			name: "not free if only time payment is set",
 			method: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerTime: time.Minute},
 			},
 			want: false,
@@ -43,7 +43,7 @@ func Test_isServiceFree(t *testing.T) {
 		{
 			name: "not free if only byte payment is set",
 			method: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerByte: 1},
 			},
 			want: false,
@@ -51,7 +51,7 @@ func Test_isServiceFree(t *testing.T) {
 		{
 			name: "not free if time + byte payment is set",
 			method: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerByte: 1, PerTime: time.Minute},
 			},
 			want: false,
@@ -64,7 +64,7 @@ func Test_isServiceFree(t *testing.T) {
 		{
 			name: "free if both zero",
 			method: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(10), money.CurrencyMyst),
+				price: money.New(big.NewInt(10), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerByte: 0, PerTime: 0},
 			},
 			want: true,
@@ -72,7 +72,7 @@ func Test_isServiceFree(t *testing.T) {
 		{
 			name: "free if price zero",
 			method: &mockPaymentMethod{
-				price: money.NewMoney(big.NewInt(0), money.CurrencyMyst),
+				price: money.New(big.NewInt(0), money.CurrencyMyst),
 				rate:  market.PaymentRate{PerByte: 1, PerTime: 2},
 			},
 			want: true,
@@ -106,7 +106,7 @@ func Test_CalculatePaymentAmount(t *testing.T) {
 					Up: 100, Down: 100,
 				},
 				method: &mockPaymentMethod{
-					price: money.NewMoney(big.NewInt(0), money.CurrencyMyst),
+					price: money.New(big.NewInt(0), money.CurrencyMyst),
 					rate:  market.PaymentRate{PerByte: 1, PerTime: 2},
 				},
 			},
@@ -120,7 +120,7 @@ func Test_CalculatePaymentAmount(t *testing.T) {
 					Up: 100, Down: 100,
 				},
 				method: &mockPaymentMethod{
-					price: money.NewMoney(big.NewInt(50000), money.CurrencyMyst),
+					price: money.New(big.NewInt(50000), money.CurrencyMyst),
 					rate:  market.PaymentRate{PerByte: 0, PerTime: time.Minute},
 				},
 			},
@@ -134,7 +134,7 @@ func Test_CalculatePaymentAmount(t *testing.T) {
 					Up: 100, Down: 100,
 				},
 				method: &mockPaymentMethod{
-					price: money.NewMoney(big.NewInt(50000), money.CurrencyMyst),
+					price: money.New(big.NewInt(50000), money.CurrencyMyst),
 					rate:  market.PaymentRate{PerByte: 0, PerTime: time.Second},
 				},
 			},
@@ -148,7 +148,7 @@ func Test_CalculatePaymentAmount(t *testing.T) {
 					Up: 1000000000 / 2, Down: 1000000000 / 2,
 				},
 				method: &mockPaymentMethod{
-					price: money.NewMoney(big.NewInt(7000000), money.CurrencyMyst),
+					price: money.New(big.NewInt(7000000), money.CurrencyMyst),
 					rate:  market.PaymentRate{PerByte: 1000000000, PerTime: 0},
 				},
 			},
@@ -162,7 +162,7 @@ func Test_CalculatePaymentAmount(t *testing.T) {
 					Up: 1000000000 / 2, Down: 1000000000 / 2,
 				},
 				method: &mockPaymentMethod{
-					price: money.NewMoney(big.NewInt(50000), money.CurrencyMyst),
+					price: money.New(big.NewInt(50000), money.CurrencyMyst),
 					rate:  market.PaymentRate{PerByte: 7142857, PerTime: time.Minute},
 				},
 			},


### PR DESCRIPTION
* Console commands and logs will now show `MYSTT` if running in testnet
* Nodes will also report their currency as `MYSTT` in proposals
* Money struct was updated to support these changes, allowing backwards comparability with optional currency param. This allows tests to not break and work as expected.

Improves: https://github.com/mysteriumnetwork/node/issues/2884