### PR TITLE
Consistent proposals format

### DIFF
--- a/cmd/commands/connection/command.go
+++ b/cmd/commands/connection/command.go
@@ -20,6 +20,8 @@ package connection
 import (
 	"errors"
 	"fmt"
+	"os"
+	"text/tabwriter"
 	"time"
 
 	"github.com/mysteriumnetwork/node/cmd/commands/cli/clio"
@@ -145,9 +147,11 @@ func (c *command) proposals(ctx *cli.Context) {
 	}
 
 	clio.Info("Found proposals:")
+	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
 	for _, p := range proposals {
-		printProposal(&p)
+		fmt.Fprintln(w, proposalFormatted(&p))
 	}
+	w.Flush()
 }
 
 func (c *command) down() {

--- a/cmd/commands/connection/util.go
+++ b/cmd/commands/connection/util.go
@@ -27,24 +27,27 @@ import (
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 )
 
-func printProposal(p *contract.ProposalDTO) {
-	fmt.Printf("| Identity: %s | Type: %s | Country: %s | Price: %s |\n",
+func proposalFormatted(p *contract.ProposalDTO) string {
+	ppm, ppgb := getPrices(p.PaymentMethod)
+	return fmt.Sprintf("| Identity: %s\t| Type: %s\t| Country: %s\t| Price: %s\t%s\t|",
 		p.ProviderID,
 		p.ServiceDefinition.LocationOriginate.NodeType,
 		p.ServiceDefinition.LocationOriginate.Country,
-		getPrice(p.PaymentMethod),
+		ppm,
+		ppgb,
 	)
 }
 
-func getPrice(pm contract.PaymentMethodDTO) string {
+func getPrices(pm contract.PaymentMethodDTO) (string, string) {
 	ppm := aproxPricePerMinute(pm)
 	ppgb := aproxPricePerGB(pm)
 	if ppm.Amount.Cmp(big.NewInt(0)) == 0 &&
 		ppgb.Amount.Cmp(big.NewInt(0)) == 0 {
-		return "Free"
+		return "Free", ""
 	}
 
-	return fmt.Sprintf("%s/min   %s/GB", ppm.String(), ppgb.String())
+	return fmt.Sprintf("%s/min", ppm.String()),
+		fmt.Sprintf("%s/GB", ppgb.String())
 }
 
 func aproxPricePerMinute(pm contract.PaymentMethodDTO) money.Money {


### PR DESCRIPTION
`myst connection proposals` command output is now formatted consistently.

Eg:
```bash
[INFO] Found proposals:
| Identity: 0x070a908615c53ff0aa69c4e802142791c7d9exxx | Type: hosting     | Country: DE | Price: Free                               |
| Identity: 0x178c926f9d18c1434bc2c2619d88b3bf7dc5fxxx | Type: residential | Country: RO | Price: 0.000100MYSTT/min 0.100000MYSTT/GB |
| Identity: 0x353008813ae83cf06e0e21a58e64853d3cbe5xxx | Type: residential | Country: UA | Price: 0.000007MYSTT/min 0.300000MYSTT/GB |
| Identity: 0x9137cbfb964275623121385ecb951e484de5fxxx | Type: hosting     | Country: SG | Price: 0.000000MYSTT/min 0.850001MYSTT/GB |
```

This is now much easier to read.