### PR TITLE
Fix e2e lottery

### DIFF
--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -40,6 +40,7 @@ import (
 	tequilapi_client "github.com/mysteriumnetwork/node/tequilapi/client"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/payments/bindings"
+	"github.com/mysteriumnetwork/payments/crypto"
 )
 
 var (
@@ -53,6 +54,7 @@ var (
 	registryAddress             = "0xbe180c8CA53F280C7BE8669596fF7939d933AA10"
 	channelImplementation       = "0x599d43715DF3070f83355D9D90AE62c159E62A75"
 	addressForTopups            = "0xa29fb77b25181df094908b027821a7492ca4245b"
+	hundredthThou               = float64(1) / float64(100000)
 )
 
 var ethClient *ethclient.Client
@@ -354,6 +356,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 }
 
 func recheckBalancesWithHermes(t *testing.T, consumerID string, consumerSpending *big.Int, serviceType, hermesURL string) {
+	var testSuccess bool
 	var lastHermes *big.Int
 	assert.Eventually(t, func() bool {
 		hermesCaller := pingpong.NewHermesCaller(requests.NewHTTPClient("0.0.0.0", time.Second), hermesURL)
@@ -361,8 +364,38 @@ func recheckBalancesWithHermes(t *testing.T, consumerID string, consumerSpending
 		assert.NoError(t, err)
 		promised := hermesData.LatestPromise.Amount
 		lastHermes = promised
-		return promised.Cmp(consumerSpending) == 0
-	}, time.Second*20, time.Millisecond*300, fmt.Sprintf("Consumer reported spending %v hermes says %v. Service type %v. Hermes url %v, consumer ID %v", consumerSpending, lastHermes, serviceType, hermesURL, consumerID))
+
+		// Author: vkuznecovas
+		// Due to the async nature of the payment system, a situation might occur where a consumers reported spending is larger than the actual amount that reaches hermes.
+		// This happens in the following flow:
+		// 1) Session is established.
+		// 2) Payments occur normally for some time.
+		// 3) Consumer received yet another invoice.
+		// 4) Consumer starts calculating the amount to promise.
+		// 5) Session is killed as operation 4) is happening.
+		// 6) The promise is incremented but never issued as the session is aborted. This can happen due to promise not being sent, or provider not listening for further promises on the given topic.
+		// 7) Hermes is not aware of the last promise, therefore the consumer and hermes reportings are different.
+		// I do not believe this will cause issues in reality, as such situations occur in e2e test regularly due to the rapid exchange of promises.
+		// Under normal circumstances, such occurences should be VERY, VERY rare and the amount of myst involved is rather small. They should have no impact on the payment system as a whole.
+		// Therefore, for these tests to be stable, the following solution is proposed:
+		// Make sure that the hermes and consumer reported spendings differ by no more than 1/100000 of a myst.
+		absDiffFloat := getDiffFloat(consumerSpending, promised)
+		res := absDiffFloat < hundredthThou
+		if res {
+			testSuccess = true
+		}
+		return res
+	}, time.Second*20, time.Millisecond*300)
+
+	if !testSuccess {
+		fmt.Printf("Consumer reported spending %v hermes says %v. Service type %v. Hermes url %v, consumer ID %v", consumerSpending, lastHermes, serviceType, hermesURL, consumerID)
+	}
+}
+
+func getDiffFloat(a, b *big.Int) float64 {
+	diff := new(big.Int).Sub(a, b)
+	absoluteDiff := new(big.Int).Abs(diff)
+	return crypto.BigMystToFloat(absoluteDiff)
 }
 
 func identityCreateFlow(t *testing.T, tequilapi *tequilapi_client.Client, idPassphrase string) string {
@@ -602,8 +635,14 @@ func providerEarnedTokens(t *testing.T, tequilapi *tequilapi_client.Client, id s
 	providerStatus, err := tequilapi.Identity(id)
 	assert.NoError(t, err)
 	assert.True(t, providerStatus.Balance.Cmp(new(big.Int)) == 0)
-	assert.Equal(t, earningsExpected, providerStatus.Earnings, fmt.Sprintf("consumers reported spend %v, providers earnings %v", earningsExpected, providerStatus.Earnings))
-	assert.Equal(t, earningsExpected, providerStatus.EarningsTotal, fmt.Sprintf("consumers reported spend %v, providers earnings %v", earningsExpected, providerStatus.Earnings))
+
+	// For reasoning behind these, see the comment in recheckBalancesWithHermes
+	actualEarnings := getDiffFloat(earningsExpected, providerStatus.Earnings)
+	assert.True(t, actualEarnings < hundredthThou)
+
+	actualEarnings = getDiffFloat(earningsExpected, providerStatus.EarningsTotal)
+	assert.True(t, actualEarnings < hundredthThou)
+
 	assert.True(t, providerStatus.Earnings.Cmp(big.NewInt(500)) == 1, "earnings should be at least 500 but is %d", providerStatus.Earnings)
 	return providerStatus.Earnings
 }


### PR DESCRIPTION
Due to the async nature of the payment system, a situation might occur where a consumers reported spending is larger than the actual amount that reaches hermes.

This happens in the following flow:
1) Session is established.
2) Payments occur normally for some time.
3) Consumer received yet another invoice.
4) Consumer starts calculating the amount to promise.
5) Session is killed as operation 4) is happening.
6) The promise is incremented but never issued as the session is aborted. This can happen due to promise not being sent, or provider not listening for further promises on the given topic.
7) Hermes is not aware of the last promise, therefore the consumer and hermes reportings are different.
I do not believe this will cause issues in reality, as such situations occur in e2e test regularly due to the rapid exchange of promises.

Under normal circumstances, such occurences should be VERY, VERY rare and the amount of myst involved is rather small. They should have no impact on the payment system as a whole.
Therefore, for these tests to be stable, the following solution is proposed:
Make sure that the hermes and consumer reported spendings differ by no more than 1/100000 of a myst.

Closes #2958
Closes #2906