### PR TITLE
Improve messages shown when topping up

### DIFF
--- a/cmd/commands/account/util.go
+++ b/cmd/commands/account/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/mysteriumnetwork/node/cmd/commands/cli/clio"
+	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 )
 
@@ -49,9 +50,7 @@ func printOrder(o contract.OrderResponse) {
 	}
 
 	clio.Info(fmt.Sprintf("Order ID '%d' is in state: '%s'", o.ID, o.Status))
-	clio.Info(fmt.Sprintf("Price: %s %s", fUnknown(o.PriceAmount), o.PriceCurrency))
 	clio.Info(fmt.Sprintf("Pay: %s %s", fUnknown(o.PayAmount), strUnknown(o.PayCurrency)))
-	clio.Info(fmt.Sprintf("Receive: %s %s", fUnknown(o.ReceiveAmount), o.ReceiveCurrency))
-	clio.Info(fmt.Sprintf("Myst amount: %f", o.MystAmount))
+	clio.Info(fmt.Sprintf("Receive %s amount: %f", config.GetString(config.FlagDefaultCurrency), o.MystAmount))
 	clio.Info(fmt.Sprintf("PaymentURL: %s", o.PaymentURL))
 }

--- a/cmd/commands/cli/command_orders.go
+++ b/cmd/commands/cli/command_orders.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/mysteriumnetwork/node/cmd/commands/cli/clio"
+	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/pkg/errors"
@@ -181,6 +182,6 @@ func printOrder(o contract.OrderResponse) {
 	clio.Info(fmt.Sprintf("Price: %s %s", fUnknown(o.PriceAmount), o.PriceCurrency))
 	clio.Info(fmt.Sprintf("Pay: %s %s", fUnknown(o.PayAmount), strUnknown(o.PayCurrency)))
 	clio.Info(fmt.Sprintf("Receive: %s %s", fUnknown(o.ReceiveAmount), o.ReceiveCurrency))
-	clio.Info(fmt.Sprintf("Myst amount: %f", o.MystAmount))
+	clio.Info(fmt.Sprintf("Receive %s amount: %f", config.GetString(config.FlagDefaultCurrency), o.MystAmount))
 	clio.Info(fmt.Sprintf("PaymentURL: %s", o.PaymentURL))
 }


### PR DESCRIPTION
User friendly CLI now only shows fields that interest basic users:
```
tomas@pop-os:~/go/src/github.com/mysteriumnetwork/node$ build/myst/myst account topup --currency MYST --amount 100
[INFO] New top up request for identity 0x6a4a64f068e9f97656a3bb92b36b3e46bbcxxxx has been created: 
[INFO] Order ID '71421xx' is in state: 'new'
[INFO] Pay: 101 MYST
[INFO] Receive MYSTT amount: 100.000000
[INFO] PaymentURL: https://pay.coingate.com/invoice/3389e3e5-3ebf-4b27-b1d6-b0bc91dxxxxx
```

The other fields were really confusing and not needed for any basic user.
Also adjusted the currency, config is now used when displaying the received money.