### PR TITLE
Disable local service discovery in docker containers

### DIFF
--- a/bin/docker/docker-entrypoint.sh
+++ b/bin/docker/docker-entrypoint.sh
@@ -18,4 +18,5 @@ exec /usr/bin/myst \
  --log-dir="" \
  --data-dir=$OS_DIR_DATA \
  --runtime-dir=$OS_DIR_RUN \
+ --local-service-discovery=false
  $@

--- a/bin/docker/docker-entrypoint.sh
+++ b/bin/docker/docker-entrypoint.sh
@@ -18,5 +18,5 @@ exec /usr/bin/myst \
  --log-dir="" \
  --data-dir=$OS_DIR_DATA \
  --runtime-dir=$OS_DIR_RUN \
- --local-service-discovery=false
+ --local-service-discovery=false \
  $@

--- a/config/flags_network.go
+++ b/config/flags_network.go
@@ -95,6 +95,12 @@ var (
 		Usage: "Comma separated list of STUN server to be used to detect NAT type",
 		Value: cli.NewStringSlice("stun.l.google.com:19302", "stun1.l.google.com:19302", "stun2.l.google.com:19302"),
 	}
+	// FlagLocalServiceDiscovery enables SSDP and Bonjour local service discovery.
+	FlagLocalServiceDiscovery = cli.BoolFlag{
+		Name:  "local-service-discovery",
+		Usage: "Enables SSDP and Bonjour local service discovery",
+		Value: true,
+	}
 )
 
 // RegisterFlagsNetwork function register network flags to flag list
@@ -113,6 +119,7 @@ func RegisterFlagsNetwork(flags *[]cli.Flag) {
 		&FlagChainID,
 		&FlagKeepConnectedOnFail,
 		&FlagSTUNservers,
+		&FlagLocalServiceDiscovery,
 	)
 }
 
@@ -130,4 +137,5 @@ func ParseFlagsNetwork(ctx *cli.Context) {
 	Current.ParseInt64Flag(ctx, FlagChainID)
 	Current.ParseBoolFlag(ctx, FlagKeepConnectedOnFail)
 	Current.ParseStringSliceFlag(ctx, FlagSTUNservers)
+	Current.ParseBoolFlag(ctx, FlagLocalServiceDiscovery)
 }

--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -244,6 +244,7 @@ services:
       --access-policy.address=http://trust:8080/api/v1/access-policies/
       --access-policy.fetch=1s
       --stun-servers=""
+      --local-service-discovery=true
       service
       --agreed-terms-and-conditions
       --identity=0xd1a23227bd5ad77f36ba62badcb78a410a1db6c5
@@ -292,6 +293,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
 
   myst-consumer-hermes2:
@@ -331,6 +333,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
 
   myst-consumer-openvpn:
@@ -370,6 +373,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
 
   myst-consumer-wireguard:
@@ -409,6 +413,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
 
   #go runner to run go programs inside localnet (usefull for contract deployment or e2e test running)

--- a/docker-compose.e2e-compatibility.yml
+++ b/docker-compose.e2e-compatibility.yml
@@ -308,6 +308,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
 
   #go runner to run go programs inside localnet (usefull for contract deployment or e2e test running)

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -340,6 +340,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
     dns: 172.30.0.254
     networks:
@@ -429,6 +430,7 @@ services:
       --quality.address=http://morqa:8085/api/v2
       --firewall.killSwitch.always
       --stun-servers=""
+      --local-service-discovery=true
       daemon
     dns: 172.30.0.254
     networks:
@@ -476,6 +478,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
     dns: 172.30.0.254
     networks:
@@ -524,6 +527,7 @@ services:
       --firewall.killSwitch.always
       --quality.address=http://morqa:8085/api/v2
       --stun-servers=""
+      --local-service-discovery=true
       daemon
     dns: 172.30.0.254
     networks:
@@ -578,6 +582,7 @@ services:
       --access-policy.address=http://trust:8080/api/v1/access-policies/
       --access-policy.fetch=1s
       --stun-servers=""
+      --local-service-discovery=true
       service
       --agreed-terms-and-conditions
       --identity=0xd1a23227bd5ad77f36ba62badcb78a410a1db6c5


### PR DESCRIPTION
Many people complain about the following error in the docker containers:
```
2021-07-15T08:53:03.505 ERR ui/server.go:106 > Failed to start local discovery service error="Could not determine host IP addresses for 0195a70a7caf.
```

It does not break anything, but confusing users. 