### PR TITLE
Less aggresive balance cache in node

### DIFF
--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -87,6 +87,13 @@ var (
 		Usage:  "sets the hermes status recheck interval. Setting this to a lower value will decrease potential loss in case of Hermes getting locked.",
 		Value:  time.Hour * 2,
 	}
+	// FlagOffchainBalanceExpiration sets how often we re-check offchain balance on hermes when balance is depleting
+	FlagOffchainBalanceExpiration = cli.DurationFlag{
+		Hidden: true,
+		Name:   "payments.consumer.offchain-expiration",
+		Usage:  "after syncing offchain balance, how long should node wait for next check to occur",
+		Value:  time.Minute * 55,
+	}
 )
 
 // RegisterFlagsPayments function register payments flags to flag list.
@@ -103,6 +110,7 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagPaymentsConsumerDataLeewayMegabytes,
 		&FlagPaymentsMaxUnpaidInvoiceValue,
 		&FlagPaymentsHermesStatusRecheckInterval,
+		&FlagOffchainBalanceExpiration,
 	)
 }
 
@@ -118,4 +126,5 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseUInt64Flag(ctx, FlagPaymentsConsumerDataLeewayMegabytes)
 	Current.ParseStringFlag(ctx, FlagPaymentsMaxUnpaidInvoiceValue)
 	Current.ParseDurationFlag(ctx, FlagPaymentsHermesStatusRecheckInterval)
+	Current.ParseDurationFlag(ctx, FlagOffchainBalanceExpiration)
 }

--- a/core/connection/connection_validator.go
+++ b/core/connection/connection_validator.go
@@ -25,6 +25,7 @@ import (
 )
 
 type consumerBalanceGetter interface {
+	NeedsForceSync(chainID int64, id identity.Identity) bool
 	GetBalance(chainID int64, id identity.Identity) *big.Int
 	ForceBalanceUpdate(chainID int64, id identity.Identity) *big.Int
 }
@@ -51,7 +52,7 @@ func NewValidator(consumerBalanceGetter consumerBalanceGetter, unlockChecker unl
 func (v *Validator) validateBalance(chainID int64, consumerID identity.Identity, proposal market.ServiceProposal) bool {
 	balance := v.consumerBalanceGetter.GetBalance(chainID, consumerID)
 
-	if balance.Cmp(big.NewInt(0)) == 0 {
+	if v.consumerBalanceGetter.NeedsForceSync(chainID, consumerID) {
 		balance = v.consumerBalanceGetter.ForceBalanceUpdate(chainID, consumerID)
 	}
 

--- a/core/connection/connection_validator_test.go
+++ b/core/connection/connection_validator_test.go
@@ -144,8 +144,13 @@ func (muc *mockUnlockChecker) IsUnlocked(id string) bool {
 }
 
 type mockConsumerBalanceGetter struct {
+	needSync    bool
 	toReturn    *big.Int
 	forceReturn *big.Int
+}
+
+func (mcbg *mockConsumerBalanceGetter) NeedsForceSync(chainID int64, id identity.Identity) bool {
+	return mcbg.needSync
 }
 
 func (mcbg *mockConsumerBalanceGetter) GetBalance(chainID int64, id identity.Identity) *big.Int {

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/node/config"
 	nodevent "github.com/mysteriumnetwork/node/core/node/event"
 	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/identity"
@@ -35,6 +36,7 @@ import (
 	"github.com/mysteriumnetwork/node/session/pingpong/event"
 	"github.com/mysteriumnetwork/payments/bindings"
 	"github.com/mysteriumnetwork/payments/client"
+	"github.com/mysteriumnetwork/payments/units"
 	"github.com/rs/zerolog/log"
 )
 
@@ -116,6 +118,26 @@ func (cbt *ConsumerBalanceTracker) Subscribe(bus eventbus.Subscriber) error {
 		return err
 	}
 	return bus.SubscribeAsync(identity.AppTopicIdentityUnlock, cbt.handleUnlockEvent)
+}
+
+// NeedsForceSync returns true if balance needs to be force synced.
+func (cbt *ConsumerBalanceTracker) NeedsForceSync(chainID int64, id identity.Identity) bool {
+	v, ok := cbt.getBalance(chainID, id)
+	if !ok {
+		return true
+	}
+
+	// Offchain balances expire after configured amount of time and need to be resynced.
+	if v.OffchainNeedsSync() {
+		return true
+	}
+
+	// Balance doesn't always go to 0 but connections can still fail.
+	if v.BCBalance.Cmp(units.SingleGweiInWei()) < 0 {
+		return true
+	}
+
+	return false
 }
 
 // GetBalance gets the current balance for given identity
@@ -253,12 +275,16 @@ func (cbt *ConsumerBalanceTracker) subscribeToExternalChannelTopup(chainID int64
 					BCBalance:          new(big.Int).Add(previous.BCBalance, e.Value),
 					BCSettled:          previous.BCSettled,
 					GrandTotalPromised: previous.GrandTotalPromised,
+					IsOffchain:         previous.IsOffchain,
+					LastOffchainSync:   previous.LastOffchainSync,
 				})
 			} else {
 				cbt.setBalance(chainID, id, ConsumerBalance{
 					BCBalance:          new(big.Int).Sub(previous.BCBalance, e.Value),
 					BCSettled:          previous.BCSettled,
 					GrandTotalPromised: previous.GrandTotalPromised,
+					IsOffchain:         previous.IsOffchain,
+					LastOffchainSync:   previous.LastOffchainSync,
 				})
 			}
 
@@ -315,6 +341,8 @@ func (cbt *ConsumerBalanceTracker) alignWithHermes(chainID int64, id identity.Id
 			BCBalance:          consumer.Balance,
 			BCSettled:          consumer.Settled,
 			GrandTotalPromised: promised,
+			IsOffchain:         true,
+			LastOffchainSync:   time.Now().UTC(),
 		})
 
 		currentBalance, _ := cbt.getBalance(chainID, id)
@@ -557,13 +585,14 @@ func (cbt *ConsumerBalanceTracker) setBalance(chainID int64, id identity.Identit
 
 func (cbt *ConsumerBalanceTracker) updateGrandTotal(chainID int64, id identity.Identity, current *big.Int) {
 	b, ok := cbt.getBalance(chainID, id)
-	before := b.BCBalance
-	if ok {
-		b.GrandTotalPromised = current
-		cbt.setBalance(chainID, id, b)
-	} else {
+	if !ok || b.OffchainNeedsSync() {
 		cbt.ForceBalanceUpdate(chainID, id)
+		return
 	}
+
+	before := b.BCBalance
+	b.GrandTotalPromised = current
+	cbt.setBalance(chainID, id, b)
 
 	after, _ := cbt.getBalance(chainID, id)
 	go cbt.publishChangeEvent(id, before, after.GetBalance())
@@ -638,6 +667,27 @@ type ConsumerBalance struct {
 	BCBalance          *big.Int
 	BCSettled          *big.Int
 	GrandTotalPromised *big.Int
+
+	// IsOffchain is an optional indicator which marks an offchain balanace.
+	// Offchain balances receive no updates on the blockchain and their
+	// actual remaining balance should be retreived from hermes.
+	IsOffchain       bool
+	LastOffchainSync time.Time
+}
+
+// OffchainNeedsSync returns true if balance is offchain and should be synced.
+func (cb ConsumerBalance) OffchainNeedsSync() bool {
+	if !cb.IsOffchain {
+		return false
+	}
+
+	if cb.LastOffchainSync.IsZero() {
+		return true
+	}
+
+	expiresAfter := config.GetDuration(config.FlagOffchainBalanceExpiration)
+	now := time.Now().UTC()
+	return cb.LastOffchainSync.Add(expiresAfter).Before(now)
 }
 
 // GetBalance returns the current balance


### PR DESCRIPTION
Balance cache is less aggresive allowing for more force syncing to occur.
Changes:
* If balance drops below 1gwei try to force sync on connect.
  * There seem to be cases where balance isn't actually 0, but very close to it and connection creation fails (even though maybe there is some balance on or off chain it was just missed)
* If balance is offchain it now has an expiration time after which we ask hermes for an update.
  * It is configurable because in most cases this will not be needed. This is mainly so that it's easier to sustain long running (many hours or days at a time) connections for super proxy.
* On connect we also force sync a balance if it's offchain and is expired.
  * Useful mainly for monitoring or regular users using node as offchain.

If any of these additional checks fail, we continue as normal. This is intentional as to not make node depend on hermes.

Closes: https://github.com/mysteriumnetwork/node/issues/3542

To make this a better solution, we would need to build some better way for consumer and provider to talk to each other. So that we wouldn't have to check balance on consumer side often or ever.