### PR TITLE
log error description for DNS lookup failures

### DIFF
--- a/requests/dialer_swarm.go
+++ b/requests/dialer_swarm.go
@@ -285,7 +285,7 @@ func (wd *dialerWithDNSCache) DialContext(ctx context.Context, network, addr str
 
 			addrs, err := net.DefaultResolver.LookupHost(lookupCtx, addrHost)
 			if err != nil {
-				log.Warn().Msgf("Failed to lookup host: %s", addrHost)
+				log.Warn().Err(err).Msgf("Failed to lookup host: %q", addrHost)
 				return
 			}
 


### PR DESCRIPTION
Logg error description to debug pretty common case of DNS failures which manifests like this:

```
#  sudo journalctl -fu mysterium-node.service
-- Logs begin at Sat 2020-09-26 04:31:05 UTC. --
Oct 03 20:04:04 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:04:04.973 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:05:38 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:05:38.286 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:06:10 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:06:10.371 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:06:42 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:06:42.458 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:07:14 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:07:14.573 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:08:18 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:08:18.862 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:08:50 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:08:50.942 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:10:25 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:10:25.557 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:10:57 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:10:57.658 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
Oct 03 20:12:32 ca11.mysterium.pulseservers.com myst[1154]: 2021-10-03T20:12:32.433 WRN requests/dialer_swarm.go:288             > Failed to lookup host: testnet3-pilvytis.mysterium.network
```