### PR TITLE
Migrate bounty payout address to BC beneficiary

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -174,7 +174,7 @@ func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) err
 		HermesAddress:       common.HexToAddress(nodeOptions.Hermes.HermesID),
 		RegistryAddress:     common.HexToAddress(nodeOptions.Transactor.RegistryAddress),
 	}
-	di.ProviderRegistrar = registry.NewProviderRegistrar(di.Transactor, di.IdentityRegistry, cfg)
+	di.ProviderRegistrar = registry.NewProviderRegistrar(di.Transactor, di.IdentityRegistry, di.MysteriumAPI, di.SignerFactory, cfg)
 	return di.ProviderRegistrar.Subscribe(di.EventBus)
 }
 


### PR DESCRIPTION
Closes: #2956

This checks does free auto-registration to BC only if identity used to have payout address for bounty payments.
Also migrates found payout address to identity beneficiary in BC.