### PR TITLE
Estimate entertainment times based on MYST amount (MVP)

### DIFF
--- a/consumer/entertainment/estimator.go
+++ b/consumer/entertainment/estimator.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package entertainment
+
+import "math"
+
+const (
+	video720pMBPerMin   = 15
+	audioNormalMBPerMin = 0.75
+	browsingMBPerMin    = 0.5
+)
+
+// Estimates represent estimated entertainment
+type Estimates struct {
+	VideoMinutes    uint64
+	MusicMinutes    uint64
+	BrowsingMinutes uint64
+	TrafficMB       uint64
+	PricePerGiB     float64
+	PricePerMin     float64
+}
+
+// Estimator stores average provider prices to estimate entertainment estimates
+type Estimator struct {
+	pricePerGiB float64
+	pricePerMin float64
+}
+
+// NewEstimator constructor
+func NewEstimator(pricePerGiB, pricePerMin float64) *Estimator {
+	return &Estimator{
+		pricePerGiB: pricePerGiB,
+		pricePerMin: pricePerMin,
+	}
+}
+
+// EstimatedEntertainment calculates average service times
+func (e *Estimator) EstimatedEntertainment(myst float64) Estimates {
+	return Estimates{
+		VideoMinutes:    e.minutes(myst, video720pMBPerMin),
+		MusicMinutes:    e.minutes(myst, audioNormalMBPerMin),
+		BrowsingMinutes: e.minutes(myst, browsingMBPerMin),
+		TrafficMB:       uint64(mib2MB(e.totalTrafficMiB(myst))),
+		PricePerGiB:     e.pricePerGiB,
+		PricePerMin:     e.pricePerMin,
+	}
+}
+
+func mib2MB(mibs float64) float64 {
+	return mibs * math.Pow(2, 20) / math.Pow(10, 6)
+}
+
+func mb2MiB(mb float64) float64 {
+	return mb * math.Pow(10, 6) / math.Pow(2, 20)
+}
+
+func (e *Estimator) totalTrafficMiB(amount float64) float64 {
+	return amount / e.pricePerGiB * 1024
+}
+
+func (e *Estimator) minutes(amount, serviceMBPerMin float64) uint64 {
+	pricePerMiB := e.pricePerGiB / 1024
+	totalPricePerMin := mb2MiB(serviceMBPerMin)*pricePerMiB + e.pricePerMin
+	return uint64(amount / totalPricePerMin)
+}

--- a/consumer/entertainment/estimator_test.go
+++ b/consumer/entertainment/estimator_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package entertainment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEstimator(t *testing.T) {
+	// given
+	estimator := NewEstimator(0.01, 0.0001)
+
+	// expect
+	assert.Equal(t, 102400.0, estimator.totalTrafficMiB(1))
+	assert.Equal(t, 204800.0, estimator.totalTrafficMiB(2))
+
+	assert.Equal(t, uint64(106), estimator.minutes(1, 1000))
+	assert.Equal(t, uint64(53), estimator.minutes(1, 2000))
+	assert.Equal(t, uint64(9555), estimator.minutes(1, 0.5))
+
+	// and
+	e := estimator.EstimatedEntertainment(5)
+	assert.Equal(t, uint64(536870), e.TrafficMB)
+	assert.Equal(t, 0.01, e.PricePerGiB)
+	assert.Equal(t, 0.0001, e.PricePerMin)
+
+	// can fluctuate based on constants so just assert it's set
+	assert.Less(t, uint64(0), e.VideoMinutes)
+	assert.Less(t, uint64(0), e.MusicMinutes)
+	assert.Less(t, uint64(0), e.BrowsingMinutes)
+}

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/mysteriumnetwork/node/consumer/entertainment"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -79,6 +81,7 @@ type MobileNode struct {
 	chainID                   int64
 	startTime                 time.Time
 	sessionStorage            SessionStorage
+	entertainmentEstimator    *entertainment.Estimator
 }
 
 // MobileNodeOptions contains common mobile node options.
@@ -274,6 +277,10 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		chainID:        nodeOptions.OptionsNetwork.ChainID,
 		sessionStorage: di.SessionStorage,
 		identityMover:  di.IdentityMover,
+		entertainmentEstimator: entertainment.NewEstimator(
+			config.FlagPaymentPricePerGB.Value,
+			config.FlagPaymentPricePerMinute.Value,
+		),
 	}
 
 	return mobileNode, nil

--- a/mobile/mysterium/estimator.go
+++ b/mobile/mysterium/estimator.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysterium
+
+import "github.com/mysteriumnetwork/node/consumer/entertainment"
+
+// Estimates represent estimated entertainment
+type Estimates struct {
+	VideoMinutes    int64
+	MusicMinutes    int64
+	BrowsingMinutes int64
+	TrafficMB       int64
+	PricePerGB      float64
+	PricePerMin     float64
+}
+
+func newEstimates(e entertainment.Estimates) *Estimates {
+	return &Estimates{
+		VideoMinutes:    int64(e.VideoMinutes),
+		MusicMinutes:    int64(e.MusicMinutes),
+		BrowsingMinutes: int64(e.BrowsingMinutes),
+		TrafficMB:       int64(e.TrafficMB),
+		PricePerGB:      e.PricePerGiB,
+		PricePerMin:     e.PricePerMin,
+	}
+}
+
+// CalculateEstimates calculates average service times
+func (mb *MobileNode) CalculateEstimates(amount float64) *Estimates {
+	return newEstimates(mb.entertainmentEstimator.EstimatedEntertainment(amount))
+}


### PR DESCRIPTION
This is all based on our default node prices. As per discussion with @vkuznecovas fixed pricing is subject to change to organic pricing model, this means that the prices will be not set by providers, so currently prices for estimations are left as constants.

Average data usages per minute are based on results from searches on average mobile data usage for most popular services: youtube, spotify, facebook... also these values are for mid range quality streams.