### PR TITLE
Remove old, unused ip

### DIFF
--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -146,7 +146,7 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		EtherClientRPC:        options.EtherClientRPC,
 		ChainID:               options.ChainID,
 		DNSMap: map[string][]string{
-			"testnet-location.mysterium.network":  {"82.196.15.9"},
+			"testnet-location.mysterium.network":  {"95.216.204.232"},
 			"testnet2-location.mysterium.network": {"95.216.204.232"},
 			"testnet2-quality.mysterium.network":  {"116.202.100.246"},
 			"feedback.mysterium.network":          {"116.203.17.150"},


### PR DESCRIPTION
This is non critical, as the nodes are now properly looking at the new location service, but still.