### PR TITLE
Some pingpong fixes

### DIFF
--- a/session/pingpong/consumer_balance_syncer.go
+++ b/session/pingpong/consumer_balance_syncer.go
@@ -39,7 +39,8 @@ func (bs *balanceSyncer) PeriodiclySyncBalance(jobKey string, toRun func(stop <-
 	defer bs.lock.Unlock()
 
 	if v, ok := bs.jobs[jobKey]; ok {
-		bs.jobs[jobKey] = v.Restart()
+		v = v.Restart()
+		bs.jobs[jobKey] = v
 		return v, true
 	}
 

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -216,7 +216,7 @@ func (cbt *ConsumerBalanceTracker) GetBalance(chainID int64, id identity.Identit
 }
 
 func (cbt *ConsumerBalanceTracker) publishChangeEvent(id identity.Identity, before, after *big.Int) {
-	if before == after {
+	if before == nil || after == nil || before.Cmp(after) == 0 {
 		return
 	}
 

--- a/session/pingpong/job_test.go
+++ b/session/pingpong/job_test.go
@@ -33,11 +33,11 @@ func TestJob(t *testing.T) {
 	}
 	f := func(stop <-chan struct{}) {
 		for {
+			actualWork()
 			select {
 			case <-stop:
 				return
 			case <-time.After(time.Millisecond):
-				actualWork()
 			}
 		}
 	}

--- a/session/pingpong/job_test.go
+++ b/session/pingpong/job_test.go
@@ -55,8 +55,8 @@ func TestJob(t *testing.T) {
 	// assert work was done
 	assert.Greater(t, loaded, uint64(0))
 
-	j = j.Restart()
-	<-j.Done()
+	nj := j.Restart()
+	<-nj.Done()
 
 	// assert more work was done
 	current := atomic.LoadUint64(&ops)


### PR DESCRIPTION
This PR contains following changes:
* Makes periodic balance syncer not lose launched jobs
* Fixes balance change event conditions
* Fixes race condition in tests because of reading and writing same variable from two locations simultaneously
* Fixes race condition in tests because of not guaranteed observation of one goroutine effects by another, despite delays added. Ref: https://golang.org/ref/mem#tmp_6