### PR TITLE
Better command parsing: support multiword args

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -57,9 +57,16 @@ func (c *cliApp) identities(argsString string) (err error) {
 		return
 	}
 
-	args := strings.Fields(argsString)
-	action := args[0]
-	actionArgs := args[1:]
+	if err = validateArgs(argsString); err != nil {
+		clio.Error(err)
+		return
+	}
+
+	action, actionArgs, err := parseCommandAndArgs(argsString)
+	if err != nil {
+		clio.Error(err)
+		return
+	}
 
 	switch action {
 	case "list":

--- a/cmd/commands/cli/command_orders.go
+++ b/cmd/commands/cli/command_orders.go
@@ -46,9 +46,16 @@ func (c *cliApp) order(argsString string) (err error) {
 		return errWrongArgumentCount
 	}
 
-	args := strings.Fields(argsString)
-	action := args[0]
-	actionArgs := args[1:]
+	if err = validateArgs(argsString); err != nil {
+		clio.Error(err)
+		return
+	}
+
+	action, actionArgs, err := parseCommandAndArgs(argsString)
+	if err != nil {
+		clio.Error(err)
+		return
+	}
 
 	switch action {
 	case "create":

--- a/cmd/commands/cli/command_stake.go
+++ b/cmd/commands/cli/command_stake.go
@@ -40,9 +40,16 @@ func (c *cliApp) stake(argsString string) (err error) {
 		return errWrongArgumentCount
 	}
 
-	args := strings.Fields(argsString)
-	action := args[0]
-	actionArgs := args[1:]
+	if err = validateArgs(argsString); err != nil {
+		clio.Error(err)
+		return
+	}
+
+	action, actionArgs, err := parseCommandAndArgs(argsString)
+	if err != nil {
+		clio.Error(err)
+		return
+	}
 
 	switch action {
 	case "increase":

--- a/cmd/commands/cli/util.go
+++ b/cmd/commands/cli/util.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"errors"
+	"strings"
+)
+
+func parseCommandAndArgs(args string) (string, []string, error) {
+	quoted := false
+	fields := strings.FieldsFunc(args, func(r rune) bool {
+		if r == '"' || r == '\'' {
+			quoted = !quoted
+		}
+		return !quoted && r == ' '
+	})
+
+	switch len(fields) {
+	case 0:
+		return "", nil, errors.New("no command provided")
+	case 1:
+		return fields[0], []string{}, nil
+	default:
+		cmd := fields[0]
+		cmdArgs := fields[1:]
+		clean := make([]string, 0)
+
+		for _, v := range cmdArgs {
+			switch {
+			case strings.Contains(v, "'"):
+				v = strings.ReplaceAll(v, "'", "")
+			case strings.Contains(v, "\""):
+				v = strings.ReplaceAll(v, "\"", "")
+			}
+			clean = append(clean, v)
+		}
+
+		return cmd, clean, nil
+	}
+}
+
+func validateArgs(args string) error {
+	countSingle := strings.Count(args, "'")
+	countDouble := strings.Count(args, "\"")
+
+	if countSingle%2 != 0 || countDouble%2 != 0 {
+		return errors.New("wrong format command strings starting with ' or \" should be closed")
+	}
+
+	return nil
+}

--- a/cmd/commands/cli/util_test.go
+++ b/cmd/commands/cli/util_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseCommandAndArgs(t *testing.T) {
+	for _, test := range []struct {
+		args string
+
+		expectedCmd  string
+		expectedArgs []string
+	}{
+		{
+			args: "cmd",
+
+			expectedCmd:  "cmd",
+			expectedArgs: []string{},
+		},
+		{
+			args: "cmd arg1 arg2",
+
+			expectedCmd:  "cmd",
+			expectedArgs: []string{"arg1", "arg2"},
+		},
+		{
+			args: `cmd "arg1 arg2" arg3`,
+
+			expectedCmd:  "cmd",
+			expectedArgs: []string{"arg1 arg2", "arg3"},
+		},
+		{
+			args: `cmd 'arg1 arg2' arg3`,
+
+			expectedCmd:  "cmd",
+			expectedArgs: []string{"arg1 arg2", "arg3"},
+		},
+		{
+			args: `cmd 'arg1' "arg2" arg3`,
+
+			expectedCmd:  "cmd",
+			expectedArgs: []string{"arg1", "arg2", "arg3"},
+		},
+		{
+			args: `cmd 'arg1 arg2' "arg3 arg4"`,
+
+			expectedCmd:  "cmd",
+			expectedArgs: []string{"arg1 arg2", "arg3 arg4"},
+		},
+	} {
+		gotCmd, gotArgs, err := parseCommandAndArgs(test.args)
+		assert.NoError(t, err)
+
+		assert.Equal(t, test.expectedCmd, gotCmd)
+		assert.Equal(t, test.expectedArgs, gotArgs)
+	}
+}


### PR DESCRIPTION
Support arguments surounded in quotes and count them as a single word.
Can be useful in places like identity export: `identities export 0x0 pass "/tmp/my dir/a.sjon"`

Before this `"` wasn't really supported correctly if included in the arguments, so this breaks nothing.

Closes: https://github.com/mysteriumnetwork/node/issues/3738