### PR TITLE
win: fix wfp and reenable it

### DIFF
--- a/supervisor/daemon/wireguard/wginterface/firewall/blocker.go
+++ b/supervisor/daemon/wireguard/wginterface/firewall/blocker.go
@@ -119,7 +119,12 @@ func EnableFirewall(luid uint64, doNotRestrict bool, restrictToDNSServers []net.
 			return wrapErr(err)
 		}
 
-		err = permitWireGuardService(session, baseObjects, 15)
+		err = permitSupervisorWireGuardService(session, baseObjects, 15)
+		if err != nil {
+			return wrapErr(err)
+		}
+
+		err = permitMystWireGuardService(session, baseObjects, 15)
 		if err != nil {
 			return wrapErr(err)
 		}

--- a/supervisor/daemon/wireguard/wginterface/firewall/helpers.go
+++ b/supervisor/daemon/wireguard/wginterface/firewall/helpers.go
@@ -10,11 +10,16 @@ package firewall
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
+)
+
+const (
+	MYST_EXECUTABLE = "myst.exe"
 )
 
 func runTransaction(session uintptr, operation wfpObjectInstaller) error {
@@ -134,6 +139,27 @@ func getCurrentProcessAppID() (*wtFwpByteBlob, error) {
 	if err != nil {
 		return nil, wrapErr(err)
 	}
+
+	curFilePtr, err := windows.UTF16PtrFromString(currentFile)
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+
+	var appID *wtFwpByteBlob
+	err = fwpmGetAppIdFromFileName0(curFilePtr, unsafe.Pointer(&appID))
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	return appID, nil
+}
+
+func getMystAppID() (*wtFwpByteBlob, error) {
+	currentFile, err := os.Executable()
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+
+	currentFile = filepath.Join(filepath.Dir(currentFile), MYST_EXECUTABLE)
 
 	curFilePtr, err := windows.UTF16PtrFromString(currentFile)
 	if err != nil {

--- a/supervisor/daemon/wireguard/wginterface/interface_windows.go
+++ b/supervisor/daemon/wireguard/wginterface/interface_windows.go
@@ -49,12 +49,9 @@ func createTunnel(interfaceName string, dns []string) (tunnel tun.Device, _ stri
 		dnsIPs = append(dnsIPs, net.ParseIP(d))
 	}
 
-	// TODO temporary disable Windows DNS firewall blocking, this creates connection problems.
-	if false {
-		err = firewall.EnableFirewall(nativeTun.LUID(), false, dnsIPs)
-		if err != nil {
-			log.Warn().Err(err).Msg("Unable to enable DNS firewall rules")
-		}
+	err = firewall.EnableFirewall(nativeTun.LUID(), false, dnsIPs)
+	if err != nil {
+		log.Warn().Err(err).Msg("Unable to enable DNS firewall rules")
 	}
 
 	wintunVersion, ndisVersion, err := nativeTun.Version()
@@ -79,5 +76,5 @@ func applySocketPermissions(_ string, _ string) error {
 }
 
 func disableFirewall() {
-	// firewall.DisableFirewall()
+	firewall.DisableFirewall()
 }


### PR DESCRIPTION
Fix #3462

Revamps efforts of PR #3338. Previous attempt wasn't successful and lead to breakage of P2P channel. It happens because WFP code implemented in that change built with assumption there is single process which holds WG connection. But we need to allow direct traffic for user-mode process as well. For this reason I introduce another allow rule for myst.exe which matches traffic by it's WFP AppID.

Suggestions are welcome.