### PR TITLE
Fix test stability regarding balance checks

### DIFF
--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -468,9 +468,12 @@ func providerRegistrationFlow(t *testing.T, tequilapi *tequilapi_client.Client, 
 	// once we're registered, check some other information
 	idStatus, err := tequilapi.Identity(id)
 	assert.NoError(t, err)
+	balance, err := tequilapi.BalanceRefresh(id)
+	assert.NoError(t, err)
+
 	assert.Equal(t, "Registered", idStatus.RegistrationStatus)
 	assert.Equal(t, providerChannelAddress, idStatus.ChannelAddress)
-	assert.Equal(t, balanceAfterRegistration, idStatus.Balance)
+	assert.Equal(t, balanceAfterRegistration, balance.Balance)
 	assert.Zero(t, idStatus.Earnings.Uint64())
 	assert.Zero(t, idStatus.EarningsTotal.Uint64())
 }

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -159,7 +159,21 @@ func (client *Client) CurrentIdentity(identity, passphrase string) (id contract.
 	return id, err
 }
 
-// Identity returns identity status with current balance
+// BalanceRefresh forces a balance refresh if possible and returns the latest balance.
+func (client *Client) BalanceRefresh(identityAddress string) (b contract.BalanceDTO, err error) {
+	path := fmt.Sprintf("identities/%s/balance/refresh", identityAddress)
+
+	response, err := client.http.Put(path, nil)
+	if err != nil {
+		return b, err
+	}
+	defer response.Body.Close()
+
+	err = parseResponseJSON(response, &b)
+	return b, err
+}
+
+// Identity returns identity status with cached balance
 func (client *Client) Identity(identityAddress string) (id contract.IdentityDTO, err error) {
 	path := fmt.Sprintf("identities/%s", identityAddress)
 


### PR DESCRIPTION
Force refresh balance after registration before checking it. Balance is cached for some time after latest balance keeper changes which can return a out of sync balance in[ tests making them fail](https://storage.googleapis.com/gitlab-gprd-artifacts/94/53/94532daf5e00f4a12510f1d4f36725eb23f0e0a8302d368587a1a64ccafdf434/2021_08_25/1532105457/1649995491/job.log?response-content-type=text%2Fplain%3B%20charset%3Dutf-8&response-content-disposition=inline&GoogleAccessId=gitlab-object-storage-prd@gitlab-production.iam.gserviceaccount.com&Signature=iOvwAhyq%2BFNzmA%2FNx2CM7cLL3YCtq9USMbi8ZHplAwPhI%2FuCfIChIlFEIg1Y%0AhL1MCqHXemfwdu38sNSerDRtXRU5vaxtu%2F3%2Fb2g5EzGkmoMvlQervDD0AwiG%0A2fIDUIt51eG6PixsVuqyu4gbTGVOTj8ZvE8E7UfUnRlxFtaHHUHnpofJbepW%0Al0wsEAJ%2F1mDPP29l8u%2F%2F0TLZVPEfNhMEK7ZyZxYZjdFr0q3RmEeiUXI%2BrIxO%0ArUBcOTX1AaFEU2hlvtZRtQVwYWOrIRFcdFw5atc3AKyTvHeUY15KdTdvAAac%0Ai9y9Kck8nB7DQgOOZ0o3W%2FhvGm0TnnQ8mgGvrb96Rg%3D%3D&Expires=1629875287).