### PR TITLE
wg endpoint: Ensure RAII on configure

### DIFF
--- a/services/wireguard/endpoint/endpoint.go
+++ b/services/wireguard/endpoint/endpoint.go
@@ -66,6 +66,9 @@ func (ce *connectionEndpoint) StartConsumerMode(cfg wgcfg.DeviceConfig) error {
 	ce.cfg = cfg
 
 	if err := ce.wgClient.ConfigureDevice(cfg); err != nil {
+		if err1 := ce.resourceAllocator.ReleaseInterface(iface); err1 != nil {
+			log.Error().Err(err1).Msg("Can't release allocated interface " + iface)
+		}
 		return errors.Wrap(err, "could not configure device")
 	}
 	return nil
@@ -105,6 +108,9 @@ func (ce *connectionEndpoint) StartProviderMode(publicIP string, config wgcfg.De
 	ce.endpoint = net.UDPAddr{IP: net.ParseIP(publicIP), Port: config.ListenPort}
 
 	if err := ce.wgClient.ConfigureDevice(config); err != nil {
+		if err1 := ce.resourceAllocator.ReleaseInterface(iface); err1 != nil {
+			log.Error().Err(err1).Msg("Can't release allocated interface " + iface)
+		}
 		return errors.Wrap(err, "could not configure device")
 	}
 	return nil

--- a/utils/actionstack/actionstack.go
+++ b/utils/actionstack/actionstack.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package actionstack
+
+// Action represents stackable action.
+type Action func()
+
+// ActionStack is a stack of actions which are executed in reverse order
+// they were added
+type ActionStack struct {
+	stack []Action
+}
+
+// NewActionStack creates empty ActionStack
+func NewActionStack() *ActionStack {
+	return new(ActionStack)
+}
+
+// Run executes pushed actions in reverse order (FILO)
+func (a *ActionStack) Run() {
+	for i := len(a.stack) - 1; i >= 0; i-- {
+		a.stack[i]()
+	}
+}
+
+// Push adds new action on top of stack. Last added action will be executed
+// by Run() first.
+func (a *ActionStack) Push(elems ...Action) {
+	a.stack = append(a.stack, elems...)
+}

--- a/utils/actionstack/actionstack.go
+++ b/utils/actionstack/actionstack.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/utils/actionstack/actionstack_test.go
+++ b/utils/actionstack/actionstack_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package actionstack
+
+import (
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	as := NewActionStack()
+	var arr []int
+	as.Push(func() {
+		arr = append(arr, 1)
+	})
+	as.Push(
+		func() {
+			arr = append(arr, 2)
+		},
+		func() {
+			arr = append(arr, 3)
+		},
+	)
+
+	as.Run()
+
+	if len(arr) != 3 {
+		t.Fail()
+	}
+	for i, v := range []int{3, 2, 1} {
+		if arr[i] != v {
+			t.Fail()
+		}
+	}
+}

--- a/utils/actionstack/actionstack_test.go
+++ b/utils/actionstack/actionstack_test.go
@@ -47,3 +47,47 @@ func TestMain(t *testing.T) {
 		}
 	}
 }
+
+func TestEmpty(t *testing.T) {
+	// Should at least not panic due to some nil-values
+	NewActionStack().Run()
+}
+
+func TestRunPanicsAfterRun(t *testing.T) {
+	var failedSuccessfully bool
+	as := NewActionStack()
+	as.Push(func() {})
+	as.Run()
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				failedSuccessfully = true
+			}
+		}()
+		as.Run()
+	}()
+
+	if !failedSuccessfully {
+		t.Fail()
+	}
+}
+
+func TestAddPanicsAfterRun(t *testing.T) {
+	var failedSuccessfully bool
+	as := NewActionStack()
+	as.Run()
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				failedSuccessfully = true
+			}
+		}()
+		as.Push(func() {})
+	}()
+
+	if !failedSuccessfully {
+		t.Fail()
+	}
+}

--- a/utils/actionstack/actionstack_test.go
+++ b/utils/actionstack/actionstack_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fix #3560 

Ensures RAII on Wireguard interface configuration routines in a way so caller either will have interface configured or will get an error and will have no need to clean up resources allocated by callee.

Incorrect resource management leads to situations when half-configured interfaces abandoned on interface configuration error.

To reproduce such situation on Linux I use following patch:

```diff
diff --git a/utils/netutil/network_linux.go b/utils/netutil/network_linux.go
index 252bb958..eff3002b 100644
--- a/utils/netutil/network_linux.go
+++ b/utils/netutil/network_linux.go
@@ -20,6 +20,7 @@
 package netutil
 
 import (
+	"errors"
 	"net"
 	"os/exec"
 	"strings"
@@ -37,6 +38,7 @@ func assignIP(iface string, subnet net.IPNet) error {
 }
 
 func excludeRoute(ip, gw net.IP) error {
+	return errors.New("Debugging error")
 	return cmdutil.SudoExec("ip", "route", "add", ip.String(), "via", gw.String())
 }
 
```