### PR TITLE
Remove openvpn port validation

### DIFF
--- a/services/openvpn/config_validator.go
+++ b/services/openvpn/config_validator.go
@@ -42,7 +42,6 @@ func NewDefaultValidator() *ConfigValidator {
 	return &ConfigValidator{
 		validators: []ValidateConfig{
 			validProtocol,
-			validPort,
 			validIPFormat,
 			validTLSPresharedKey,
 			validCACertificate,
@@ -68,13 +67,6 @@ func validProtocol(config VPNConfig) error {
 		return nil
 	}
 	return errors.New("invalid protocol: " + config.RemoteProtocol)
-}
-
-func validPort(config VPNConfig) error {
-	if config.RemotePort > 65535 || config.RemotePort < 1024 {
-		return errors.New("invalid port range, should fall within 1024 .. 65535 range")
-	}
-	return nil
 }
 
 func validIPFormat(config VPNConfig) error {

--- a/services/openvpn/config_validator_test.go
+++ b/services/openvpn/config_validator_test.go
@@ -83,11 +83,6 @@ func TestUnknownProtocolIsNotAllowed(t *testing.T) {
 	assert.Error(t, validProtocol(vpnConfig))
 }
 
-func TestPortOutOfRangeIsNotAllowed(t *testing.T) {
-	vpnConfig := VPNConfig{RemotePort: -1}
-	assert.Error(t, validPort(vpnConfig))
-}
-
 func TestTLSPresharedKeyIsValid(t *testing.T) {
 	vpnConfig := VPNConfig{TLSPresharedKey: tlsTestKey}
 	assert.NoError(t, validTLSPresharedKey(vpnConfig))


### PR DESCRIPTION
This validation is not stated anywhere in the docs, neither is it really beneficial to the end user.
If you assign something wrong it will fail, if you want to go below 1024 and you can set it up I dont see a reason why we shouldn't let you.