### PR TITLE
Make Linux standalone builds static

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -29,7 +29,16 @@ if [ "$FLAG_RACE" == "true" ]; then R=-race; fi
 
 echo "Compiling 'myst' for '$GOOS/$GOARCH'.."
 
-go build $R -ldflags="-w -s $(get_linker_ldflags)" -o $GOBIN/myst cmd/mysterium_node/mysterium_node.go
+LD_FLAGS="-w -s $(get_linker_ldflags)"
+STATIC_OPTS=
+
+if [[ "$BUILD_STATIC" = 1 ]] ; then
+	export CGO_ENABLED=0
+	LD_FLAGS="$LD_FLAGS"' -extldflags "-static"'
+	STATIC_OPTS="$STATIC_OPTS -a -tags netgo"
+fi
+
+go build $R -ldflags="$LD_FLAGS" $STATIC_OPTS -o $GOBIN/myst cmd/mysterium_node/mysterium_node.go
 if [ $? -ne 0 ]; then
     print_error "Compile failed!"
     exit 1

--- a/ci/packages/package.go
+++ b/ci/packages/package.go
@@ -261,10 +261,19 @@ func goGet(pkg string) error {
 
 func packageStandalone(binaryPath, os, arch string) error {
 	log.Info().Msgf("Packaging %s %s %s", binaryPath, os, arch)
-	if err := buildCrossBinary(os, arch); err != nil {
+	var err error
+	if os == "linux" {
+		filename := path.Base(binaryPath)
+		binaryPath = path.Join("build", filename, filename)
+		err = buildBinaryFor(path.Join("cmd", "mysterium_node", "mysterium_node.go"), filename, os, arch, true)
+	} else {
+		err = buildCrossBinary(os, arch)
+	}
+	if err != nil {
 		return err
 	}
-	err := buildBinaryFor(path.Join("cmd", "supervisor", "supervisor.go"), "myst_supervisor", os, arch)
+
+	err = buildBinaryFor(path.Join("cmd", "supervisor", "supervisor.go"), "myst_supervisor", os, arch, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR makes standalone Linux builds (those which in zip archives on releases page of GitHub) actually standalone as it makes them static and independent from system runtime libraries.