### PR TITLE
Bump NDK version to LTS 21e

### DIFF
--- a/bin/package_android
+++ b/bin/package_android
@@ -29,7 +29,7 @@ docker run --rm \
     -e TARGETS=android/. \
     -e EXT_GOPATH=/ext-go/1 \
     -e GO111MODULE=on \
-    mysteriumnetwork/xgomobile:1.13.8-ndk19 ./mobile/mysterium
+    mysteriumnetwork/xgomobile:1.13.15-ndk21e ./mobile/mysterium
 
 print_success "Android package '$PACKAGE_FILE' complete!"
 exit 0


### PR DESCRIPTION
In hopes of solving JNI crashes on some android devices

Reported by mobile team:

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 0 >>> network.mysterium.vpn <<<
backtrace:
  #00  pc 00000000008cc388  /data/app/~~Q8wArlLj0qFTX2c1xEREDg==/network.mysterium.vpn-gID6PJiPWBGPvEq6D5xLVA==/split_config.arm64_v8a.apk!lib/arm64-v8a/libgojni.so (offset 0x1000)
```

This [issue thread](https://github.com/trojan-gfw/igniter/issues/203) suggested updating NDK 