### PR TITLE
Do not use wireguard replace peers by default

### DIFF
--- a/services/wireguard/wgcfg/device_config.go
+++ b/services/wireguard/wgcfg/device_config.go
@@ -47,7 +47,7 @@ type DeviceConfig struct {
 	DNSScriptDir string `json:"dns_script_dir"`
 
 	Peer         Peer `json:"peer"`
-	ReplacePeers bool `json:"replace_peers"`
+	ReplacePeers bool `json:"replace_peers,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler interface to provide human readable configuration.
@@ -67,7 +67,7 @@ func (dc DeviceConfig) MarshalJSON() ([]byte, error) {
 		DNS          []string `json:"dns"`
 		DNSScriptDir string   `json:"dns_script_dir"`
 		Peer         peer     `json:"peer"`
-		ReplacePeers bool     `json:"replace_peers"`
+		ReplacePeers bool     `json:"replace_peers,omitempty"`
 	}
 
 	var peerEndpoint string
@@ -160,7 +160,11 @@ func (dc *DeviceConfig) Encode() string {
 
 	res.WriteString(fmt.Sprintf("private_key=%s\n", hexKey))
 	res.WriteString(fmt.Sprintf("listen_port=%d\n", dc.ListenPort))
-	res.WriteString(fmt.Sprintf("replace_peers=%t\n", dc.ReplacePeers))
+
+	if dc.ReplacePeers {
+		res.WriteString(fmt.Sprintf("replace_peers=%t\n", dc.ReplacePeers))
+	}
+
 	res.WriteString(dc.Peer.Encode())
 	return res.String()
 }

--- a/services/wireguard/wgcfg/device_config_test.go
+++ b/services/wireguard/wgcfg/device_config_test.go
@@ -45,7 +45,6 @@ func TestDeviceConfig_Encode(t *testing.T) {
 			},
 			expected: `private_key=0f2c702c9fbe8d53be6b3bacbbbacf127cdd81f9bed1f88e050d464db924dd04
 listen_port=53511
-replace_peers=false
 public_key=0f2c702c9fbe8d53be6b3bacbbbacf127cdd81f9bed1f88e050d464db924dd04
 persistent_keepalive_interval=20
 endpoint=182.122.22.19:3233
@@ -61,7 +60,6 @@ allowed_ip=192.168.4.11/32
 			},
 			expected: `private_key=
 listen_port=0
-replace_peers=false
 public_key=
 persistent_keepalive_interval=0
 `,
@@ -97,7 +95,7 @@ func TestDeviceConfig_MarshalJSON(t *testing.T) {
 					KeepAlivePeriodSeconds: 20,
 				},
 			},
-			expected: `{"iface_name":"myst0","subnet":"10.0.182.2/24","private_key":"DyxwLJ++jVO+azusu7rPEnzdgfm+0fiOBQ1GTbkk3QQ=","listen_port":53511,"dns":["1.1.1.1"],"dns_script_dir":"/etc/resolv.conf","peer":{"public_key":"DyxwLJ++jVO+azusu7rPEnzdgfm+0fiOBQ1GTbkk3QQ=","endpoint":"182.122.22.19:3233","allowed_i_ps":["192.168.4.10/32","192.168.4.11/32"],"keep_alive_period_seconds":20},"replace_peers":false}`,
+			expected: `{"iface_name":"myst0","subnet":"10.0.182.2/24","private_key":"DyxwLJ++jVO+azusu7rPEnzdgfm+0fiOBQ1GTbkk3QQ=","listen_port":53511,"dns":["1.1.1.1"],"dns_script_dir":"/etc/resolv.conf","peer":{"public_key":"DyxwLJ++jVO+azusu7rPEnzdgfm+0fiOBQ1GTbkk3QQ=","endpoint":"182.122.22.19:3233","allowed_i_ps":["192.168.4.10/32","192.168.4.11/32"],"keep_alive_period_seconds":20}}`,
 		},
 		{
 			name: "Test marshal default values",
@@ -118,7 +116,7 @@ func TestDeviceConfig_MarshalJSON(t *testing.T) {
 					KeepAlivePeriodSeconds: 0,
 				},
 			},
-			expected: `{"iface_name":"","subnet":"\u003cnil\u003e","private_key":"","listen_port":0,"dns":[],"dns_script_dir":"","peer":{"public_key":"","endpoint":"","allowed_i_ps":null,"keep_alive_period_seconds":0},"replace_peers":false}`,
+			expected: `{"iface_name":"","subnet":"\u003cnil\u003e","private_key":"","listen_port":0,"dns":[],"dns_script_dir":"","peer":{"public_key":"","endpoint":"","allowed_i_ps":null,"keep_alive_period_seconds":0}}`,
 		},
 	}
 


### PR DESCRIPTION
```
ERROR: (utun6) 2021/05/24 11:56:09 Failed to set replace_peers, invalid value: false
```