### PR TITLE
Fix auto settle with 0 stake

### DIFF
--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -976,9 +976,7 @@ func (ss settlementState) needsSettling(threshold float64, channel HermesChannel
 
 	if channel.Channel.Stake.Cmp(big.NewInt(0)) == 0 {
 		// if starting with zero stake, only settle one myst or more.
-		if channel.UnsettledBalance().Cmp(big.NewInt(0).SetUint64(crypto.Myst)) == -1 {
-			return false
-		}
+		return channel.UnsettledBalance().Cmp(big.NewInt(0).SetUint64(crypto.Myst)) == 1
 	}
 
 	floated := new(big.Float).SetInt(channel.availableBalance())


### PR DESCRIPTION
Providers with 0 stake would settle promises incorrectly.

They should only settle amounts larger than 1 myst, they used to settle anything that was larger than the fee.