### PR TITLE
don't exclude routes for killswitch for now

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -1040,7 +1040,10 @@ func (di *Dependencies) AllowURLAccess(servers ...string) error {
 		return err
 	}
 
-	if config.GetBool(config.FlagKeepConnectedOnFail) {
+	// Doesn't work as expected because some services share IP address with
+	// each other and with location oracle which is supposed to be routed
+	// through VPN tunnel.
+	if false && config.GetBool(config.FlagKeepConnectedOnFail) {
 		if err := router.AllowURLAccess(servers...); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR makes killswitch work on desktop at least on par with mobile node for Android.

Split tunneling with separate routes doesn't work as expected, we've got to use something like fd protection on Android. On Android this feature doesn't give a trouble because `utils/netutils.excludeRoute` is a noop stub for Android.

Fix #3483