### PR TITLE
Attempt to avoid ghost sessions in NodeUI

### DIFF
--- a/core/state/state.go
+++ b/core/state/state.go
@@ -186,7 +186,7 @@ func (k *Keeper) Subscribe(bus eventbus.Subscriber) error {
 	if err := bus.SubscribeAsync(servicestate.AppTopicServiceStatus, k.consumeServiceStateEvent); err != nil {
 		return err
 	}
-	if err := bus.SubscribeAsync(sevent.AppTopicSession, k.consumeServiceSessionEvent); err != nil {
+	if err := bus.Subscribe(sevent.AppTopicSession, k.consumeServiceSessionEvent); err != nil {
 		return err
 	}
 	if err := bus.SubscribeAsync(sevent.AppTopicDataTransferred, k.consumeServiceSessionStatisticsEvent); err != nil {


### PR DESCRIPTION
We have been getting some bug reports that SSE state push contains long-running sessions with 0 traffic. It is possible that Session `Created` and `Removed` could be fired almost the same time but due to `SubscribeAsync` will arrive in reverse order permanently adding a session to pushed SSE state which in turn will display a ghost session in NodeUI that is not sending/receiving traffic.

Signed-off-by: Mantas Domaševičius <mantas@mysterium.network>