### PR TITLE
Node UI password rework

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -227,7 +227,7 @@ func (di *Dependencies) Bootstrap(nodeOptions node.Options) error {
 	if err := di.bootstrapAuthenticator(); err != nil {
 		return err
 	}
-
+	di.migrateCrendentials()
 	di.bootstrapUIServer(nodeOptions)
 	if err := di.bootstrapMMN(); err != nil {
 		return err
@@ -835,10 +835,33 @@ func (di *Dependencies) bootstrapAuthenticator() error {
 	if err != nil {
 		return err
 	}
-	di.Authenticator = auth.NewAuthenticator(di.Storage)
+	di.Authenticator = auth.NewAuthenticator()
 	di.JWTAuthenticator = auth.NewJWTAuthenticator(key)
 
 	return nil
+}
+
+// TODO: This should be removed when we no longer need to care about
+// migrating credentials.
+func (di *Dependencies) migrateCrendentials() {
+	s := []auth.Storage{di.Storage}
+	if !config.GetBool(config.FlagTestnet2) {
+		testnet2, err := boltdb.NewStorage(node.GetOptionsDirectoryDB(node.NetworkSubDirTestnet2))
+		if err == nil {
+			s = append(s, testnet2)
+		}
+	}
+
+	if !config.GetBool(config.FlagTestnet) {
+		testnet, err := boltdb.NewStorage(node.GetOptionsDirectoryDB(node.NetworkSubDirTestnet))
+		if err == nil {
+			s = append(s, testnet)
+		}
+	}
+
+	if err := auth.MigrateCredentials(s); err != nil {
+		log.Err(err).Msg("Credential migration did not finish correctly")
+	}
 }
 
 func (di *Dependencies) bootstrapPilvytis(options node.Options) {

--- a/cmd/mysterium_node/mysterium_node.go
+++ b/cmd/mysterium_node/mysterium_node.go
@@ -116,6 +116,7 @@ var uiCommands = map[string]struct{}{
 	account.CommandName:     {},
 	connection.CommandName:  {},
 	command_cfg.CommandName: {},
+	reset.CommandName:       {},
 }
 
 // configureLogging returns a func which configures global

--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -21,24 +21,27 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/urfave/cli/v2"
-
-	"github.com/spf13/cast"
-
-	"github.com/mysteriumnetwork/node/tequilapi/client"
-
 	"github.com/mysteriumnetwork/node/config"
+
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cast"
+	"github.com/urfave/cli/v2"
 )
 
 // Config - remote config struct
 type Config struct {
-	client *client.Client
+	client Fetcher
 	config map[string]interface{}
 }
 
+// Fetcher interface represents anything that
+// is able to fetch a config.
+type Fetcher interface {
+	FetchConfig() (map[string]interface{}, error)
+}
+
 // NewConfig - new remote config instance
-func NewConfig(client *client.Client) (*Config, error) {
+func NewConfig(client Fetcher) (*Config, error) {
 	cfg := &Config{
 		client: client,
 	}

--- a/core/auth/migrator.go
+++ b/core/auth/migrator.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"github.com/mysteriumnetwork/node/config"
+)
+
+// Storage for Credentials.
+type Storage interface {
+	GetValue(bucket string, key interface{}, to interface{}) error
+	SetValue(bucket string, key interface{}, to interface{}) error
+}
+
+const credentialsDBBucket = "app-credentials"
+
+// MigrateCredentials check if a password file exists, if it doesn't
+// it will create it following the rules:
+//
+// Create a new file with a password from testnet2 Storage if
+// testnet2 doesn't have a password set, else use testnet.
+//
+// If password can't be found in either Storage and no file exists
+// we assume that the user is new and he will create it.
+func MigrateCredentials(passStorages []Storage) error {
+	handler := NewCredentialsManager(config.GetString(config.FlagDataDir))
+	_, err := handler.getPassword()
+	if err == nil {
+		// Password in a file exists, we can exit.
+		return nil
+	}
+
+	for _, s := range passStorages {
+		var storedHash string
+		err := s.GetValue(
+			credentialsDBBucket,
+			config.FlagTequilapiUsername.Value,
+			&storedHash,
+		)
+
+		if err == nil {
+			return handler.setPassword(storedHash)
+		}
+	}
+
+	// Password not found in any of the given storages
+	// we can assume that user is launching the app for the first time.
+	// Just continue as normal.
+	return nil
+}

--- a/core/node/options_directory.go
+++ b/core/node/options_directory.go
@@ -40,25 +40,42 @@ type OptionsDirectory struct {
 	Runtime string
 }
 
+const (
+	// NetworkSubDirTestnet represents testnet subdir
+	NetworkSubDirTestnet = "testnet"
+
+	// NetworkSubDirTestnet2 represents testnet2 subdir
+	NetworkSubDirTestnet2 = "testnet2"
+
+	// NetworkSubDirLocalnet represents localnet subdir
+	NetworkSubDirLocalnet = "localnet"
+)
+
 // GetOptionsDirectory retrieves directory configuration from app configuration.
 func GetOptionsDirectory(network *OptionsNetwork) *OptionsDirectory {
 	dataDir := config.GetString(config.FlagDataDir)
-	networkSubdir := "testnet2" // Matches DefaultNetworkDefinition
+	networkSubdir := NetworkSubDirTestnet2 // Matches DefaultNetworkDefinition
 	switch {
 	case network.Testnet2:
-		networkSubdir = "testnet2"
+		networkSubdir = NetworkSubDirTestnet2
 	case network.Testnet:
 		networkSubdir = "" // Leave testnet files intact before it's merged into master
 	case network.Localnet:
-		networkSubdir = "localnet"
+		networkSubdir = NetworkSubDirLocalnet
 	}
 	return &OptionsDirectory{
 		Data:     dataDir,
-		Storage:  filepath.Join(dataDir, networkSubdir, "db"),
+		Storage:  GetOptionsDirectoryDB(networkSubdir),
 		Keystore: filepath.Join(dataDir, "keystore"),
 		Script:   config.GetString(config.FlagScriptDir),
 		Runtime:  config.GetString(config.FlagRuntimeDir),
 	}
+}
+
+// GetOptionsDirectoryDB returns a database directory given a networkSubdir.
+func GetOptionsDirectoryDB(networkSubdir string) string {
+	dataDir := config.GetString(config.FlagDataDir)
+	return filepath.Join(dataDir, networkSubdir, "db")
 }
 
 // Check checks that configured dirs exist (which should contain info) and runtime dirs are created (if not exist)


### PR DESCRIPTION
* Reworked how node password is stored: we now store a password in a separate file on the users machine
* Added a migration to migrate the current password that user has set to be stored in a file (works for testnet and testnet2)
* Fixed the reset command, it now resets users password to default node configured password
* We no longer display debug information when reset command is run

Current config workflow has led to some [unwanted workflows ](https://github.com/mysteriumnetwork/node/pull/2978/files#diff-2626c43c402014222bb0a6bbdd214e37a96687df78dee668b5d20fd304bed007R49)which could be remedied only by improving how we handle the config.
Closes: #2971