### PR TITLE
Set stop timeout for service to finish cleanup

### DIFF
--- a/bin/package/installation/mysterium-consumer.service
+++ b/bin/package/installation/mysterium-consumer.service
@@ -15,7 +15,6 @@ LogsDirectory=mysterium-node
 EnvironmentFile=-/etc/default/mysterium-node
 ExecStart=/usr/bin/myst $CONF_DIR $SCRIPT_DIR $DATA_DIR $RUN_DIR $DAEMON_OPTS daemon
 KillMode=process
-TimeoutStopSec=10
 SendSIGKILL=yes
 Restart=on-failure
 RestartSec=5

--- a/bin/package/installation/mysterium-node.service
+++ b/bin/package/installation/mysterium-node.service
@@ -17,7 +17,6 @@ LogsDirectory=mysterium-node
 EnvironmentFile=-/etc/default/mysterium-node
 ExecStart=/usr/bin/myst $CONF_DIR $SCRIPT_DIR $DATA_DIR $RUN_DIR $DAEMON_OPTS service --agreed-terms-and-conditions $SERVICE_OPTS
 KillMode=process
-TimeoutStopSec=10
 SendSIGKILL=yes
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
On some slow machines, 10 seconds is not enough to finish the cleanup process.
This leads to issues when consumers can keep using connections even after myst process exited.
This sets default stop timeout to the default value of 90 seconds.

![image](https://user-images.githubusercontent.com/8612618/120146627-2f5b3c00-c207-11eb-95c7-0a171fdbd33a.png)
