### PR TITLE
Port check routine

### DIFF
--- a/cmd/portcheck/main.go
+++ b/cmd/portcheck/main.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mysteriumnetwork/node/core/port"
+)
+
+const addressListSeparator = ","
+
+var (
+	serverAddress = flag.String("server", "vm-0.com:4589", "asymmetric UDP echo server")
+	reqTimeout    = flag.Duration("req-timeout", 1*time.Second, "timeout to wait for UDP response")
+	checkedPort   = flag.Int("port", 12345, "checked port")
+	totalTimeout  = flag.Duration("total-timeout", 3*time.Second, "overall operation deadline")
+//	raw           = flag.Bool("raw", false, "print raw NAT_TYPE_* value")
+)
+
+func run() int {
+	flag.Parse()
+
+	ctx, cl := context.WithTimeout(context.Background(), *totalTimeout)
+	defer cl()
+	res, err := port.GloballyReachable(ctx, port.Port(*checkedPort), *serverAddress, *reqTimeout)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return 1
+	}
+	fmt.Println(res)
+	return 0
+}
+
+func main() {
+	os.Exit(run())
+}

--- a/core/port/reachability.go
+++ b/core/port/reachability.go
@@ -107,7 +107,7 @@ func GloballyReachable(ctx context.Context, port Port, echoServerAddresses []str
 	}
 
 	// Await response
-	ctx1, cl := context.WithTimeout(ctx, timeout)
+	ctx, cl := context.WithTimeout(ctx, timeout)
 	defer cl()
 	responseChan := make(chan struct{})
 
@@ -131,7 +131,7 @@ func GloballyReachable(ctx context.Context, port Port, echoServerAddresses []str
 				select {
 				case responseChan <- struct{}{}:
 					return
-				case <-ctx1.Done():
+				case <-ctx.Done():
 					return
 				}
 			}
@@ -142,7 +142,7 @@ func GloballyReachable(ctx context.Context, port Port, echoServerAddresses []str
 	select {
 	case <-responseChan:
 		return true, nil
-	case <-ctx1.Done():
+	case <-ctx.Done():
 		return false, nil
 	}
 }

--- a/core/port/reachability.go
+++ b/core/port/reachability.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package port
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"net"
+	"time"
+
+	"github.com/gofrs/uuid"
+)
+
+const (
+	PortFieldSize = 2
+	UUIDSize      = uuid.Size
+	PacketSize    = PortFieldSize + UUIDSize
+	SendPackets   = 3
+)
+
+// GloballyReachable checks if UDP port is reachable from global Internet,
+// performing probe against asymmetric UDP echo server
+func GloballyReachable(ctx context.Context, port Port, echoServerAddress string, timeout time.Duration) (bool, error) {
+	// Claim port
+	rxAddr := &net.UDPAddr{
+		Port: port.Num(),
+	}
+
+	rxSock, err := net.ListenUDP("udp", rxAddr)
+	if err != nil {
+		return false, err
+	}
+	defer rxSock.Close()
+
+	// Send probe
+	dialer := net.Dialer{}
+	txSock, err := dialer.DialContext(ctx, "udp", echoServerAddress)
+	if err != nil {
+		return false, err
+	}
+	defer txSock.Close()
+
+	msg := make([]byte, PacketSize)
+	binary.BigEndian.PutUint16(msg, uint16(port.Num()))
+
+	probeUUID, err := uuid.NewV4()
+	if err != nil {
+		return false, err
+	}
+	copy(msg[PortFieldSize:], probeUUID[:])
+
+	for i := 0; i < 3; i++ {
+		_, err = txSock.Write(msg)
+		if err != nil && i == 0 {
+			return false, err
+		}
+	}
+
+	// Await response
+	ctx1, cl := context.WithTimeout(ctx, timeout)
+	defer cl()
+	responseChan := make(chan struct{})
+
+	// Background context-aware receiver
+	go func() {
+		buf := make([]byte, uuid.Size)
+		for {
+			n, _, err := rxSock.ReadFromUDP(buf)
+			if err != nil {
+				if n == 0 {
+					return
+				}
+				continue
+			}
+
+			if n < uuid.Size {
+				continue
+			}
+
+			if bytes.Equal(buf, probeUUID[:]) {
+				select {
+				case responseChan <- struct{}{}:
+					return
+				case <-ctx1.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	// Either response will be receiver or not (context timeout)
+	select {
+	case <-responseChan:
+		return true, nil
+	case <-ctx1.Done():
+		return false, nil
+	}
+}


### PR DESCRIPTION
This PR implements external UDP port check routine.

Not integrating routine into node in this PR for two reasons:

* Keep size reviewable.
* @soffokl is now already working on changes in P2PListener which I'm about to touch too.