### PR TITLE
Insert ToS agreement when installing deb package

### DIFF
--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -165,6 +165,7 @@ func (sc *serviceCommand) tryRememberTOS(ctx *cli.Context, errCh chan error) {
 		for i := 0; i < 5; i++ {
 			if err := sc.tequilapi.UpdateTerms(contract.TermsRequest{
 				AgreedProvider: &t,
+				AgreedConsumer: &t,
 				AgreedVersion:  metadata.CurrentTermsVersion,
 			}); err == nil {
 				return


### PR DESCRIPTION
Updates: #2948

This is a somewhat fragile way to insert the ToS agreement in the config if user is installing the deb package.

While this works any suggestions are welcome.