### PR TITLE
If balance is a known offchain use cache if hermes is down

### DIFF
--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -92,7 +92,7 @@ var (
 		Hidden: true,
 		Name:   "payments.consumer.offchain-expiration",
 		Usage:  "after syncing offchain balance, how long should node wait for next check to occur",
-		Value:  time.Minute * 55,
+		Value:  time.Minute * 30,
 	}
 )
 


### PR DESCRIPTION
If hermes is down, we used to check on chain. This resulted in balances becoming 0.
Also adjusted the timeouts and expiration timers.