### PR TITLE
No more beneficiary

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -50,7 +50,7 @@ func (di *Dependencies) bootstrapTequilapi(nodeOptions node.Options, listener ne
 	tequilapi_endpoints.AddRoutesForService(router, di.ServicesManager, services.JSONParsersByType, di.ProposalRepository)
 	tequilapi_endpoints.AddRoutesForAccessPolicies(di.HTTPClient, router, config.GetString(config.FlagAccessPolicyAddress))
 	tequilapi_endpoints.AddRoutesForNAT(router, di.StateKeeper)
-	tequilapi_endpoints.AddRoutesForTransactor(router, di.IdentityRegistry, di.Transactor, di.HermesPromiseSettler, di.SettlementHistoryStorage, di.AddressProvider, di.BeneficiarySaver, di.BeneficiaryProvider)
+	tequilapi_endpoints.AddRoutesForTransactor(router, di.IdentityRegistry, di.Transactor, di.HermesPromiseSettler, di.SettlementHistoryStorage, di.AddressProvider)
 	tequilapi_endpoints.AddRoutesForConfig(router)
 	tequilapi_endpoints.AddRoutesForMMN(router, di.MMN)
 	tequilapi_endpoints.AddRoutesForFeedback(router, di.Reporter)

--- a/cmd/commands/account/command.go
+++ b/cmd/commands/account/command.go
@@ -262,7 +262,7 @@ func (c *command) parseToken(ctx *cli.Context) *string {
 }
 
 func (c *command) registerIdentity(identity string, token *string) {
-	err := c.tequilapi.RegisterIdentity(identity, "", new(big.Int).SetInt64(0), token)
+	err := c.tequilapi.RegisterIdentity(identity, new(big.Int).SetInt64(0), token)
 	if err != nil {
 		clio.Error("Failed to register the identity")
 		return

--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -171,10 +171,10 @@ func (c *cliApp) unlockIdentity(actionArgs []string) {
 	clio.Success(fmt.Sprintf("Identity %s unlocked.", address))
 }
 
-const usageRegisterIdentity = "register <identity> [stake] [beneficiary] [referralcode]"
+const usageRegisterIdentity = "register <identity> [stake] [referralcode]"
 
 func (c *cliApp) registerIdentity(actionArgs []string) {
-	if len(actionArgs) < 1 || len(actionArgs) > 4 {
+	if len(actionArgs) < 1 || len(actionArgs) > 3 {
 		clio.Info("Usage: " + usageRegisterIdentity)
 		return
 	}
@@ -188,17 +188,13 @@ func (c *cliApp) registerIdentity(actionArgs []string) {
 		}
 		stake = s
 	}
-	var beneficiary string
-	if len(actionArgs) >= 3 {
-		beneficiary = actionArgs[2]
-	}
 
 	var token *string
-	if len(actionArgs) >= 4 {
-		token = &actionArgs[3]
+	if len(actionArgs) >= 3 {
+		token = &actionArgs[2]
 	}
 
-	err := c.tequilapi.RegisterIdentity(address, beneficiary, stake, token)
+	err := c.tequilapi.RegisterIdentity(address, stake, token)
 	if err != nil {
 		clio.Warn(errors.Wrap(err, "could not register identity"))
 		return

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -608,44 +608,6 @@ func (client *Client) DecreaseStake(ID identity.Identity, amount *big.Int) error
 	return nil
 }
 
-// SettleWithBeneficiaryStatus set new beneficiary address for the provided identity.
-func (client *Client) SettleWithBeneficiaryStatus(address string) (res contract.BeneficiaryTxStatus, err error) {
-	response, err := client.http.Get("identities/"+address+"/beneficiary-status", nil)
-	if err != nil {
-		return contract.BeneficiaryTxStatus{}, err
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return contract.BeneficiaryTxStatus{}, fmt.Errorf("expected 200 got %v", response.StatusCode)
-	}
-
-	err = parseResponseJSON(response, &res)
-	return res, err
-}
-
-// SettleWithBeneficiary set new beneficiary address for the provided identity.
-func (client *Client) SettleWithBeneficiary(address, beneficiary, hermesID string) error {
-	payload := contract.SettleWithBeneficiaryRequest{
-		SettleRequest: contract.SettleRequest{
-			ProviderID: address,
-			HermesID:   hermesID,
-		},
-		Beneficiary: beneficiary,
-	}
-	response, err := client.http.Post("identities/"+address+"/beneficiary", payload)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("expected 202 got %v", response.StatusCode)
-	}
-
-	return nil
-}
-
 // Beneficiary gets beneficiary address for the provided identity.
 func (client *Client) Beneficiary(address string) (res contract.IdentityBeneficiaryResponse, err error) {
 	response, err := client.http.Get("identities/"+address+"/beneficiary", nil)

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -201,10 +201,9 @@ func (client *Client) GetTransactorFees() (contract.FeesDTO, error) {
 }
 
 // RegisterIdentity registers identity
-func (client *Client) RegisterIdentity(address, beneficiary string, stake *big.Int, token *string) error {
+func (client *Client) RegisterIdentity(address string, stake *big.Int, token *string) error {
 	payload := contract.IdentityRegisterRequest{
 		Stake:         stake,
-		Beneficiary:   beneficiary,
 		ReferralToken: token,
 	}
 

--- a/tequilapi/contract/identity.go
+++ b/tequilapi/contract/identity.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/tequilapi/validation"
 )
@@ -123,8 +122,6 @@ func (r IdentityCurrentRequest) Validate() *validation.FieldErrorMap {
 type IdentityRegisterRequest struct {
 	// Stake is used by Provider, default 0
 	Stake *big.Int `json:"stake,omitempty"`
-	// Cache out address for Provider
-	Beneficiary string `json:"beneficiary,omitempty"`
 	// Token: referral token, if the user has one
 	ReferralToken *string `json:"referral_token,omitempty"`
 }
@@ -132,10 +129,6 @@ type IdentityRegisterRequest struct {
 // Validate validates fields in request
 func (irr *IdentityRegisterRequest) Validate() *validation.FieldErrorMap {
 	errors := validation.NewErrorMap()
-
-	if irr.Beneficiary != "" && !common.IsHexAddress(irr.Beneficiary) {
-		errors.ForField("beneficiary").Invalid(irr.Beneficiary + " - is not a valid ethereum wallet address")
-	}
 
 	if irr.ReferralToken == nil {
 		if irr.Stake == nil {

--- a/tequilapi/endpoints/transactor.go
+++ b/tequilapi/endpoints/transactor.go
@@ -19,16 +19,13 @@ package endpoints
 
 import (
 	"encoding/json"
-	errs "errors"
 	"fmt"
 	"math/big"
 	"net/http"
 
-	"github.com/asdine/storm/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/julienschmidt/httprouter"
 	"github.com/mysteriumnetwork/node/config"
-	"github.com/mysteriumnetwork/node/core/beneficiary"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/node/session/pingpong"
@@ -63,11 +60,6 @@ type addressProvider interface {
 	GetActiveHermes(chainID int64) (common.Address, error)
 }
 
-type beneficiarySaver interface {
-	SettleAndSaveBeneficiary(id identity.Identity, beneficiary common.Address) error
-	CleanupAndGetChangeStatus(id identity.Identity, currentBeneficiary string) (*beneficiary.ChangeStatus, error)
-}
-
 type settlementHistoryProvider interface {
 	List(pingpong.SettlementHistoryFilter) ([]pingpong.SettlementHistoryEntry, error)
 }
@@ -78,7 +70,6 @@ type transactorEndpoint struct {
 	promiseSettler            promiseSettler
 	settlementHistoryProvider settlementHistoryProvider
 	addressProvider           addressProvider
-	bhandler                  beneficiarySaver
 	bprovider                 beneficiaryProvider
 }
 
@@ -89,8 +80,6 @@ func NewTransactorEndpoint(
 	promiseSettler promiseSettler,
 	settlementHistoryProvider settlementHistoryProvider,
 	addressProvider addressProvider,
-	bhander beneficiarySaver,
-	bprovider beneficiaryProvider,
 ) *transactorEndpoint {
 	return &transactorEndpoint{
 		transactor:                transactor,
@@ -98,8 +87,6 @@ func NewTransactorEndpoint(
 		promiseSettler:            promiseSettler,
 		settlementHistoryProvider: settlementHistoryProvider,
 		addressProvider:           addressProvider,
-		bhandler:                  bhander,
-		bprovider:                 bprovider,
 	}
 }
 
@@ -307,85 +294,6 @@ func (te *transactorEndpoint) RegisterIdentity(resp http.ResponseWriter, request
 	resp.WriteHeader(http.StatusAccepted)
 }
 
-// swagger:operation POST /identities/{id}/beneficiary
-// ---
-// summary: Settle with Beneficiary
-// description: Change beneficiary and settle earnings to it. This is async method.
-// parameters:
-// - name: id
-//   in: path
-//   description: Identity address to register
-//   type: string
-//   required: true
-// responses:
-//   202:
-//     description: settle request accepted
-func (te *transactorEndpoint) SettleWithBeneficiaryAsync(resp http.ResponseWriter, request *http.Request, params httprouter.Params) {
-	id := params.ByName("id")
-
-	req := &contract.SettleWithBeneficiaryRequest{}
-	err := json.NewDecoder(request.Body).Decode(&req)
-	if err != nil {
-		utils.SendError(resp, fmt.Errorf("failed to parse set beneficiary request: %w", err), http.StatusBadRequest)
-		return
-	}
-
-	go func() {
-		err = te.bhandler.SettleAndSaveBeneficiary(identity.FromAddress(id), common.HexToAddress(req.Beneficiary))
-		if err != nil {
-			log.Err(err).Msgf("Failed set beneficiary request for ID: %s, %+v", id, req)
-		}
-	}()
-
-	resp.WriteHeader(http.StatusAccepted)
-}
-
-// swagger:operation GET /identities/{id}/beneficiary-status
-// ---
-// summary: Returns beneficiary transaction status
-// description: Returns the last beneficiary transaction status for given identity
-// parameters:
-// - name: id
-//   in: path
-//   description: Identity address to register
-//   type: string
-//   required: true
-// responses:
-//   200:
-//     description: Returns beneficiary transaction status
-//     schema:
-//       "$ref": "#/definitions/BeneficiaryTxStatus"
-//   404:
-//     description: Beneficiary change never recorded.
-func (te *transactorEndpoint) BeneficiaryTxStatus(resp http.ResponseWriter, _ *http.Request, params httprouter.Params) {
-	id := params.ByName("id")
-
-	identity := identity.FromAddress(id)
-	current, err := te.bprovider.GetBeneficiary(identity.ToCommonAddress())
-	if err != nil {
-		utils.SendError(resp, fmt.Errorf("failed to parse get current beneficiary: %s", err), http.StatusInternalServerError)
-		return
-	}
-	status, err := te.bhandler.CleanupAndGetChangeStatus(identity, current.Hex())
-	if err != nil {
-		if errs.Is(err, storm.ErrNotFound) {
-			resp.WriteHeader(http.StatusNotFound)
-			return
-		}
-		utils.SendError(resp, fmt.Errorf("failed to get current transaction status: %s", err), http.StatusInternalServerError)
-		return
-	}
-
-	utils.WriteAsJSON(
-		&contract.BeneficiaryTxStatus{
-			State:    status.State,
-			Error:    status.Error,
-			ChangeTo: status.ChangeTo,
-		},
-		resp,
-	)
-}
-
 // swagger:operation GET /settle/history settlementList
 // ---
 // summary: Returns settlement history
@@ -579,13 +487,9 @@ func AddRoutesForTransactor(
 	promiseSettler promiseSettler,
 	settlementHistoryProvider settlementHistoryProvider,
 	addressProvider addressProvider,
-	bhandler beneficiarySaver,
-	bprovider beneficiaryProvider,
 ) {
-	te := NewTransactorEndpoint(transactor, identityRegistry, promiseSettler, settlementHistoryProvider, addressProvider, bhandler, bprovider)
+	te := NewTransactorEndpoint(transactor, identityRegistry, promiseSettler, settlementHistoryProvider, addressProvider)
 	router.POST("/identities/:id/register", te.RegisterIdentity)
-	router.POST("/identities/:id/beneficiary", te.SettleWithBeneficiaryAsync)
-	router.GET("/identities/:id/beneficiary-status", te.BeneficiaryTxStatus)
 	router.GET("/transactor/fees", te.TransactorFees)
 	router.POST("/transactor/settle/sync", te.SettleSync)
 	router.POST("/transactor/settle/async", te.SettleAsync)

--- a/tequilapi/endpoints/transactor.go
+++ b/tequilapi/endpoints/transactor.go
@@ -284,7 +284,7 @@ func (te *transactorEndpoint) RegisterIdentity(resp http.ResponseWriter, request
 		regFee = rf.Fee
 	}
 
-	err = te.transactor.RegisterIdentity(id.Address, req.Stake, regFee, req.Beneficiary, chainID, req.ReferralToken)
+	err = te.transactor.RegisterIdentity(id.Address, req.Stake, regFee, "", chainID, req.ReferralToken)
 	if err != nil {
 		log.Err(err).Msgf("Failed identity registration request for ID: %s, %+v", id.Address, req)
 		utils.SendError(resp, errors.Wrap(err, "failed identity registration request"), http.StatusInternalServerError)

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -54,7 +54,7 @@ func Test_RegisterIdentity(t *testing.T) {
 
 	req, err := http.NewRequest(
 		http.MethodPost,
-		"/identities/{id}/register",
+		"/identities/0x0000000000000000000000000000000000000000/register",
 		bytes.NewBufferString(identityRegData),
 	)
 	assert.Nil(t, err)

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mysteriumnetwork/node/core/beneficiary"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/julienschmidt/httprouter"
 	"github.com/mysteriumnetwork/node/mocks"
@@ -52,7 +50,7 @@ func Test_RegisterIdentity(t *testing.T) {
 	router := httprouter.New()
 
 	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-	AddRoutesForTransactor(router, &registry.FakeRegistry{RegistrationStatus: registry.Unregistered}, tr, nil, &settlementHistoryProviderMock{}, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+	AddRoutesForTransactor(router, &registry.FakeRegistry{RegistrationStatus: registry.Unregistered}, tr, nil, &settlementHistoryProviderMock{}, &mockAddressProvider{})
 
 	req, err := http.NewRequest(
 		http.MethodPost,
@@ -77,7 +75,7 @@ func Test_Get_TransactorFees(t *testing.T) {
 	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
 	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{
 		feeToReturn: 11,
-	}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+	}, &settlementHistoryProviderMock{}, &mockAddressProvider{})
 
 	req, err := http.NewRequest(
 		http.MethodGet,
@@ -100,7 +98,7 @@ func Test_SettleAsync_OK(t *testing.T) {
 	router := httprouter.New()
 
 	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{}, &settlementHistoryProviderMock{}, &mockAddressProvider{})
 
 	settleRequest := `{"hermes_id": "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "provider_id": "0xbe180c8CA53F280C7BE8669596fF7939d933AA10"}`
 	req, err := http.NewRequest(
@@ -124,8 +122,7 @@ func Test_SettleAsync_ReturnsError(t *testing.T) {
 	router := httprouter.New()
 
 	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{errToReturn: errors.New("explosions everywhere")}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
-
+	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{errToReturn: errors.New("explosions everywhere")}, &settlementHistoryProviderMock{}, &mockAddressProvider{})
 	settleRequest := `asdasdasd`
 	req, err := http.NewRequest(
 		http.MethodPost,
@@ -148,7 +145,7 @@ func Test_SettleSync_OK(t *testing.T) {
 	router := httprouter.New()
 
 	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{}, &settlementHistoryProviderMock{}, &mockAddressProvider{})
 
 	settleRequest := `{"hermes_id": "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "provider_id": "0xbe180c8CA53F280C7BE8669596fF7939d933AA10"}`
 	req, err := http.NewRequest(
@@ -172,7 +169,7 @@ func Test_SettleSync_ReturnsError(t *testing.T) {
 	router := httprouter.New()
 
 	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{errToReturn: errors.New("explosions everywhere")}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+	AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, &mockSettler{errToReturn: errors.New("explosions everywhere")}, &settlementHistoryProviderMock{}, &mockAddressProvider{})
 
 	settleRequest := `{"hermes_id": "0xbe180c8CA53F280C7BE8669596fF7939d933AA10", "provider_id": "0xbe180c8CA53F280C7BE8669596fF7939d933AA10"}`
 	req, err := http.NewRequest(
@@ -197,7 +194,7 @@ func Test_SettleHistory(t *testing.T) {
 
 		router := httprouter.New()
 		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-		AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, nil, &settlementHistoryProviderMock{errToReturn: errors.New("explosions everywhere")}, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+		AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, nil, &settlementHistoryProviderMock{errToReturn: errors.New("explosions everywhere")}, &mockAddressProvider{})
 
 		req, err := http.NewRequest(http.MethodGet, "/transactor/settle/history", nil)
 		assert.Nil(t, err)
@@ -230,7 +227,7 @@ func Test_SettleHistory(t *testing.T) {
 
 		router := httprouter.New()
 		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-		AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, nil, mockStorage, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+		AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, nil, mockStorage, &mockAddressProvider{})
 
 		req, err := http.NewRequest(http.MethodGet, "/transactor/settle/history", nil)
 		assert.Nil(t, err)
@@ -279,7 +276,7 @@ func Test_SettleHistory(t *testing.T) {
 		defer server.Close()
 		router := httprouter.New()
 		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
-		AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, nil, mockStorage, &mockAddressProvider{}, &mockBeneficiarySaver{}, &mockBeneficiaryProvider{})
+		AddRoutesForTransactor(router, mockIdentityRegistryInstance, tr, nil, mockStorage, &mockAddressProvider{})
 
 		req, err := http.NewRequest(
 			http.MethodGet,
@@ -346,24 +343,6 @@ type mockSettler struct {
 
 func (ms *mockSettler) ForceSettle(_ int64, _ identity.Identity, _ common.Address) error {
 	return ms.errToReturn
-}
-
-type mockBeneficiarySaver struct {
-	errToReturn error
-}
-
-func (ms *mockBeneficiarySaver) SettleAndSaveBeneficiary(_ identity.Identity, _ common.Address) error {
-	return ms.errToReturn
-}
-
-func (ms *mockBeneficiarySaver) CleanupAndGetChangeStatus(id identity.Identity, currentBeneficiary string) (*beneficiary.ChangeStatus, error) {
-	return &beneficiary.ChangeStatus{}, nil
-}
-
-type mockBeneficiaryProvider struct{}
-
-func (ms *mockBeneficiaryProvider) GetBeneficiary(identity common.Address) (common.Address, error) {
-	return common.Address{}, nil
 }
 
 func (ms *mockSettler) SettleIntoStake(_ int64, providerID identity.Identity, hermesID common.Address) error {


### PR DESCRIPTION
Beneficiaries as we know them are removed since on testnet3 we require providers to use consumer channel addresses as their beneficiaries.

Closes #3551 
Closes #3552 