### PR TITLE
p2p: verify provider identity

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -308,15 +308,17 @@ func (di *Dependencies) bootstrapAddressProvider(nodeOptions node.Options) {
 func (di *Dependencies) bootstrapP2P(p2pPorts *port.Range) {
 	portPool := di.PortPool
 	natPinger := di.NATPinger
-	identityVerifier := identity.NewVerifierSigned()
+	verifierFactory := func (id identity.Identity) identity.Verifier {
+		return identity.NewVerifierIdentity(id)
+	}
 	if p2pPorts.IsSpecified() {
 		log.Info().Msgf("Fixed p2p service port range (%s) configured, using custom port pool", p2pPorts)
 		portPool = port.NewFixedRangePool(*p2pPorts)
 		natPinger = traversal.NewNoopPinger(di.EventBus)
 	}
 
-	di.P2PListener = p2p.NewListener(di.BrokerConnection, di.SignerFactory, identityVerifier, di.IPResolver, natPinger, portPool, di.PortMapper, di.EventBus)
-	di.P2PDialer = p2p.NewDialer(di.BrokerConnector, di.SignerFactory, identityVerifier, di.IPResolver, natPinger, portPool, di.EventBus)
+	di.P2PListener = p2p.NewListener(di.BrokerConnection, di.SignerFactory, identity.NewVerifierSigned(), di.IPResolver, natPinger, portPool, di.PortMapper, di.EventBus)
+	di.P2PDialer = p2p.NewDialer(di.BrokerConnector, di.SignerFactory, verifierFactory, di.IPResolver, natPinger, portPool, di.EventBus)
 }
 
 func (di *Dependencies) createTequilaListener(nodeOptions node.Options) (net.Listener, error) {

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -308,7 +308,7 @@ func (di *Dependencies) bootstrapAddressProvider(nodeOptions node.Options) {
 func (di *Dependencies) bootstrapP2P(p2pPorts *port.Range) {
 	portPool := di.PortPool
 	natPinger := di.NATPinger
-	verifierFactory := func (id identity.Identity) identity.Verifier {
+	verifierFactory := func(id identity.Identity) identity.Verifier {
 		return identity.NewVerifierIdentity(id)
 	}
 	if p2pPorts.IsSpecified() {

--- a/identity/verifier.go
+++ b/identity/verifier.go
@@ -17,6 +17,9 @@
 
 package identity
 
+// VerifierFactory callback returning Verifier
+type VerifierFactory func(id Identity) Verifier
+
 // Verifier checks message's sanity
 type Verifier interface {
 	Verify(message []byte, signature Signature) bool

--- a/p2p/dialer.go
+++ b/p2p/dialer.go
@@ -50,27 +50,27 @@ type Dialer interface {
 }
 
 // NewDialer creates new p2p communication dialer which is used on consumer side.
-func NewDialer(broker brokerConnector, signer identity.SignerFactory, verifier identity.Verifier, ipResolver ip.Resolver, consumerPinger natConsumerPinger, portPool port.ServicePortSupplier, eventBus eventbus.EventBus) Dialer {
+func NewDialer(broker brokerConnector, signer identity.SignerFactory, verifierFactory identity.VerifierFactory, ipResolver ip.Resolver, consumerPinger natConsumerPinger, portPool port.ServicePortSupplier, eventBus eventbus.EventBus) Dialer {
 	return &dialer{
-		broker:         broker,
-		ipResolver:     ipResolver,
-		signer:         signer,
-		verifier:       verifier,
-		portPool:       portPool,
-		consumerPinger: consumerPinger,
-		eventBus:       eventBus,
+		broker:          broker,
+		ipResolver:      ipResolver,
+		signer:          signer,
+		verifierFactory: verifierFactory,
+		portPool:        portPool,
+		consumerPinger:  consumerPinger,
+		eventBus:        eventBus,
 	}
 }
 
 // dialer implements Dialer interface.
 type dialer struct {
-	portPool       port.ServicePortSupplier
-	broker         brokerConnector
-	consumerPinger natConsumerPinger
-	signer         identity.SignerFactory
-	verifier       identity.Verifier
-	ipResolver     ip.Resolver
-	eventBus       eventbus.EventBus
+	portPool        port.ServicePortSupplier
+	broker          brokerConnector
+	consumerPinger  natConsumerPinger
+	signer          identity.SignerFactory
+	verifierFactory identity.VerifierFactory
+	ipResolver      ip.Resolver
+	eventBus        eventbus.EventBus
 }
 
 // Dial exchanges p2p configuration via broker, performs NAT pinging if needed
@@ -188,7 +188,7 @@ func (m *dialer) startConfigExchange(config *p2pConnectConfig, ctx context.Conte
 	}
 
 	// Parse provider response with public key and encrypted and signed connection config.
-	exchangeMsgReplySignedMsg, err := unpackSignedMsg(m.verifier, exchangeMsgBrokerReply)
+	exchangeMsgReplySignedMsg, err := unpackSignedMsg(m.verifierFactory(providerID), exchangeMsgBrokerReply)
 	if err != nil {
 		return nil, fmt.Errorf("could not unpack peer signed message: %w", err)
 	}

--- a/p2p/dialer_test.go
+++ b/p2p/dialer_test.go
@@ -83,6 +83,9 @@ func TestDialer_Exchange_And_Communication_With_Provider(t *testing.T) {
 				return &identity.SignerFake{}
 			}
 			verifier := &identity.VerifierFake{}
+			verifierFactory := func(_ identity.Identity) identity.Verifier {
+				return verifier
+			}
 			brokerConn := nats.StartConnectionMock()
 			defer brokerConn.Close()
 			mockBroker := &mockBroker{conn: brokerConn}
@@ -98,7 +101,7 @@ func TestDialer_Exchange_And_Communication_With_Provider(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Consumer starts dialing provider.
-			channelDialer := NewDialer(mockBroker, signerFactory, verifier, test.ipResolver, test.natConsumerPinger, portPool, nil)
+			channelDialer := NewDialer(mockBroker, signerFactory, verifierFactory, test.ipResolver, test.natConsumerPinger, portPool, nil)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			consumerChannel, err := channelDialer.Dial(ctx, identity.FromAddress("0x2"), providerID, "wireguard", ContactDefinition{BrokerAddresses: []string{"broker"}}, trace.NewTracer("Dial"))


### PR DESCRIPTION
Closes #3645 

Adds verification of provider's identity from consumer side.

Code organization note: I've made factory of verificator just like it's Signer counterpart.