### PR TITLE
Keep permissions when copying files

### DIFF
--- a/utils/fileutil/fileutil.go
+++ b/utils/fileutil/fileutil.go
@@ -78,13 +78,21 @@ func CopyDirs(src, dest string) error {
 	return nil
 }
 
+// copyFile copies a file from `src` to `dest`.
+// It tries to also copy it with the same permissions,
+// if thats not possible 0644 is used.
 func copyFile(src, dest string) error {
 	data, err := ioutil.ReadFile(src)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(dest, data, 0644)
+	perm := os.FileMode(0644)
+	if info, err := os.Stat(src); err == nil {
+		perm = info.Mode().Perm()
+	}
+
+	err = ioutil.WriteFile(dest, data, perm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When building using `mage` config files like `update-resolv-conf` were being copied without keeping their configured permissions. While they're executable in `bin/package/config/linux` they become `0644` after moving them to the `build/` directory.

This not only makes the daemon not connect to proposals, but it also bricks the internet connection requiring a reboot of the system. 

There are two ways to address this: either we just move everything with `0744` permissions hard coded or carry over the permissions. I think this is more `safe`. The default 0644 is also debatable.

Before:
```sh
tomas@pop-os:~/go$ ls -l build/myst/config/
total 16
-rw-r--r-- 1 tomas tomas   27 Dec 14 15:17 nonpriv-ip
-rw-r--r-- 1 tomas tomas  166 Dec 14 15:17 prepare-env.sh
-rw-r--r-- 1 tomas tomas   97 Dec 14 15:17 README
-rw-r--r-- 1 tomas tomas 1594 Dec 14 15:17 update-resolv-conf
```

After:
```sh
tomas@pop-os:~/go$ ls -l build/myst/config/
total 16
-rwxrwxr-x 1 tomas tomas   27 Dec 14 15:44 nonpriv-ip
-rwxrwxr-x 1 tomas tomas  166 Dec 14 15:44 prepare-env.sh
-rw-rw-r-- 1 tomas tomas   97 Dec 14 15:44 README
-rwxrwxr-x 1 tomas tomas 1594 Dec 14 15:44 update-resolv-conf
```

Closes: https://github.com/mysteriumnetwork/node/issues/2928