### PR TITLE
TOS check directly via config

### DIFF
--- a/tequilapi/contract/terms.go
+++ b/tequilapi/contract/terms.go
@@ -76,15 +76,15 @@ func NewTermsResp() *TermsResponse {
 // ToMap turns a TermsRequest in to an iterable map which
 // can be mapped directly to a user config.
 func (t *TermsRequest) ToMap() map[string]interface{} {
-	give := map[string]interface{}{}
+	m := map[string]interface{}{}
 	if t.AgreedConsumer != nil {
-		give[TermsConsumerAgreed] = *t.AgreedConsumer
+		m[TermsConsumerAgreed] = *t.AgreedConsumer
 	}
 
 	if t.AgreedProvider != nil {
-		give[TermsProviderAgreed] = *t.AgreedProvider
+		m[TermsProviderAgreed] = *t.AgreedProvider
 	}
-	give[TermsVersion] = t.AgreedVersion
+	m[TermsVersion] = t.AgreedVersion
 
-	return give
+	return m
 }


### PR DESCRIPTION
Check - https://github.com/mysteriumnetwork/node/issues/2948

These changes aim to patch faulty workflow as CLI tool reads config from a predefined path but updates it via tequilapi.
I am not sure this is right approach at all but @tomasmik argued that we should have a possibility to launch CLI tool without backing NODE. 

My personal opinion would be to not allow that and follow the common idea that it should only work if the NODE is up. Like with desktop app, webUI and android.

@Waldz you seem to know about CLI philosophy so your opinion is much appreciated.