### PR TITLE
Fix race condition in the NAT traversal test

### DIFF
--- a/nat/traversal/pinger.go
+++ b/nat/traversal/pinger.go
@@ -388,7 +388,7 @@ func (p *Pinger) singlePing(ctx context.Context, remoteIP string, localPort, rem
 
 	remoteAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", remoteIP, remotePort))
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve remote addres: %w", err)
+		return nil, fmt.Errorf("failed to resolve remote address: %w", err)
 	}
 
 	pingReceived := make(chan struct{}, 1)
@@ -409,14 +409,14 @@ func (p *Pinger) singlePing(ctx context.Context, remoteIP string, localPort, rem
 
 	conn.Close()
 
-	conn, err = net.DialUDP("udp4", laddr, raddr)
+	newConn, err := net.DialUDP("udp4", laddr, raddr)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := router.ProtectUDPConn(conn); err != nil {
+	if err := router.ProtectUDPConn(newConn); err != nil {
 		return nil, fmt.Errorf("failed to protect udp connection: %w", err)
 	}
 
-	return conn, nil
+	return newConn, nil
 }


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c000010018 by goroutine 13:
  github.com/mysteriumnetwork/node/nat/traversal.(*Pinger).singlePing()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger.go:412 +0xb36
  github.com/mysteriumnetwork/node/nat/traversal.(*Pinger).multiPingN.func1()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger.go:359 +0x179
Previous read at 0x00c000010018 by goroutine 56:
  github.com/mysteriumnetwork/node/nat/traversal.(*Pinger).singlePing.func1()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger.go:396 +0x57
Goroutine 13 (running) created at:
  github.com/mysteriumnetwork/node/nat/traversal.(*Pinger).multiPingN()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger.go:357 +0x296
  github.com/mysteriumnetwork/node/nat/traversal.(*Pinger).PingProviderPeer()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger.go:171 +0x216
  github.com/mysteriumnetwork/node/nat/traversal.TestPinger_PingPeer_N_Connections.func1()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger_test.go:61 +0xfb
Goroutine 56 (running) created at:
  github.com/mysteriumnetwork/node/nat/traversal.(*Pinger).singlePing()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger.go:395 +0x824
  github.com/mysteriumnetwork/node/nat/traversal.(*Pinger).multiPingN.func1()
      /home/gitlab-runner/go/src/github.com/mysteriumnetwork/node/nat/traversal/pinger.go:359 +0x179
```