### PR TITLE
Add user agent to http requests

### DIFF
--- a/requests/client_test.go
+++ b/requests/client_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestClientDoRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, getUserAgent(), r.Header.Get("User-Agent"))
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()


### PR DESCRIPTION
Sets the user agent string for all HTTP requests.

Updates #3155