### PR TITLE
Extend sudeors for consumer workflow

### DIFF
--- a/bin/package/sudoers/mysterium-node
+++ b/bin/package/sudoers/mysterium-node
@@ -8,3 +8,4 @@ mysterium-node    ALL=NOPASSWD: /sbin/ip
 mysterium-node    ALL=NOPASSWD: /etc/mysterium-node/prepare-env.sh
 mysterium-node    ALL=NOPASSWD: /sbin/tc
 mysterium-node    ALL=NOPASSWD: /sbin/modprobe
+mysterium-node    ALL=NOPASSWD: /usr/sbin/resolvconf


### PR DESCRIPTION
Seems that if I pull latest node on latest ubuntu I can't complete my connection
Checking the logs shows:
```
pam_unix(sudo:auth): conversation failed
pam_unix(sudo:auth): auth could not identify password for [mysterium-node]
mysterium-node : command not allowed ; TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/sbin/resolvconf -a tun.myst0
```

This addition to sudeors fixes this issue and allows me to connect.
Closes: https://github.com/mysteriumnetwork/node/issues/2976