### PR TITLE
p2p: add fuzzing test for message serializer

### DIFF
--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -1,0 +1,55 @@
+package p2p
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"net/textproto"
+	"testing"
+)
+
+// Size of Ethereum signature, for instance
+const randomDataSize = 65
+const fuzzingIterations = 1_000_000
+
+func randomData() ([]byte, error) {
+	data := make([]byte, randomDataSize)
+	_, err := rand.Read(data)
+	return data, err
+}
+
+func roundTrip(t *testing.T) {
+	var out bytes.Buffer
+	conn := textproto.NewWriter(bufio.NewWriter(&out))
+	conn2 := textproto.NewReader(bufio.NewReader(&out))
+
+	data, err := randomData()
+	if err != nil {
+		t.Fatalf("Can't generate random data portion: %v", err)
+	}
+
+	msg := transportMsg{
+		topic: "test",
+		data:  data,
+	}
+	err = msg.writeTo(conn)
+	if err != nil {
+		t.Fatalf("Can't write data into conn: %v", err)
+	}
+
+	var msg2 transportMsg
+	err = msg2.readFrom(conn2)
+	if err != nil {
+		t.Fatalf("Can't read data from conn2: %v", err)
+	}
+
+	if bytes.Compare(msg.data, msg2.data) != 0 {
+		t.Fatalf("Data wasn't properly recovered: original %x != recovered %x", msg.data, msg2.data)
+	}
+}
+
+func TestTransportMessageFuzzing(t *testing.T) {
+	for i := 0; i < fuzzingIterations; i++ {
+		roundTrip(t)
+	}
+}


### PR DESCRIPTION
This PR adds test which always fails. It is intended to illustrate and prove critical bug which affects P2P channel communication and corrupts messages containing binary data. This PR is not intended to be merged now.

It turns out, our transport messages are serialized with net/textproto which is only suitable for text protocols. Due to its text nature, following distortions will occur:

- If message last byte is `0x0a`, it will be stripped.
- If message last byte is `0x0d`, it will be stripped.
- If message contains sequence `0x0d0a`, it will be replaced with `0x0a` byte.

Fuzzing experiment indicate that if message contains, for example, 65 bytes of uniformly distributed binary data (like sec256k1 ethereum signature), there is ~1% chance for message to arrive corrupted on the other end.

Also, as [noted in documentation](https://pkg.go.dev/net/textproto#NewReader) for "net/textproto" module, denial of service attack is possible if remote peer is able to exhaust node memory within time period limited by channel message read timeout.

Fix of this bug will require to change P2P message serialization format, rendering new protocol incompatible with old one. Therefore, new protocol must be negotiated out of band, with some additional attribute in providers' proposals.