### PR TITLE
Restrict Host header values for TequilAPI

### DIFF
--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -175,7 +175,7 @@ var (
 	FlagTequilapiAllowedHostnames = cli.StringFlag{
 		Name:  "tequilapi.allowed-hostnames",
 		Usage: "Comma separated list of allowed domains. Prepend value with dot for wildcard mask",
-		Value: ".localhost",
+		Value: ".localhost, localhost, .localdomain",
 	}
 	// FlagTequilapiPort port for listening for incoming API requests.
 	FlagTequilapiPort = cli.IntFlag{

--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -171,6 +171,12 @@ var (
 		Usage: "IP address to bind API to",
 		Value: "127.0.0.1",
 	}
+	// FlagTequilapiAllowedHostnames Restrict hostnames in requests' Host header to following domains.
+	FlagTequilapiAllowedHostnames = cli.StringFlag{
+		Name:  "tequilapi.allowed-hostnames",
+		Usage: "Comma separated list of allowed domains. Prepend value with dot for wildcard mask",
+		Value: ".localhost",
+	}
 	// FlagTequilapiPort port for listening for incoming API requests.
 	FlagTequilapiPort = cli.IntFlag{
 		Name:  "tequilapi.port",
@@ -322,6 +328,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		&FlagQualityType,
 		&FlagQualityAddress,
 		&FlagTequilapiAddress,
+		&FlagTequilapiAllowedHostnames,
 		&FlagTequilapiPort,
 		&FlagTequilapiUsername,
 		&FlagTequilapiPassword,
@@ -377,6 +384,7 @@ func ParseFlagsNode(ctx *cli.Context) {
 	Current.ParseStringFlag(ctx, FlagQualityAddress)
 	Current.ParseStringFlag(ctx, FlagQualityType)
 	Current.ParseStringFlag(ctx, FlagTequilapiAddress)
+	Current.ParseStringFlag(ctx, FlagTequilapiAllowedHostnames)
 	Current.ParseIntFlag(ctx, FlagTequilapiPort)
 	Current.ParseStringFlag(ctx, FlagTequilapiUsername)
 	Current.ParseStringFlag(ctx, FlagTequilapiPassword)

--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -335,6 +335,7 @@ services:
       --firewall.protected.networks=""
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --transactor.address=http://transactor:8888/api/v1
       --keystore.lightweight
@@ -396,6 +397,7 @@ services:
       --log-level=debug
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --ether.client.rpcl2=ws://ganache2:8545
       --ether.client.rpcl1=http://ganache:8545
@@ -445,6 +447,7 @@ services:
       --log-level=debug
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --ether.client.rpcl2=ws://ganache2:8545
       --ether.client.rpcl1=http://ganache:8545
@@ -494,6 +497,7 @@ services:
       --log-level=debug
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --ether.client.rpcl2=ws://ganache2:8545
       --ether.client.rpcl1=http://ganache:8545
@@ -543,6 +547,7 @@ services:
       --log-level=debug
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --ether.client.rpcl2=ws://ganache2:8545
       --ether.client.rpcl1=http://ganache:8545

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -441,6 +441,7 @@ services:
       --log-level=debug
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --chains.2.myst=0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
       --chains.2.registry=0x241F6e1d0bB17f45767DC60A6Bd3D21Cdb543a0c
@@ -545,6 +546,7 @@ services:
       --log-level=debug
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --chains.2.myst=0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
       --chains.2.registry=0x241F6e1d0bB17f45767DC60A6Bd3D21Cdb543a0c
@@ -605,6 +607,7 @@ services:
       --log-level=debug
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --api.address=http://discovery:8080/api/v3
       --chains.2.myst=0x4D1d104AbD4F4351a0c51bE1e9CA0750BbCa1665
       --chains.2.registry=0x241F6e1d0bB17f45767DC60A6Bd3D21Cdb543a0c
@@ -668,6 +671,7 @@ services:
       --chain-id=80001
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --ether.client.rpcl2=ws://ganache2:8545
       --ether.client.rpcl1=http://ganache:8545
       --api.address=http://discovery:8080/api/v3
@@ -717,6 +721,7 @@ services:
       --location.country=e2e-land
       --broker-address=broker
       --tequilapi.address=0.0.0.0
+      --tequilapi.allowed-hostnames=.
       --firewall.protected.networks=""
       --chains.1.registry=0x241F6e1d0bB17f45767DC60A6Bd3D21Cdb543a0c
       --chains.1.chainID=5

--- a/tequilapi/http_api_server.go
+++ b/tequilapi/http_api_server.go
@@ -65,6 +65,7 @@ func NewServer(
 	g.Use(middlewares.ApplyCacheConfigMiddleware)
 	g.Use(gin.Recovery())
 	g.Use(cors.New(corsConfig))
+	g.Use(middlewares.NewHostFilter())
 
 	for _, h := range handlers {
 		err := h(g)

--- a/tequilapi/middlewares/http_middlewares.go
+++ b/tequilapi/middlewares/http_middlewares.go
@@ -18,12 +18,81 @@
 package middlewares
 
 import (
+	"net"
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/mysteriumnetwork/node/config"
 )
 
 // ApplyCacheConfigMiddleware forces no caching policy via "Cache-control" header
 func ApplyCacheConfigMiddleware(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Cache-control", strings.Join([]string{"no-cache", "no-store", "must-revalidate"}, ", "))
+}
+
+func normalizeHostname(hostname string) string {
+	return strings.ToLower(
+		strings.TrimRight(
+			strings.TrimSpace(hostname),
+			".",
+		),
+	)
+}
+
+// NewHostFilter returns instance of middleware allowing only requests
+// with allowed domains in Host header
+func NewHostFilter() func(*gin.Context) {
+	domainList := strings.Split(config.GetString(config.FlagTequilapiAllowedHostnames), ",")
+	exactList := make(map[string]struct{})
+	suffixList := make(map[string]struct{})
+	for _, domain := range domainList {
+		domain = strings.TrimSpace(domain)
+		normalized := normalizeHostname(domain)
+		if strings.Index(domain, ".") == 0 {
+			// suffix pattern
+			suffixList[strings.TrimLeft(normalized, ".")] = struct{}{}
+		} else {
+			// exact domain name
+			exactList[normalized] = struct{}{}
+		}
+	}
+	return func(c *gin.Context) {
+		// handle special case of root suffix (".")
+		if _, found := suffixList[""] ; found {
+			return
+		}
+
+		host := c.Request.Host
+		if host == "" {
+			return
+		}
+
+		hostname, _, err := net.SplitHostPort(host)
+		if err != nil {
+			// There was no port, so we assume the address was just a hostname
+			hostname = host
+		}
+
+		if net.ParseIP(hostname) != nil {
+			return
+		}
+
+		hostname = normalizeHostname(hostname)
+
+		// check for exact match
+		if _, found := exactList[hostname]; found {
+			return
+		}
+
+		// check for suffix match
+		for needle := strings.Split(hostname, ".")[1:] ; len(needle) > 0 ; needle = needle[1:] {
+			if _, found := suffixList[strings.Join(needle, ".")] ; found {
+				return
+			}
+		}
+
+		c.AbortWithStatus(http.StatusForbidden)
+	}
 }

--- a/utils/domain/whitelist.go
+++ b/utils/domain/whitelist.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package domain
+
+import (
+	"strings"
+)
+
+// NormalizeHostname casts FQDN to canonical representation:
+// no whitespace, no trailing dot, lower case.
+func NormalizeHostname(hostname string) string {
+	return strings.ToLower(
+		strings.TrimRight(
+			strings.TrimSpace(hostname),
+			".",
+		),
+	)
+}
+
+// Whitelist is a set of domain names and suffixes for fast matching
+type Whitelist struct {
+	exactList  map[string]struct{}
+	suffixList map[string]struct{}
+}
+
+// NewWhitelist creates Whitelist from list of domains and suffixes
+func NewWhitelist(domainList []string) *Whitelist {
+	exactList := make(map[string]struct{})
+	suffixList := make(map[string]struct{})
+	for _, domain := range domainList {
+		domain = strings.TrimSpace(domain)
+		normalized := NormalizeHostname(domain)
+		if strings.Index(domain, ".") == 0 {
+			// suffix pattern
+			suffixList[strings.TrimLeft(normalized, ".")] = struct{}{}
+		} else {
+			// exact domain name
+			exactList[normalized] = struct{}{}
+		}
+	}
+	return &Whitelist{
+		exactList:  exactList,
+		suffixList: suffixList,
+	}
+}
+
+// Match returns whether hostname is present in whitelist
+func (l *Whitelist) Match(hostname string) bool {
+	hostname = NormalizeHostname(hostname)
+
+	// check for exact match
+	if _, found := l.exactList[hostname]; found {
+		return true
+	}
+
+	// handle special case of root suffix (".") added to whitelist
+	if _, found := l.suffixList[""]; found && hostname != "" {
+		return true
+	}
+
+	// check for suffix match
+	for needle := strings.Split(hostname, ".")[1:]; len(needle) > 0; needle = needle[1:] {
+		if _, found := l.suffixList[strings.Join(needle, ".")]; found {
+			return true
+		}
+	}
+
+	return false
+}

--- a/utils/domain/whitelist_test.go
+++ b/utils/domain/whitelist_test.go
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2021 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package domain
+
+import (
+	"testing"
+)
+
+type testcase struct {
+	input  string
+	result bool
+}
+
+func TestMatch(t *testing.T) {
+	l := []string{
+		"localhost",
+		".localhost",
+		".localdomain",
+	}
+	wl := NewWhitelist(l)
+
+	testVector := []testcase{
+		{
+			input:  "localhost",
+			result: true,
+		},
+		{
+			input:  "localhost1",
+			result: false,
+		},
+		{
+			input:  "localhost.localhost",
+			result: true,
+		},
+		{
+			input:  "localdomain",
+			result: false,
+		},
+		{
+			input:  "localhost.localdomain",
+			result: true,
+		},
+		{
+			input:  " localhost ",
+			result: true,
+		},
+		{
+			input:  "example.org",
+			result: false,
+		},
+		{
+			input:  "localhost.",
+			result: true,
+		},
+		{
+			input:  "localhost1.",
+			result: false,
+		},
+		{
+			input:  "localhost.localhost.",
+			result: true,
+		},
+		{
+			input:  "localdomain.",
+			result: false,
+		},
+		{
+			input:  "localhost.localdomain.",
+			result: true,
+		},
+		{
+			input:  " localhost. ",
+			result: true,
+		},
+		{
+			input:  "example.org.",
+			result: false,
+		},
+	}
+
+	for _, tc := range testVector {
+		res := wl.Match(tc.input)
+		if res != tc.result {
+			t.Errorf("Whitelist(%#v).Match(%#v) returned wrong result. Expected: %v. Got: %v.",
+				l, tc.input, tc.result, res)
+		}
+	}
+}
+
+func TestRootWildcard(t *testing.T) {
+	l := []string{"."}
+	wl := NewWhitelist(l)
+	testVector := []testcase{
+		{
+			input:  "localhost",
+			result: true,
+		},
+		{
+			input:  "localhost1",
+			result: true,
+		},
+		{
+			input:  "localhost.localhost",
+			result: true,
+		},
+		{
+			input:  "localdomain",
+			result: true,
+		},
+		{
+			input:  "localhost.localdomain",
+			result: true,
+		},
+		{
+			input:  " localhost ",
+			result: true,
+		},
+		{
+			input:  "example.org",
+			result: true,
+		},
+		{
+			input:  "localhost.",
+			result: true,
+		},
+		{
+			input:  "localhost1.",
+			result: true,
+		},
+		{
+			input:  "localhost.localhost.",
+			result: true,
+		},
+		{
+			input:  "localdomain.",
+			result: true,
+		},
+		{
+			input:  "localhost.localdomain.",
+			result: true,
+		},
+		{
+			input:  " localhost. ",
+			result: true,
+		},
+		{
+			input:  "example.org.",
+			result: true,
+		},
+		{
+			input:  ".",
+			result: false,
+		},
+		{
+			input:  "",
+			result: false,
+		},
+	}
+
+	for _, tc := range testVector {
+		res := wl.Match(tc.input)
+		if res != tc.result {
+			t.Errorf("Whitelist(%#v).Match(%#v) returned wrong result. Expected: %v. Got: %v.",
+				l, tc.input, tc.result, res)
+		}
+	}
+}
+
+func TestRootExact(t *testing.T) {
+	l := []string{""}
+	wl := NewWhitelist(l)
+	testVector := []testcase{
+		{
+			input:  "localhost",
+			result: false,
+		},
+		{
+			input:  "localhost1",
+			result: false,
+		},
+		{
+			input:  "localhost.localhost",
+			result: false,
+		},
+		{
+			input:  "localdomain",
+			result: false,
+		},
+		{
+			input:  "localhost.localdomain",
+			result: false,
+		},
+		{
+			input:  " localhost ",
+			result: false,
+		},
+		{
+			input:  "example.org",
+			result: false,
+		},
+		{
+			input:  "localhost.",
+			result: false,
+		},
+		{
+			input:  "localhost1.",
+			result: false,
+		},
+		{
+			input:  "localhost.localhost.",
+			result: false,
+		},
+		{
+			input:  "localdomain.",
+			result: false,
+		},
+		{
+			input:  "localhost.localdomain.",
+			result: false,
+		},
+		{
+			input:  " localhost. ",
+			result: false,
+		},
+		{
+			input:  "example.org.",
+			result: false,
+		},
+		{
+			input:  ".",
+			result: true,
+		},
+		{
+			input:  "",
+			result: true,
+		},
+	}
+
+	for _, tc := range testVector {
+		res := wl.Match(tc.input)
+		if res != tc.result {
+			t.Errorf("Whitelist(%#v).Match(%#v) returned wrong result. Expected: %v. Got: %v.",
+				l, tc.input, tc.result, res)
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/mysteriumnetwork/environment/issues/728

@Waldz this PR introduced potentially breaking change. Requests with Host header not in whitelist will be rejected. If you invoke Tequilapi using some domain name, you may need to adjust `tequilapi.allowed-hostnames` config parameter or use CLI argument `--tequilapi.allowed-hostnames`.

Value examples:
* `".localhost, localhost, .localdomain"` - allow Host header values with `localhost` domain, all `localhost` subdomains and `localdomain` subdomains (but not `localdomain` itself!).
* `"."` - allows all subdomains of root domain (virtually all domains).