### PR TITLE
Do not quit on unknown Hermes error

### DIFF
--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -561,8 +561,11 @@ func (it *InvoiceTracker) handleHermesError(err error) error {
 		)
 		return err
 	default:
-		log.Err(err).Msgf("unknown hermes error encountered")
-		return err
+		if it.incrementHermesFailureCount() > it.deps.MaxHermesFailureCount {
+			return err
+		}
+		log.Warn().Err(err).Msg("unknown hermes error encountered, will retry")
+		return nil
 	}
 }
 

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -687,8 +687,13 @@ func TestInvoiceTracker_handleHermesError(t *testing.T) {
 			err:                   ErrHermesHashlockMissmatch,
 		},
 		{
-			name:                  "returns unknown error",
-			wantErr:               errors.New("unknown error"),
+			name:    "returns unknown error if failures exceeded",
+			wantErr: errors.New("unknown error"),
+			err:     errors.New("unknown error"),
+		},
+		{
+			name:                  "returns nil on unknown error if failures not exceeded",
+			wantErr:               nil,
 			maxHermesFailureCount: 100,
 			err:                   errors.New("unknown error"),
 		},


### PR DESCRIPTION
This would improve session stablity, as errors such as timeouts would not interrupt the session.