### PR TITLE
Fix superfluous response.WriteHeader write

### DIFF
--- a/tequilapi/endpoints/feedback.go
+++ b/tequilapi/endpoints/feedback.go
@@ -102,7 +102,7 @@ func (api *feedbackAPI) ReportIssue(httpRes http.ResponseWriter, httpReq *http.R
 
 	if !result.Success {
 		log.Error().Stack().Err(err).Msg("Submitting an issue failed")
-		utils.SendErrorBody(httpRes, result.Errors, result.HTTPResponse.StatusCode)
+		utils.WriteAsJSON(result.Errors, httpRes, result.HTTPResponse.StatusCode)
 		return
 	}
 

--- a/tequilapi/endpoints/sessions_test.go
+++ b/tequilapi/endpoints/sessions_test.go
@@ -160,7 +160,7 @@ func Test_SessionsEndpoint_ListBubblesError(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, resp.Code)
 	assert.Equal(t,
-		fmt.Sprintf(`{"message":%q}%v`, mockErr.Error(), "\n"),
+		fmt.Sprintf(`{"message":%q}`, mockErr.Error()),
 		resp.Body.String(),
 	)
 }

--- a/tequilapi/utils/utils_test.go
+++ b/tequilapi/utils/utils_test.go
@@ -64,21 +64,6 @@ func TestSendErrorRendersErrorMessage(t *testing.T) {
 		resp.Body.String())
 }
 
-func TestSendErrorMessageRendersErrorMessage(t *testing.T) {
-	resp := httptest.NewRecorder()
-
-	SendErrorBody(resp, errorMessage{"error_message"}, http.StatusInternalServerError)
-
-	assert.Equal(t, http.StatusInternalServerError, resp.Code)
-	assert.JSONEq(
-		t,
-		`{
-			"message" : "error_message"
-		}`,
-		resp.Body.String())
-
-}
-
 func TestSendValidationErrorMessageRendersErrorMessage(t *testing.T) {
 	resp := httptest.NewRecorder()
 


### PR DESCRIPTION
Writing to http.ResponseWriter twice is illegal, so we no longer do that.
Closes: https://github.com/mysteriumnetwork/node/issues/3075

Fixes log errors:
```
2020-09-19T09:05:58.460 ??? github.com/rs/zerolog@v1.17.2/log.go:403 > http: superfluous response.WriteHeader call from github.com/mysteriumnetwork/node/tequilapi/utils.WriteAsJSON (utils.go:38)
```