### PR TITLE
Fixed withdraw bug in cli

### DIFF
--- a/cmd/commands/cli/command.go
+++ b/cmd/commands/cli/command.go
@@ -641,6 +641,7 @@ func newAutocompleter(tequilapi *tequilapi_client.Client, proposals []contract.P
 			readline.PcItem("referralcode", readline.PcItemDynamic(getIdentityOptionList(tequilapi))),
 			readline.PcItem("export", readline.PcItemDynamic(getIdentityOptionList(tequilapi))),
 			readline.PcItem("import"),
+			readline.PcItem("withdraw", readline.PcItemDynamic(getIdentityOptionList(tequilapi))),
 		),
 		readline.PcItem("status"),
 		readline.PcItem(


### PR DESCRIPTION
Withdraw option is now showing under help and works with autocompletion

Closes: https://github.com/mysteriumnetwork/node/issues/3884

Signed-off-by: Guillem <guillem@mysterium.network>