### PR TITLE
Migrate testnet2 providers automatically

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -486,6 +486,9 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		return err
 	}
 
+	di.bootstrapBeneficiarySaver(nodeOptions)
+	di.bootstrapBeneficiaryProvider(nodeOptions)
+
 	di.Transactor = registry.NewTransactor(
 		di.HTTPClient,
 		nodeOptions.Transactor.TransactorEndpointAddress,
@@ -494,8 +497,6 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		di.EventBus,
 		di.BCHelper,
 	)
-
-	di.bootstrapBeneficiaryProvider(nodeOptions)
 
 	if err := di.bootstrapProviderRegistrar(nodeOptions); err != nil {
 		return err
@@ -534,7 +535,6 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 	if err := di.bootstrapHermesPromiseSettler(nodeOptions); err != nil {
 		return err
 	}
-	di.bootstrapBeneficiarySaver(nodeOptions)
 
 	di.PayoutAddressStorage = payout.NewAddressStorage(di.Storage)
 

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -159,7 +159,7 @@ func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) err
 		Stake:               nodeOptions.Transactor.ProviderRegistrationStake,
 		DelayBetweenRetries: nodeOptions.Transactor.ProviderRegistrationRetryDelay,
 	}
-	di.ProviderRegistrar = registry.NewProviderRegistrar(di.Transactor, di.IdentityRegistry, di.AddressProvider, di.BCHelper, cfg)
+	di.ProviderRegistrar = registry.NewProviderRegistrar(di.Transactor, di.IdentityRegistry, di.AddressProvider, di.BCHelper, cfg, di.BeneficiarySaver)
 	return di.ProviderRegistrar.Subscribe(di.EventBus)
 }
 


### PR DESCRIPTION
This will auto register any old testnet2 providers on testnet3.