### PR TITLE
fix reverse proxy host header

### DIFF
--- a/ui/reverse_proxy.go
+++ b/ui/reverse_proxy.go
@@ -51,6 +51,7 @@ func buildReverseProxy(tequilapiAddress string, tequilapiPort int) *httputil.Rev
 			req.URL.Path = strings.Replace(req.URL.Path, tequilapiUrlPrefix, "", 1)
 			req.URL.Path = strings.TrimRight(req.URL.Path, "/")
 			req.Header.Del("Origin")
+			req.Host = "127.0.0.1" + ":" + strconv.Itoa(tequilapiPort)
 		},
 		ModifyResponse: func(res *http.Response) error {
 			// remove TequilAPI CORS headers


### PR DESCRIPTION
Make proxied requests of WebUI to TequilAPI always pass through Host header filter.

Fixes #3951