### PR TITLE
Don't include NodeUI and Tequilapi in mobile

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,0 +1,90 @@
+// +build !ios,!android
+
+/*
+ * Copyright (C) 2018 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cmd
+
+import (
+	"net"
+
+	"github.com/mysteriumnetwork/node/ui"
+	uinoop "github.com/mysteriumnetwork/node/ui/noop"
+
+	"github.com/mysteriumnetwork/node/config"
+	"github.com/mysteriumnetwork/node/core/node"
+	"github.com/mysteriumnetwork/node/services"
+	"github.com/mysteriumnetwork/node/tequilapi"
+	tequilapi_endpoints "github.com/mysteriumnetwork/node/tequilapi/endpoints"
+	"github.com/mysteriumnetwork/node/utils"
+)
+
+func (di *Dependencies) bootstrapTequilapi(nodeOptions node.Options, listener net.Listener) (tequilapi.APIServer, error) {
+	if !nodeOptions.TequilapiEnabled {
+		return tequilapi.NewNoopAPIServer(), nil
+	}
+
+	router := tequilapi.NewAPIRouter()
+	tequilapi_endpoints.AddRoutesForDocs(router)
+	tequilapi_endpoints.AddRouteForStop(router, utils.SoftKiller(di.Shutdown))
+	tequilapi_endpoints.AddRoutesForAuthentication(router, di.Authenticator, di.JWTAuthenticator)
+	tequilapi_endpoints.AddRoutesForIdentities(router, di.IdentityManager, di.IdentitySelector, di.IdentityRegistry, di.ConsumerBalanceTracker, di.AddressProvider, di.HermesChannelRepository, di.BCHelper, di.Transactor, di.BeneficiaryProvider)
+	tequilapi_endpoints.AddRoutesForConnection(router, di.ConnectionManager, di.StateKeeper, di.ProposalRepository, di.IdentityRegistry, di.EventBus, di.AddressProvider)
+	tequilapi_endpoints.AddRoutesForSessions(router, di.SessionStorage)
+	tequilapi_endpoints.AddRoutesForConnectionLocation(router, di.IPResolver, di.LocationResolver, di.LocationResolver)
+	tequilapi_endpoints.AddRoutesForProposals(router, di.ProposalRepository, di.QualityClient)
+	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, services.JSONParsersByType)
+	tequilapi_endpoints.AddRoutesForPayout(router, di.IdentityManager, di.SignerFactory, di.MysteriumAPI)
+	tequilapi_endpoints.AddRoutesForAccessPolicies(di.HTTPClient, router, config.GetString(config.FlagAccessPolicyAddress))
+	tequilapi_endpoints.AddRoutesForNAT(router, di.StateKeeper)
+	tequilapi_endpoints.AddRoutesForTransactor(router, di.IdentityRegistry, di.Transactor, di.HermesPromiseSettler, di.SettlementHistoryStorage, di.AddressProvider, di.BeneficiarySaver)
+	tequilapi_endpoints.AddRoutesForConfig(router)
+	tequilapi_endpoints.AddRoutesForMMN(router, di.MMN)
+	tequilapi_endpoints.AddRoutesForFeedback(router, di.Reporter)
+	tequilapi_endpoints.AddRoutesForConnectivityStatus(router, di.SessionConnectivityStatusStorage)
+	tequilapi_endpoints.AddRoutesForCurrencyExchange(router, di.PilvytisAPI)
+	tequilapi_endpoints.AddRoutesForPilvytis(router, di.PilvytisAPI)
+	tequilapi_endpoints.AddRoutesForTerms(router)
+	if err := tequilapi_endpoints.AddRoutesForSSE(router, di.StateKeeper, di.EventBus); err != nil {
+		return nil, err
+	}
+
+	if config.GetBool(config.FlagPProfEnable) {
+		tequilapi_endpoints.AddRoutesForPProf(router)
+	}
+
+	corsPolicy := tequilapi.NewMysteriumCorsPolicy()
+	return tequilapi.NewServer(listener, router, corsPolicy), nil
+}
+
+func (di *Dependencies) bootstrapUIServer(options node.Options) (err error) {
+	if !options.UI.UIEnabled {
+		di.UIServer = uinoop.NewServer()
+		return nil
+	}
+
+	bindAddress := options.UI.UIBindAddress
+	if bindAddress == "" {
+		bindAddress, err = di.IPResolver.GetOutboundIP()
+		if err != nil {
+			return err
+		}
+		bindAddress = bindAddress + ",127.0.0.1"
+	}
+	di.UIServer = ui.NewServer(bindAddress, options.UI.UIPort, options.TequilapiAddress, options.TequilapiPort, di.JWTAuthenticator, di.HTTPClient)
+	return nil
+}

--- a/cmd/bootstrap_mobile.go
+++ b/cmd/bootstrap_mobile.go
@@ -1,0 +1,37 @@
+// +build ios android
+
+/*
+ * Copyright (C) 2018 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cmd
+
+import (
+	"net"
+
+	"github.com/mysteriumnetwork/node/core/node"
+	"github.com/mysteriumnetwork/node/tequilapi"
+	uinoop "github.com/mysteriumnetwork/node/ui/noop"
+)
+
+func (di *Dependencies) bootstrapTequilapi(_ node.Options, _ net.Listener) (tequilapi.APIServer, error) {
+	return tequilapi.NewNoopAPIServer(), nil
+}
+
+func (di *Dependencies) bootstrapUIServer(_ node.Options) (err error) {
+	di.UIServer = uinoop.NewServer()
+	return nil
+}

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -73,15 +73,12 @@ import (
 	"github.com/mysteriumnetwork/node/p2p"
 	"github.com/mysteriumnetwork/node/pilvytis"
 	"github.com/mysteriumnetwork/node/requests"
-	"github.com/mysteriumnetwork/node/services"
 	service_noop "github.com/mysteriumnetwork/node/services/noop"
 	service_openvpn "github.com/mysteriumnetwork/node/services/openvpn"
 	"github.com/mysteriumnetwork/node/session/connectivity"
 	"github.com/mysteriumnetwork/node/session/pingpong"
 	"github.com/mysteriumnetwork/node/sleep"
 	"github.com/mysteriumnetwork/node/tequilapi"
-	tequilapi_endpoints "github.com/mysteriumnetwork/node/tequilapi/endpoints"
-	"github.com/mysteriumnetwork/node/utils"
 	"github.com/mysteriumnetwork/node/utils/netutil"
 	"github.com/mysteriumnetwork/payments/client"
 	paymentClient "github.com/mysteriumnetwork/payments/client"
@@ -573,44 +570,6 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 
 	di.Node = NewNode(di.ConnectionManager, tequilapiHTTPServer, di.EventBus, di.NATPinger, di.UIServer, sleepNotifier)
 	return nil
-}
-
-func (di *Dependencies) bootstrapTequilapi(nodeOptions node.Options, listener net.Listener) (tequilapi.APIServer, error) {
-	if !nodeOptions.TequilapiEnabled {
-		return tequilapi.NewNoopAPIServer(), nil
-	}
-
-	router := tequilapi.NewAPIRouter()
-	tequilapi_endpoints.AddRoutesForDocs(router)
-	tequilapi_endpoints.AddRouteForStop(router, utils.SoftKiller(di.Shutdown))
-	tequilapi_endpoints.AddRoutesForAuthentication(router, di.Authenticator, di.JWTAuthenticator)
-	tequilapi_endpoints.AddRoutesForIdentities(router, di.IdentityManager, di.IdentitySelector, di.IdentityRegistry, di.ConsumerBalanceTracker, di.AddressProvider, di.HermesChannelRepository, di.BCHelper, di.Transactor, di.BeneficiaryProvider)
-	tequilapi_endpoints.AddRoutesForConnection(router, di.ConnectionManager, di.StateKeeper, di.ProposalRepository, di.IdentityRegistry, di.EventBus, di.AddressProvider)
-	tequilapi_endpoints.AddRoutesForSessions(router, di.SessionStorage)
-	tequilapi_endpoints.AddRoutesForConnectionLocation(router, di.IPResolver, di.LocationResolver, di.LocationResolver)
-	tequilapi_endpoints.AddRoutesForProposals(router, di.ProposalRepository, di.QualityClient)
-	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, services.JSONParsersByType)
-	tequilapi_endpoints.AddRoutesForPayout(router, di.IdentityManager, di.SignerFactory, di.MysteriumAPI)
-	tequilapi_endpoints.AddRoutesForAccessPolicies(di.HTTPClient, router, config.GetString(config.FlagAccessPolicyAddress))
-	tequilapi_endpoints.AddRoutesForNAT(router, di.StateKeeper)
-	tequilapi_endpoints.AddRoutesForTransactor(router, di.IdentityRegistry, di.Transactor, di.HermesPromiseSettler, di.SettlementHistoryStorage, di.AddressProvider, di.BeneficiarySaver)
-	tequilapi_endpoints.AddRoutesForConfig(router)
-	tequilapi_endpoints.AddRoutesForMMN(router, di.MMN)
-	tequilapi_endpoints.AddRoutesForFeedback(router, di.Reporter)
-	tequilapi_endpoints.AddRoutesForConnectivityStatus(router, di.SessionConnectivityStatusStorage)
-	tequilapi_endpoints.AddRoutesForCurrencyExchange(router, di.PilvytisAPI)
-	tequilapi_endpoints.AddRoutesForPilvytis(router, di.PilvytisAPI)
-	tequilapi_endpoints.AddRoutesForTerms(router)
-	if err := tequilapi_endpoints.AddRoutesForSSE(router, di.StateKeeper, di.EventBus); err != nil {
-		return nil, err
-	}
-
-	if config.GetBool(config.FlagPProfEnable) {
-		tequilapi_endpoints.AddRoutesForPProf(router)
-	}
-
-	corsPolicy := tequilapi.NewMysteriumCorsPolicy()
-	return tequilapi.NewServer(listener, router, corsPolicy), nil
 }
 
 // function decides on network definition combined from testnet/localnet flags and possible overrides

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -43,9 +43,6 @@ import (
 	wireguard_service "github.com/mysteriumnetwork/node/services/wireguard/service"
 	"github.com/mysteriumnetwork/node/session/pingpong"
 	pingpong_noop "github.com/mysteriumnetwork/node/session/pingpong/noop"
-	"github.com/mysteriumnetwork/node/ui"
-	uinoop "github.com/mysteriumnetwork/node/ui/noop"
-
 	"github.com/rs/zerolog/log"
 
 	"github.com/pkg/errors"
@@ -297,24 +294,6 @@ func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options) {
 		return wireguard_connection.NewConnection(opts, di.IPResolver, endpointFactory, handshakeWaiter)
 	}
 	di.ConnectionRegistry.Register(wireguard.ServiceType, connFactory)
-}
-
-func (di *Dependencies) bootstrapUIServer(options node.Options) (err error) {
-	if !options.UI.UIEnabled {
-		di.UIServer = uinoop.NewServer()
-		return nil
-	}
-
-	bindAddress := options.UI.UIBindAddress
-	if bindAddress == "" {
-		bindAddress, err = di.IPResolver.GetOutboundIP()
-		if err != nil {
-			return err
-		}
-		bindAddress = bindAddress + ",127.0.0.1"
-	}
-	di.UIServer = ui.NewServer(bindAddress, options.UI.UIPort, options.TequilapiAddress, options.TequilapiPort, di.JWTAuthenticator, di.HTTPClient)
-	return nil
 }
 
 func (di *Dependencies) bootstrapMMN() error {


### PR DESCRIPTION
Managed to reduce it around 10Mb so that's approx 2.5Mb per architecture. The aar file is compressed so I assume that playstore downloads will go down by 2.5Mb also.

Maybe someone has some ideas what else we can cut out (maybe OpenVPN ?) although it did not seem that easy to do.

![image](https://user-images.githubusercontent.com/20511486/109956918-e3bef200-7cec-11eb-8bf8-acaf81c922f8.png)
