### PR TITLE
Fix Raspberry auto updates

### DIFF
--- a/bin/package/raspberry/files/unattended-upgrades
+++ b/bin/package/raspberry/files/unattended-upgrades
@@ -1,7 +1,7 @@
 Unattended-Upgrade::Origins-Pattern {
         "origin=Raspbian,codename=${distro_codename},label=Raspbian";
         "origin=Raspbian,codename=${distro_codename},label=Raspbian-Security";
-        "o=LP-PPA-mysteriumnetwork-node,a=bionic";
+        "o=LP-PPA-mysteriumnetwork-node";
 };
 
 Unattended-Upgrade::AutoFixInterruptedDpkg "true";


### PR DESCRIPTION
Updates: https://gitlab.com/mysteriumnetwork/node/-/commit/d241e5483c275cd28228e50655823b20405c115e

`/etc/apt/apt.conf.d/50unattended-upgrades` describes the list of filters what to use for updates.
Previous update pointed filter to the `bionic`, but had a `focal` in the repo lists, so no package matched.