### PR TITLE
Allow resolving monitoring failed proposals

### DIFF
--- a/core/discovery/apidiscovery/repository.go
+++ b/core/discovery/apidiscovery/repository.go
@@ -37,9 +37,10 @@ func NewRepository(api *mysterium.MysteriumAPI) *apiRepository {
 // Proposal returns proposal by ID.
 func (a *apiRepository) Proposal(id market.ProposalID) (*market.ServiceProposal, error) {
 	proposals, err := a.discoveryAPI.QueryProposals(mysterium.ProposalsQuery{
-		ProviderID:   id.ProviderID,
-		ServiceType:  id.ServiceType,
-		AccessPolicy: "all",
+		ProviderID:              id.ProviderID,
+		ServiceType:             id.ServiceType,
+		AccessPolicy:            "all",
+		IncludeMonitoringFailed: true,
 	})
 	if err != nil {
 		return nil, err

--- a/core/discovery/proposal/filter.go
+++ b/core/discovery/proposal/filter.go
@@ -36,6 +36,7 @@ type Filter struct {
 	CompatibilityMin, CompatibilityMax int
 	QualityMin                         float32
 	ExcludeUnsupported                 bool
+	IncludeMonitoringFailed            bool
 }
 
 // Matches return flag if filter matches given proposal
@@ -81,15 +82,16 @@ func (filter *Filter) Matches(proposal market.ServiceProposal) bool {
 // ToAPIQuery serialises filter to query of Mysterium API
 func (filter *Filter) ToAPIQuery() mysterium.ProposalsQuery {
 	query := mysterium.ProposalsQuery{
-		ProviderID:         filter.ProviderID,
-		ServiceType:        filter.ServiceType,
-		LocationCountry:    filter.LocationCountry,
-		IPType:             filter.IPType,
-		CompatibilityMin:   filter.CompatibilityMin,
-		CompatibilityMax:   filter.CompatibilityMax,
-		AccessPolicy:       filter.AccessPolicy,
-		AccessPolicySource: filter.AccessPolicySource,
-		QualityMin:         filter.QualityMin,
+		ProviderID:              filter.ProviderID,
+		ServiceType:             filter.ServiceType,
+		LocationCountry:         filter.LocationCountry,
+		IPType:                  filter.IPType,
+		CompatibilityMin:        filter.CompatibilityMin,
+		CompatibilityMax:        filter.CompatibilityMax,
+		AccessPolicy:            filter.AccessPolicy,
+		AccessPolicySource:      filter.AccessPolicySource,
+		QualityMin:              filter.QualityMin,
+		IncludeMonitoringFailed: filter.IncludeMonitoringFailed,
 	}
 	if priceGibMax := filter.PriceGiBMax; priceGibMax != nil {
 		query.PriceGibMax = priceGibMax.Uint64()

--- a/market/mysterium/dto.go
+++ b/market/mysterium/dto.go
@@ -35,6 +35,8 @@ type ProposalsQuery struct {
 	IPType                    string
 	PriceGibMax, PriceHourMax uint64
 	QualityMin                float32
+
+	IncludeMonitoringFailed bool
 }
 
 // ToURLValues converts the query to url.Values.
@@ -70,6 +72,9 @@ func (q ProposalsQuery) ToURLValues() url.Values {
 	}
 	if q.QualityMin != 0 {
 		values.Set("quality_min", fmt.Sprintf("%.2f", q.QualityMin))
+	}
+	if q.IncludeMonitoringFailed {
+		values.Set("include_monitoring_failed", fmt.Sprint(q.IncludeMonitoringFailed))
 	}
 	return values
 }

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -360,6 +360,7 @@ func (client *Client) ProposalsByPrice(priceHourMax, priceGiBMax *big.Int) ([]co
 	values.Add("price_gib_max", fmt.Sprintf("%v", priceGiBMax))
 	values.Add("price_hour_max", fmt.Sprintf("%v", priceHourMax))
 	values.Add("access_policy", "all")
+	values.Add("include_monitoring_failed", "true")
 	return client.proposals(values)
 }
 

--- a/tequilapi/endpoints/proposals.go
+++ b/tequilapi/endpoints/proposals.go
@@ -128,19 +128,21 @@ func (pe *proposalsEndpoint) List(resp http.ResponseWriter, req *http.Request, _
 		return float32(f)
 	}()
 
+	includeMonitoringFailed, _ := strconv.ParseBool(req.URL.Query().Get("include_monitoring_failed"))
 	proposals, err := pe.proposalRepository.Proposals(&proposal.Filter{
-		ProviderID:         req.URL.Query().Get("provider_id"),
-		ServiceType:        req.URL.Query().Get("service_type"),
-		AccessPolicy:       req.URL.Query().Get("access_policy"),
-		AccessPolicySource: req.URL.Query().Get("access_policy_source"),
-		LocationCountry:    req.URL.Query().Get("location_country"),
-		IPType:             req.URL.Query().Get("ip_type"),
-		PriceGiBMax:        priceGiBMax,
-		PriceHourMax:       priceHourMax,
-		CompatibilityMin:   compatibilityMin,
-		CompatibilityMax:   compatibilityMax,
-		QualityMin:         qualityMin,
-		ExcludeUnsupported: true,
+		ProviderID:              req.URL.Query().Get("provider_id"),
+		ServiceType:             req.URL.Query().Get("service_type"),
+		AccessPolicy:            req.URL.Query().Get("access_policy"),
+		AccessPolicySource:      req.URL.Query().Get("access_policy_source"),
+		LocationCountry:         req.URL.Query().Get("location_country"),
+		IPType:                  req.URL.Query().Get("ip_type"),
+		PriceGiBMax:             priceGiBMax,
+		PriceHourMax:            priceHourMax,
+		CompatibilityMin:        compatibilityMin,
+		CompatibilityMax:        compatibilityMax,
+		QualityMin:              qualityMin,
+		ExcludeUnsupported:      true,
+		IncludeMonitoringFailed: includeMonitoringFailed,
 	})
 	if err != nil {
 		utils.SendError(resp, err, http.StatusInternalServerError)


### PR DESCRIPTION
These changes allow to attempt a connection to a proposal with monitoring failed status.


@soffokl can you check what's going on with connection attempt to provider that has a monitoring failed proposal? I think node set's up TUN interface but doesn't clean it up, as I am left with broken connection on my Manjaro Linux distro at least.

Monitoring failed proposal: wireguard 0xd554a868627fcbf662aa9906b6ad51c6a26c4776