### PR TITLE
Closes #2667

### DIFF
--- a/core/discovery/brokerdiscovery/repository_test.go
+++ b/core/discovery/brokerdiscovery/repository_test.go
@@ -76,7 +76,7 @@ func Test_Subscriber_StartSyncsNewProposals(t *testing.T) {
 	connection := nats.StartConnectionMock()
 	defer connection.Close()
 
-	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 10*time.Millisecond)
+	repo := NewRepository(connection, NewStorage(eventbus.New()), 10*time.Millisecond, 1*time.Second)
 	err := repo.Start()
 	defer repo.Stop()
 	assert.NoError(t, err)


### PR DESCRIPTION
Having a super small proposal timeout caused issues as the proposal would be invalidated when we were looking for it in storage. This fixes the test's flakiness.