### PR TITLE
Add more logs for price calculation

### DIFF
--- a/session/pingpong/price_calculator.go
+++ b/session/pingpong/price_calculator.go
@@ -21,9 +21,10 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/mysteriumnetwork/node/datasize"
 	"github.com/mysteriumnetwork/node/market"
-	"github.com/rs/zerolog/log"
 )
 
 // CalculatePaymentAmount calculates the required payment amount.
@@ -48,6 +49,7 @@ func CalculatePaymentAmount(timePassed time.Duration, bytesTransferred DataTrans
 	bc, _ := dataComponent.Int(nil)
 
 	total := new(big.Int).Add(tc, bc)
-	log.Debug().Msgf("Calculated price %v. Time component: %v, data component: %v ", total, timeComponent, dataComponent)
+	log.Debug().Msgf("Calculated price %v. Time component: %v, data component: %v. Transferred: %v, duration: %v. Price %v",
+		total, timeComponent, dataComponent, bytesTransferred.sum(), timePassed.Seconds(), price.String())
 	return total
 }


### PR DESCRIPTION
Trying to catch price calculation problem in `e56059ae-873c-470e-968d-0a537b69b37a` session:
![image](https://user-images.githubusercontent.com/8612618/134275563-900aadc7-01ea-40a3-b876-104bfb897bd7.png)
![image](https://user-images.githubusercontent.com/8612618/134275622-d64e8f7e-54e4-42b2-9e3e-b46bf5705471.png)
