### PR TITLE
Make e2e tests more stable again

### DIFF
--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/mysteriumnetwork/node/core/beneficiary"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/requests"
 	"github.com/mysteriumnetwork/node/session/pingpong"
@@ -191,6 +192,11 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 		// settle hermes 1
 		err = tequilapiProvider.SettleWithBeneficiary(providerID, providerChannelAddress, hermesID)
 		assert.NoError(t, err)
+		assert.Eventually(t, func() bool {
+			res, err := tequilapiProvider.SettleWithBeneficiaryStatus(providerID)
+			assert.NoError(t, err)
+			return res.State == beneficiary.Completed
+		}, time.Second*30, time.Second/2)
 		assert.Eventually(t, func() bool {
 			res, err := tequilapiProvider.Beneficiary(providerID)
 			assert.NoError(t, err)

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -595,6 +595,22 @@ func (client *Client) DecreaseStake(ID identity.Identity, amount *big.Int) error
 	return nil
 }
 
+// SettleWithBeneficiaryStatus set new beneficiary address for the provided identity.
+func (client *Client) SettleWithBeneficiaryStatus(address string) (res contract.BeneficiaryTxStatus, err error) {
+	response, err := client.http.Get("identities/"+address+"/beneficiary-status", nil)
+	if err != nil {
+		return contract.BeneficiaryTxStatus{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return contract.BeneficiaryTxStatus{}, fmt.Errorf("expected 200 got %v", response.StatusCode)
+	}
+
+	err = parseResponseJSON(response, &res)
+	return res, err
+}
+
 // SettleWithBeneficiary set new beneficiary address for the provided identity.
 func (client *Client) SettleWithBeneficiary(address, beneficiary, hermesID string) error {
 	payload := contract.SettleWithBeneficiaryRequest{


### PR DESCRIPTION
After settle with beneficiary turn into to an async settle, this no longer waits and sometimes tries to settle another settlement before beneficiary one is finished. 