### PR TITLE
Fill optional pilvytis headers

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -880,7 +880,7 @@ func (di *Dependencies) migrateCrendentials() {
 }
 
 func (di *Dependencies) bootstrapPilvytis(options node.Options) {
-	di.PilvytisAPI = pilvytis.NewAPI(di.HTTPClient, options.PilvytisAddress, di.SignerFactory)
+	di.PilvytisAPI = pilvytis.NewAPI(di.HTTPClient, options.PilvytisAddress, di.SignerFactory, di.LocationResolver)
 	statusTracker := pilvytis.NewStatusTracker(di.PilvytisAPI, di.IdentityManager, di.EventBus, 30*time.Second)
 	di.Pilvytis = pilvytis.NewService(di.PilvytisAPI, di.IdentityManager, statusTracker)
 	di.Pilvytis.Start()


### PR DESCRIPTION
Updates: https://github.com/mysteriumnetwork/pilvytis/issues/88
Is related to: https://github.com/mysteriumnetwork/pilvytis/pull/89

Pilvytis allows optional headers to provide additional information about the request. These headers are now sent.