### PR TITLE
Offchain identity registration and balance handling

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -477,13 +477,6 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		di.BCHelper,
 	)
 
-	hermesURL, err := di.getHermesURL(nodeOptions)
-	if err != nil {
-		return err
-	}
-
-	di.HermesCaller = pingpong.NewHermesCaller(di.HTTPClient, hermesURL)
-
 	di.bootstrapBeneficiaryProvider(nodeOptions)
 
 	if err := di.bootstrapHermesPromiseSettler(nodeOptions); err != nil {
@@ -506,7 +499,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		di.AddressProvider,
 	)
 
-	err = di.ConsumerBalanceTracker.Subscribe(di.EventBus)
+	err := di.ConsumerBalanceTracker.Subscribe(di.EventBus)
 	if err != nil {
 		return errors.Wrap(err, "could not subscribe consumer balance tracker to relevant events")
 	}
@@ -647,12 +640,15 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 	di.HermesURLGetter = pingpong.NewHermesURLGetter(di.BCHelper, di.AddressProvider)
 
 	registryStorage := registry.NewRegistrationStatusStorage(di.Storage)
-	if di.IdentityRegistry, err = identity_registry.NewIdentityRegistryContract(di.EtherClient, di.AddressProvider, registryStorage, di.EventBus); err != nil {
-		return err
-	}
 
 	hermesURL, err := di.getHermesURL(options)
 	if err != nil {
+		return err
+	}
+
+	di.HermesCaller = pingpong.NewHermesCaller(di.HTTPClient, hermesURL)
+
+	if di.IdentityRegistry, err = identity_registry.NewIdentityRegistryContract(di.EtherClient, di.AddressProvider, registryStorage, di.EventBus, di.HermesCaller); err != nil {
 		return err
 	}
 

--- a/session/pingpong/hermes_caller.go
+++ b/session/pingpong/hermes_caller.go
@@ -203,6 +203,19 @@ func (ac *HermesCaller) RevealR(r, provider string, agreementID *big.Int) error 
 	}, boff)
 }
 
+// IsIdentityOffchain returns true if identity is considered offchain in hermes.
+func (ac *HermesCaller) IsIdentityOffchain(chainID int64, id string) (bool, error) {
+	data, err := ac.GetConsumerData(chainID, id)
+	if err != nil {
+		if errors.Is(err, ErrHermesNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return data.IsOffchain, nil
+}
+
 // GetConsumerData gets consumer data from hermes
 func (ac *HermesCaller) GetConsumerData(chainID int64, id string) (ConsumerData, error) {
 	req, err := requests.NewGetRequest(ac.hermesBaseURI, fmt.Sprintf("data/consumer/%v", id), nil)
@@ -268,6 +281,7 @@ type ConsumerData struct {
 	Stake            *big.Int      `json:"Stake"`
 	LatestPromise    LatestPromise `json:"LatestPromise"`
 	LatestSettlement time.Time     `json:"LatestSettlement"`
+	IsOffchain       bool          `json:"IsOffchain"`
 }
 
 // LatestPromise represents the latest promise

--- a/session/pingpong/hermes_caller_test.go
+++ b/session/pingpong/hermes_caller_test.go
@@ -150,7 +150,7 @@ func TestHermesGetConsumerData_OK(t *testing.T) {
 
 const defaultChainID = 1
 
-var mockConsumerData = `{"Identity":"0x74CbcbBfEd45D7836D270068116440521033EDc7","Beneficiary":"0x0000000000000000000000000000000000000000","ChannelID":"0xc80A1758A36cf9a0903a9FE37f98B51AEC978CB6","Balance":133,"Settled":0,"Stake":0,"LatestPromise":{"ChannelID":"0xc80a1758a36cf9a0903a9fe37f98b51aec978cb6","Amount":1077,"Fee":0,"Hashlock":"0x528a7340eb740124306c25c53ac7fa27c0d038ac4ab0bb09c0894487b8d1bc5f","Signature":"0xaf3f9e23336513fa75b5a03cb81dbecf8e4b5c61ce14a9479b8d5728970eab1f1d2cf4d22d14f6441d0ae8db06b5ce34eb18000aae9aeedc013e449fc1ced8a31b","ChainID":1},"LatestSettlement":"0001-01-01T00:00:00Z"}`
+var mockConsumerData = `{"Identity":"0x74CbcbBfEd45D7836D270068116440521033EDc7","Beneficiary":"0x0000000000000000000000000000000000000000","ChannelID":"0xc80A1758A36cf9a0903a9FE37f98B51AEC978CB6","Balance":133,"Settled":0,"Stake":0,"LatestPromise":{"ChannelID":"0xc80a1758a36cf9a0903a9fe37f98b51aec978cb6","Amount":1077,"Fee":0,"Hashlock":"0x528a7340eb740124306c25c53ac7fa27c0d038ac4ab0bb09c0894487b8d1bc5f","Signature":"0xaf3f9e23336513fa75b5a03cb81dbecf8e4b5c61ce14a9479b8d5728970eab1f1d2cf4d22d14f6441d0ae8db06b5ce34eb18000aae9aeedc013e449fc1ced8a31b","ChainID":1},"LatestSettlement":"0001-01-01T00:00:00Z","IsOffchain":false}`
 var mockConsumerDataResponse = fmt.Sprintf(`{"%d":%v}`, defaultChainID, mockConsumerData)
 
 func TestLatestPromise_isValid(t *testing.T) {


### PR DESCRIPTION
Offchain identities are now supported in node.
* Offchain identities dont need to register. If an identity is in state Unregistered we check hermes, if it's an offchain identity it's status gets converted to `registered`
* Offchain identities dont need to have balance to work.  ForceBalanceUpdate now also checks hermes, if identity is on hermes and it's offchain then the balance is set to hermes response.

If at any point we fail to contact hermes we continue assuming that the identity is not offchain. This eliminates our service from not working if hermes is unreachable or introduces some breaking changes in the check endpoint.

This does put additional strain on hermes, but I cannot think of a better way to do this.