### PR TITLE
Load user config for mobile node

### DIFF
--- a/e2e/mobile_entrypoint_test.go
+++ b/e2e/mobile_entrypoint_test.go
@@ -129,6 +129,25 @@ func TestMobileNodeConsumer(t *testing.T) {
 		require.Equal(t, "Unregistered", identity.RegistrationStatus)
 	})
 
+	t.Run("Test resident country", func(t *testing.T) {
+		// given
+		identity, err := node.GetIdentity(&mysterium.GetIdentityRequest{})
+		require.NoError(t, err)
+
+		// when
+		err = node.UpdateResidentCountry(&mysterium.ResidentCountryUpdateRequest{IdentityAddress: identity.IdentityAddress, Country: "AU"})
+		require.NoError(t, err)
+
+		// then
+		require.Equal(t, "AU", node.ResidentCountry(), "default country should be set")
+
+		// and
+		err = node.UpdateResidentCountry(&mysterium.ResidentCountryUpdateRequest{IdentityAddress: identity.IdentityAddress})
+		require.Error(t, err, "country is required")
+		err = node.UpdateResidentCountry(&mysterium.ResidentCountryUpdateRequest{Country: "UK"})
+		require.Error(t, err, "identity is required")
+	})
+
 	t.Run("Test shutdown", func(t *testing.T) {
 		err := node.Shutdown()
 		require.NoError(t, err)

--- a/mobile/mysterium/config.go
+++ b/mobile/mysterium/config.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysterium
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mysteriumnetwork/node/config"
+	"github.com/rs/zerolog/log"
+)
+
+const userConfigFilename = "user-config.toml"
+
+func loadUserConfig(dataDir string) error {
+	if err := createDirIfNotExists(dataDir); err != nil {
+		return err
+	}
+
+	userConfigPath := dataDir + "/" + userConfigFilename
+	if err := createFileIfNotExists(userConfigPath); err != nil {
+		return err
+	}
+	if err := config.Current.LoadUserConfig(userConfigPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createDirIfNotExists(dir string) error {
+	err := dirExists(dir)
+	if os.IsNotExist(err) {
+		log.Info().Msg("Directory does not exist, creating a new one: " + dir)
+		return os.MkdirAll(dir, 0700)
+	}
+	return err
+}
+
+func createFileIfNotExists(filePath string) error {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		log.Info().Msg("Config file does not exist, attempting to create: " + filePath)
+		_, err := os.Create(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to create config file %w", err)
+		}
+	}
+	return nil
+}
+
+func dirExists(dir string) error {
+	fileStat, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if isDir := fileStat.IsDir(); !isDir {
+		return fmt.Errorf("directory expected: %s", dir)
+	}
+	return nil
+}

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -145,6 +145,9 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 
 	dataDir := filepath.Join(appPath, ".mysterium")
 	currentDir := appPath
+	if err := loadUserConfig(dataDir); err != nil {
+		return nil, err
+	}
 
 	config.Current.SetDefault(config.FlagChainID.Name, options.ChainID)
 	config.Current.SetDefault(config.FlagDefaultCurrency.Name, metadata.DefaultNetwork.DefaultCurrency)


### PR DESCRIPTION
Resident country is saved in user config and without loading it before hand it's not saved successfully