### PR TITLE
Fix crash for some users with certain configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -234,8 +234,7 @@ func (cfg *Config) GetString(key string) string {
 
 // GetStringSlice returns config value as []string.
 func (cfg *Config) GetStringSlice(key string) []string {
-	value := cfg.Get(key).([]string)
-	return cast.ToStringSlice(value)
+	return cast.ToStringSlice(cfg.Get(key))
 }
 
 // ParseBoolFlag parses a cli.BoolFlag from command's context and


### PR DESCRIPTION
Prevents node from starting with corrupt config
```
panic: interface conversion: interface {} is []interface {}, not []string
goroutine 1 [running]:
github.com/mysteriumnetwork/node/config.(*Config).GetStringSlice(0xc000178080, 0x52aecd2, 0xe, 0xc000483140, 0x29, 0x0)
	/source/config/config.go:237 +0xd3
github.com/mysteriumnetwork/node/config.GetStringSlice(...)
	/source/config/config.go:351
github.com/mysteriumnetwork/node/core/node.GetOptions(0xc0000afe80)
	/source/core/node/options.go:94 +0x2b4
github.com/mysteriumnetwork/node/cmd/commands/daemon.NewCommand.func1(0xc0000afe80, 0x0, 0x0)
	/source/cmd/commands/daemon/command.go:46 +0xbe
github.com/urfave/cli/v2.(*Command).Run(0xc00048e6c0, 0xc0000afdc0, 0x0, 0x0)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/command.go:161 +0x4b9
github.com/urfave/cli/v2.(*App).RunContext(0xc0001a7e00, 0x59e9de0, 0xc0000ce010, 0xc0000ae040, 0x4, 0x4, 0x0, 0x0)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:302 +0x790
github.com/urfave/cli/v2.(*App).Run(...)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:211
main.main()
	/source/cmd/mysterium_node/mysterium_node.go:66 +0x87
```