### PR TITLE
Fix withdrawal fee issue

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -311,7 +311,7 @@ func (di *Dependencies) bootstrapAddressProvider(nodeOptions node.Options) {
 	}
 
 	keeper := client.NewMultiChainAddressKeeper(addresses)
-	di.AddressProvider = pingpong.NewAddressProvider(keeper, common.HexToAddress(nodeOptions.Transactor.Identity))
+	di.AddressProvider = pingpong.NewAddressProvider(keeper)
 }
 
 func (di *Dependencies) bootstrapP2P() {

--- a/config/flags_transactor.go
+++ b/config/flags_transactor.go
@@ -31,12 +31,6 @@ var (
 		Usage: "Transactor URL address",
 		Value: metadata.DefaultNetwork.TransactorAddress,
 	}
-	// FlagTransactorIdentity is the identity of the transactor which is used.
-	FlagTransactorIdentity = cli.StringFlag{
-		Name:  "transactor.identity-address",
-		Usage: "the identity of the in use transactor",
-		Value: metadata.DefaultNetwork.TransactorIdentity,
-	}
 	// FlagTransactorProviderMaxRegistrationAttempts determines the number of registration attempts that the provider will attempt before giving up.
 	FlagTransactorProviderMaxRegistrationAttempts = cli.IntFlag{
 		Name:  "transactor.provider.max-registration-attempts",
@@ -56,7 +50,6 @@ func RegisterFlagsTransactor(flags *[]cli.Flag) {
 	*flags = append(
 		*flags,
 		&FlagTransactorAddress,
-		&FlagTransactorIdentity,
 		&FlagTransactorProviderMaxRegistrationAttempts,
 		&FlagTransactorProviderRegistrationRetryDelay,
 	)
@@ -64,7 +57,6 @@ func RegisterFlagsTransactor(flags *[]cli.Flag) {
 
 // ParseFlagsTransactor function fills in transactor options from CLI context
 func ParseFlagsTransactor(ctx *cli.Context) {
-	Current.ParseStringFlag(ctx, FlagTransactorIdentity)
 	Current.ParseStringFlag(ctx, FlagTransactorAddress)
 	Current.ParseIntFlag(ctx, FlagTransactorProviderMaxRegistrationAttempts)
 	Current.ParseDurationFlag(ctx, FlagTransactorProviderRegistrationRetryDelay)

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -143,7 +143,6 @@ func GetOptions() *Options {
 			IPType:        config.GetString(config.FlagLocationIPType),
 		},
 		Transactor: OptionsTransactor{
-			Identity:                        config.GetString(config.FlagTransactorIdentity),
 			TransactorEndpointAddress:       config.GetString(config.FlagTransactorAddress),
 			ProviderMaxRegistrationAttempts: config.GetInt(config.FlagTransactorProviderMaxRegistrationAttempts),
 			ProviderRegistrationRetryDelay:  config.GetDuration(config.FlagTransactorProviderRegistrationRetryDelay),

--- a/core/node/options_transactor.go
+++ b/core/node/options_transactor.go
@@ -23,7 +23,6 @@ import (
 
 // OptionsTransactor describes possible parameters for interaction with transactor
 type OptionsTransactor struct {
-	Identity                        string
 	TransactorEndpointAddress       string
 	ProviderMaxRegistrationAttempts int
 	ProviderRegistrationRetryDelay  time.Duration

--- a/session/pingpong/address_provider.go
+++ b/session/pingpong/address_provider.go
@@ -27,14 +27,12 @@ import (
 // AddressProvider can calculate channel addresses as well as provide SC addresses for various chains.
 type AddressProvider struct {
 	*client.MultiChainAddressKeeper
-	transactorAddress common.Address
 }
 
 // NewAddressProvider returns a new instance of AddressProvider.
-func NewAddressProvider(multichainAddressKeeper *client.MultiChainAddressKeeper, transactorAddress common.Address) *AddressProvider {
+func NewAddressProvider(multichainAddressKeeper *client.MultiChainAddressKeeper) *AddressProvider {
 	return &AddressProvider{
 		MultiChainAddressKeeper: multichainAddressKeeper,
-		transactorAddress:       transactorAddress,
 	}
 }
 
@@ -61,9 +59,4 @@ func (ap *AddressProvider) GetChannelAddress(chainID int64, id identity.Identity
 func (ap *AddressProvider) GetArbitraryChannelAddress(hermes, registry, channel common.Address, id identity.Identity) (common.Address, error) {
 	addr, err := crypto.GenerateChannelAddress(id.Address, hermes.Hex(), registry.Hex(), channel.Hex())
 	return common.HexToAddress(addr), err
-}
-
-// GetTransactorAddress returns the transactor address.
-func (ap *AddressProvider) GetTransactorAddress() common.Address {
-	return ap.transactorAddress
 }

--- a/session/pingpong/consumer_balance_tracker_test.go
+++ b/session/pingpong/consumer_balance_tracker_test.go
@@ -429,9 +429,6 @@ type mockAddressProvider struct {
 	addrToReturn common.Address
 }
 
-func (ma *mockAddressProvider) GetTransactorAddress() common.Address {
-	return ma.transactor
-}
 func (ma *mockAddressProvider) GetChannelAddress(chainID int64, id identity.Identity) (common.Address, error) {
 	return ma.addrToReturn, nil
 }

--- a/session/pingpong/hermes_promise_handler_test.go
+++ b/session/pingpong/hermes_promise_handler_test.go
@@ -46,6 +46,7 @@ func TestHermesPromiseHandler_RequestPromise(t *testing.T) {
 		queue: make(chan enqueuedRequest),
 		stop:  make(chan struct{}),
 	}
+	aph.transactorFees = make(map[int64]registry.FeesResponse)
 	err := aph.Subscribe(bus)
 	assert.NoError(t, err)
 	bus.Publish(event.AppTopicNode, event.Payload{
@@ -88,6 +89,7 @@ func TestHermesPromiseHandler_RequestPromise_BubblesErrors(t *testing.T) {
 		queue: make(chan enqueuedRequest),
 		stop:  make(chan struct{}),
 	}
+	aph.transactorFees = make(map[int64]registry.FeesResponse)
 	err := aph.Subscribe(bus)
 	assert.NoError(t, err)
 	bus.Publish(event.AppTopicNode, event.Payload{

--- a/session/pingpong/hermes_url_getter.go
+++ b/session/pingpong/hermes_url_getter.go
@@ -35,7 +35,6 @@ type HermesURLGetter struct {
 }
 
 type addressProvider interface {
-	GetTransactorAddress() common.Address
 	GetChannelAddress(chainID int64, id identity.Identity) (common.Address, error)
 	GetArbitraryChannelAddress(hermes, registry, channel common.Address, id identity.Identity) (common.Address, error)
 	GetChannelImplementation(chainID int64) (common.Address, error)


### PR DESCRIPTION
When withdrawing, the fee would at first be set to the incorrect chains' fee and updated prior to sending to transactor with the correct one. It now is set to the correct fee.

Also removed redundant transactor identity flag.

All tested and example can be found here:
https://testnet3-hermes.mysterium.network/api/v1/data/provider/0xb861f881b489858b698dc43577b8d3b52994513d