### PR TITLE
Remove additional `--update` for `apk` in Dockerfile

### DIFF
--- a/bin/docker/alpine-prebuilt/Dockerfile
+++ b/bin/docker/alpine-prebuilt/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.12
 
 # Install packages
-RUN apk add --update --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv
+RUN apk add --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv
 
 COPY bin/helpers/prepare-run-env.sh /usr/local/bin/prepare-run-env.sh
 COPY bin/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/bin/docker/alpine/Dockerfile
+++ b/bin/docker/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-alpine AS builder
 
 # Install packages
-RUN apk add --update --no-cache git bash gcc musl-dev make linux-headers \
+RUN apk add --no-cache git bash gcc musl-dev make linux-headers \
     && rm -rf /var/cache/apk/*
 
 ARG BUILD_BRANCH=$BUILD_BRANCH
@@ -20,7 +20,7 @@ RUN bin/build
 FROM alpine:3.12
 
 # Install packages
-RUN apk add --update --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv
+RUN apk add --no-cache iptables ipset ca-certificates openvpn bash sudo openresolv
 
 COPY bin/helpers/prepare-run-env.sh /usr/local/bin/prepare-run-env.sh
 COPY bin/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/e2e/forwarder/Dockerfile
+++ b/e2e/forwarder/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6 AS forwarder
 
 # Install packages
-RUN apk add --update --no-cache bash gcc musl-dev make iptables conntrack-tools tcpdump dnsmasq \
+RUN apk add --no-cache bash gcc musl-dev make iptables conntrack-tools tcpdump dnsmasq \
     && rm -rf /var/cache/apk/*
 
 COPY e2e/forwarder/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/e2e/gorunner/Dockerfile
+++ b/e2e/gorunner/Dockerfile
@@ -1,3 +1,3 @@
 FROM golang:1.13-alpine
 
-RUN apk add --update --no-cache bash gcc musl-dev make linux-headers iptables ipset ca-certificates openvpn bash sudo openresolv
+RUN apk add --no-cache bash gcc musl-dev make linux-headers iptables ipset ca-certificates openvpn bash sudo openresolv

--- a/e2e/gorunner/Dockerfile.precompiled
+++ b/e2e/gorunner/Dockerfile.precompiled
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-RUN apk add --update --no-cache bash gcc musl-dev make linux-headers iptables ipset ca-certificates openvpn bash sudo openresolv
+RUN apk add --no-cache bash gcc musl-dev make linux-headers iptables ipset ca-certificates openvpn bash sudo openresolv
 RUN ln -s /sbin/iptables /usr/sbin/iptables
 
 COPY ./build/e2e/test /usr/local/bin/test

--- a/localnet/node/Dockerfile
+++ b/localnet/node/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-alpine
 
 # Install packages
-RUN apk add --update --no-cache iptables ipset ca-certificates openvpn wireguard-tools bash sudo openresolv gcc musl-dev make linux-headers vim curl tcpdump
+RUN apk add --no-cache iptables ipset ca-certificates openvpn wireguard-tools bash sudo openresolv gcc musl-dev make linux-headers vim curl tcpdump
 
 COPY ./bin/helpers/prepare-run-env.sh /usr/local/bin/prepare-run-env.sh
 COPY ./bin/package/config/common /etc/mysterium-node


### PR DESCRIPTION
There is no need to use `--update` with `--no-cache`, as using `--no-cache` will fetch the index every time and leave no local cache, so the index will always be the latest and without temporary files remains in the image.