### PR TITLE
Periodic sync should stop when channel is closed

### DIFF
--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -281,6 +281,8 @@ func (cbt *ConsumerBalanceTracker) periodicSync(stop <-chan struct{}, chainID in
 		select {
 		case <-cbt.stop:
 			return
+		case <-stop:
+			return
 		case <-time.After(syncPeriod):
 			_ = cbt.ForceBalanceUpdate(chainID, id)
 		}


### PR DESCRIPTION
without this change every single topup creates a never ending loop where we call blockchain to sync our balance every 30 seconds