### PR TITLE
Provider auto register

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -492,7 +492,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 
 	di.bootstrapBeneficiarySaver(nodeOptions)
 	di.bootstrapBeneficiaryProvider(nodeOptions)
-	di.PayoutAddressStorage = payout.NewAddressStorage(di.Storage, di.MMN)
+	di.PayoutAddressStorage = payout.NewAddressStorage(di.Storage)
 
 	if err := di.bootstrapProviderRegistrar(nodeOptions); err != nil {
 		return err

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -134,11 +134,13 @@ func (di *Dependencies) bootstrapProviderRegistrar(nodeOptions node.Options) err
 	}
 
 	cfg := registry.ProviderRegistrarConfig{
-		IsTestnet3:          nodeOptions.OptionsNetwork.Testnet3,
-		MaxRetries:          nodeOptions.Transactor.ProviderMaxRegistrationAttempts,
 		DelayBetweenRetries: nodeOptions.Transactor.ProviderRegistrationRetryDelay,
 	}
-	di.ProviderRegistrar = registry.NewProviderRegistrar(di.Transactor, di.IdentityRegistry, di.AddressProvider, di.BCHelper, cfg, di.PayoutAddressStorage)
+
+	fact := func(hermesURL string) registry.ProviderPromiseQuerier {
+		return pingpong.NewHermesCaller(di.HTTPClient, hermesURL)
+	}
+	di.ProviderRegistrar = registry.NewProviderRegistrar(di.Transactor, di.IdentityRegistry, di.AddressProvider, di.BCHelper, cfg, fact)
 	return di.ProviderRegistrar.Subscribe(di.EventBus)
 }
 

--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -125,6 +125,14 @@ var (
 		Usage:  "after syncing offchain balance, how long should node wait for next check to occur",
 		Value:  time.Minute * 30,
 	}
+	// FlagTestnet3HermesURL sets the default value for legacy (testnet3) hermes URL.
+	// TODO: Remove after migrations are considered done.
+	FlagTestnet3HermesURL = cli.StringFlag{
+		Name:   "payments.testnet3-hermes-url",
+		Usage:  "sets the URL for legacy testnet3 hermes",
+		Value:  metadata.Testnet3Definition.Testnet3HermesURL,
+		Hidden: true,
+	}
 )
 
 // RegisterFlagsPayments function register payments flags to flag list.
@@ -146,6 +154,7 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagPaymentsMaxUnpaidInvoiceValue,
 		&FlagPaymentsHermesStatusRecheckInterval,
 		&FlagOffchainBalanceExpiration,
+		&FlagTestnet3HermesURL,
 	)
 }
 
@@ -167,4 +176,5 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseStringFlag(ctx, FlagPaymentsMaxUnpaidInvoiceValue)
 	Current.ParseDurationFlag(ctx, FlagPaymentsHermesStatusRecheckInterval)
 	Current.ParseDurationFlag(ctx, FlagOffchainBalanceExpiration)
+	Current.ParseStringFlag(ctx, FlagTestnet3HermesURL)
 }

--- a/core/payout/payout_test.go
+++ b/core/payout/payout_test.go
@@ -23,19 +23,8 @@ import (
 	"testing"
 
 	"github.com/mysteriumnetwork/node/core/storage/boltdb"
-	"github.com/mysteriumnetwork/node/mmn"
 	"github.com/stretchr/testify/assert"
 )
-
-type mmnMock struct {
-}
-
-func (m *mmnMock) UpdateBeneficiary(data *mmn.UpdateBeneficiaryRequest) error {
-	return nil
-}
-func (m *mmnMock) GetBeneficiary(identityStr string) (string, error) {
-	return "", nil
-}
 
 func TestPayout(t *testing.T) {
 	// given:
@@ -44,7 +33,7 @@ func TestPayout(t *testing.T) {
 
 	defer os.RemoveAll(dir)
 	db, err := boltdb.NewStorage(dir)
-	payout := NewAddressStorage(db, &mmnMock{})
+	payout := NewAddressStorage(db)
 
 	// when
 	addr, err := payout.Address("random")

--- a/identity/registry/provider_registrar_test.go
+++ b/identity/registry/provider_registrar_test.go
@@ -32,7 +32,7 @@ func Test_ProviderRegistrar_StartsAndStops(t *testing.T) {
 	mt := mockTransactor{}
 	mrsp := mockRegistrationStatusProvider{}
 	cfg := ProviderRegistrarConfig{}
-	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, &mockPayoutStorage{})
+	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, newHermesMockFactory(nil, nil))
 
 	done := make(chan struct{})
 
@@ -49,7 +49,7 @@ func Test_ProviderRegistrar_needsHandling(t *testing.T) {
 	mt := mockTransactor{}
 	mrsp := mockRegistrationStatusProvider{}
 	cfg := ProviderRegistrarConfig{}
-	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, &mockPayoutStorage{})
+	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, newHermesMockFactory(nil, nil))
 
 	mockEvent := queuedEvent{
 		event:   servicestate.AppEventServiceStatus{},
@@ -78,7 +78,7 @@ func Test_ProviderRegistrar_RegistersProvider(t *testing.T) {
 		addrToReturn: newRegistryAddress,
 	}, &mockBlockchain{
 		beneficiaryToReturn: common.HexToAddress("0x3b2e61d42aa1ba340f8a60128fadb273894df145"),
-	}, cfg, &mockPayoutStorage{})
+	}, cfg, newHermesMockFactory(nil, nil))
 
 	mockEvent := queuedEvent{
 		event: servicestate.AppEventServiceStatus{
@@ -112,7 +112,7 @@ func Test_ProviderRegistrar_Does_NotRegisterWithNoBounty(t *testing.T) {
 		status: Unregistered,
 	}
 	cfg := ProviderRegistrarConfig{}
-	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, &mockPayoutStorage{})
+	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, newHermesMockFactory(nil, nil))
 
 	mockEvent := queuedEvent{
 		event: servicestate.AppEventServiceStatus{
@@ -138,21 +138,28 @@ func Test_ProviderRegistrar_Does_NotRegisterWithNoBounty(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func Test_ProviderRegistrar_Does_NotRegisterWithNoBounty_Testnet3(t *testing.T) {
+func Test_ProviderRegistrar_Does_NotIfUnknownInHermes_Mainnet(t *testing.T) {
 	mt := mockTransactor{
 		bountyResult: false,
 	}
 	mrsp := mockRegistrationStatusProvider{
 		status: Unregistered,
 	}
-	cfg := ProviderRegistrarConfig{
-		IsTestnet3: true,
-	}
+	cfg := ProviderRegistrarConfig{}
+
 	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{
 		addrToReturn: newRegistryAddress,
 	}, &mockBlockchain{
 		beneficiaryToReturn: common.HexToAddress("0x3b2e61d42aa1ba340f8a60128fadb273894df145"),
-	}, cfg, &mockPayoutStorage{})
+	}, cfg, newHermesMockFactory(nil, nil))
+
+	done := make(chan struct{})
+
+	go func() {
+		err := registrar.start()
+		assert.Nil(t, err)
+		done <- struct{}{}
+	}()
 
 	mockEvent := queuedEvent{
 		event: servicestate.AppEventServiceStatus{
@@ -161,6 +168,31 @@ func Test_ProviderRegistrar_Does_NotRegisterWithNoBounty_Testnet3(t *testing.T) 
 		},
 		retries: 0,
 	}
+
+	registrar.consumeServiceEvent(mockEvent.event)
+
+	registrar.stop()
+	<-done
+
+	_, ok := registrar.registeredIdentities[mockEvent.event.ProviderID]
+	assert.False(t, ok)
+}
+
+func Test_ProviderRegistrar_Does_RegisterIfKnownProvider_Mainnet(t *testing.T) {
+	mt := mockTransactor{
+		bountyResult: false,
+	}
+	mrsp := mockRegistrationStatusProvider{
+		status: Unregistered,
+	}
+	cfg := ProviderRegistrarConfig{}
+
+	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{
+		addrToReturn: newRegistryAddress,
+	}, &mockBlockchain{
+		beneficiaryToReturn: common.HexToAddress("0x3b2e61d42aa1ba340f8a60128fadb273894df145"),
+	}, cfg, newHermesMockFactory(big.NewInt(10), nil))
+
 	done := make(chan struct{})
 
 	go func() {
@@ -168,6 +200,14 @@ func Test_ProviderRegistrar_Does_NotRegisterWithNoBounty_Testnet3(t *testing.T) 
 		assert.Nil(t, err)
 		done <- struct{}{}
 	}()
+
+	mockEvent := queuedEvent{
+		event: servicestate.AppEventServiceStatus{
+			Status:     "Running",
+			ProviderID: "0x3b2e61d42aa1ba340f8a60128fadb273894df145",
+		},
+		retries: 0,
+	}
 
 	registrar.consumeServiceEvent(mockEvent.event)
 
@@ -186,7 +226,7 @@ func Test_ProviderRegistrar_FailsAfterRetries(t *testing.T) {
 	cfg := ProviderRegistrarConfig{
 		MaxRetries: 5,
 	}
-	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, &mockPayoutStorage{})
+	registrar := NewProviderRegistrar(&mt, &mrsp, &mockAddressKeeper{}, &mockBlockchain{}, cfg, newHermesMockFactory(nil, nil))
 
 	mockEvent := queuedEvent{
 		event: servicestate.AppEventServiceStatus{
@@ -259,4 +299,22 @@ type mockPayoutStorage struct {
 
 func (mb *mockPayoutStorage) Save(identity, address string) error {
 	return nil
+}
+
+type mockHermes struct {
+	result *big.Int
+	err    error
+}
+
+func (m *mockHermes) ProviderPromiseAmount(chainID int64, id string) (*big.Int, error) {
+	return m.result, m.err
+}
+
+func newHermesMockFactory(result *big.Int, err error) HermesCallerFactory {
+	return func(hermesURL string) ProviderPromiseQuerier {
+		return &mockHermes{
+			result: result,
+			err:    err,
+		}
+	}
 }

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -33,6 +33,7 @@ type NetworkDefinition struct {
 	DefaultChainID            int64
 	DefaultCurrency           string
 	LocationAddress           string
+	Testnet3HermesURL         string
 	Payments                  Payments
 }
 
@@ -97,9 +98,10 @@ var Testnet3Definition = NetworkDefinition{
 		"testnet3-transactor.mysterium.network": {"167.233.11.60"},
 		"testnet3-pilvytis.mysterium.network":   {"167.233.11.60"},
 	},
-	DefaultChainID:  80001,
-	DefaultCurrency: "MYSTT",
-	LocationAddress: "https://testnet3-location.mysterium.network/api/v1/location",
+	DefaultChainID:    80001,
+	DefaultCurrency:   "MYSTT",
+	LocationAddress:   "https://testnet3-location.mysterium.network/api/v1/location",
+	Testnet3HermesURL: "https://testnet3-hermes.mysterium.network/api/v1",
 	Payments: Payments{
 		Consumer: Consumer{
 			DataLeewayMegabytes: 20,

--- a/mmn/client.go
+++ b/mmn/client.go
@@ -18,10 +18,7 @@
 package mmn
 
 import (
-	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -67,94 +64,6 @@ func (m *client) RegisterNode(info *NodeInformationDto) error {
 	}
 
 	return m.httpClient.DoRequest(req)
-}
-
-// UpdateBeneficiaryRequest is used when setting a new beneficiary in MMN.
-type UpdateBeneficiaryRequest struct {
-	Beneficiary string `json:"beneficiary"`
-	Identity    string `json:"identity"`
-}
-
-// UpdateBeneficiary updates beneficiary in MMN
-func (m *client) UpdateBeneficiary(data *UpdateBeneficiaryRequest) error {
-	log.Debug().Msgf("Updating beneficiary in MMN: %+v", *data)
-
-	id := identity.FromAddress(data.Identity)
-	req, err := requests.NewSignedPutRequest(m.mmnAddress, "node/beneficiary", data, m.signer(id))
-	if err != nil {
-		return err
-	}
-
-	resp, err := m.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return fmt.Errorf("got a non ok response code: %d", resp.StatusCode)
-	}
-
-	var respBody struct {
-		Success bool   `json:"success"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(body, &respBody); err != nil {
-		return err
-	}
-
-	if !respBody.Success {
-		return fmt.Errorf("update beneficiary request failed with message: %s", respBody.Message)
-	}
-
-	return nil
-}
-
-// GetBeneficiary get beneficiary from MMN.
-func (m *client) GetBeneficiary(identityStr string) (string, error) {
-	id := identity.FromAddress(identityStr)
-	req, err := requests.NewSignedGetRequest(m.mmnAddress, "node/beneficiary?identity="+identityStr, m.signer(id))
-	if err != nil {
-		return "", err
-	}
-	resp, err := m.httpClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return "", fmt.Errorf("got a non ok response code: %d", resp.StatusCode)
-	}
-
-	var benef struct {
-		Success     bool   `json:"success"`
-		Message     string `json:"message"`
-		Beneficiary string `json:"beneficiary"`
-	}
-	if err := json.Unmarshal(body, &benef); err != nil {
-		return "", err
-	}
-
-	if !benef.Success {
-		if strings.Contains(benef.Message, "not found") {
-			return "", nil
-		}
-
-		return "", fmt.Errorf("beneficiary get request failed with message: %s", benef.Message)
-	}
-
-	return benef.Beneficiary, nil
 }
 
 // GetReport does an HTTP call to MMN and fetches node report

--- a/mmn/mmn.go
+++ b/mmn/mmn.go
@@ -118,16 +118,6 @@ func (m *MMN) GetReport() (string, error) {
 	return m.client.GetReport(m.lastIdentity)
 }
 
-// UpdateBeneficiary updates beneficiary in MMN.
-func (m *MMN) UpdateBeneficiary(data *UpdateBeneficiaryRequest) error {
-	return m.client.UpdateBeneficiary(data)
-}
-
-// GetBeneficiary get beneficiary from MMN.
-func (m *MMN) GetBeneficiary(identityStr string) (string, error) {
-	return m.client.GetBeneficiary(identityStr)
-}
-
 func getOS() string {
 	switch runtime.GOOS {
 	case "darwin":

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -125,7 +125,7 @@ func NewConsumerBalanceTracker(
 }
 
 type consumerInfoGetter interface {
-	GetConsumerData(chainID int64, id string) (ConsumerData, error)
+	GetConsumerData(chainID int64, id string) (HermesUserInfo, error)
 }
 
 type consumerBalanceChecker interface {
@@ -629,7 +629,7 @@ func (cbt *ConsumerBalanceTracker) recoverGrandTotalPromised(chainID int64, iden
 		}
 	}()
 
-	var data ConsumerData
+	var data HermesUserInfo
 	boff = backoff.WithContext(boff, ctx)
 	toRetry := func() error {
 		d, err := cbt.consumerInfoGetter.GetConsumerData(chainID, identity.Address)

--- a/session/pingpong/consumer_balance_tracker_test.go
+++ b/session/pingpong/consumer_balance_tracker_test.go
@@ -384,8 +384,8 @@ type mockconsumerInfoGetter struct {
 	amount *big.Int
 }
 
-func (mcig *mockconsumerInfoGetter) GetConsumerData(_ int64, _ string) (ConsumerData, error) {
-	return ConsumerData{
+func (mcig *mockconsumerInfoGetter) GetConsumerData(_ int64, _ string) (HermesUserInfo, error) {
+	return HermesUserInfo{
 		LatestPromise: LatestPromise{
 			Amount: mcig.amount,
 		},

--- a/session/pingpong/hermes_promise_handler.go
+++ b/session/pingpong/hermes_promise_handler.go
@@ -52,7 +52,8 @@ type HermesHTTPRequester interface {
 	RequestPromise(rp RequestPromise) (crypto.Promise, error)
 	RevealR(r string, provider string, agreementID *big.Int) error
 	UpdatePromiseFee(promise crypto.Promise, newFee *big.Int) (crypto.Promise, error)
-	GetConsumerData(chainID int64, id string) (ConsumerData, error)
+	GetConsumerData(chainID int64, id string) (HermesUserInfo, error)
+	GetProviderData(chainID int64, id string) (HermesUserInfo, error)
 }
 
 type encryption interface {

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -717,7 +717,7 @@ func (aps *hermesPromiseSettler) generateAgreementID() *big.Int {
 	return new(big.Int).SetBytes(agreementID)
 }
 
-func (aps *hermesPromiseSettler) getHermesData(chainID int64, hermesID, identity common.Address) (*ConsumerData, error) {
+func (aps *hermesPromiseSettler) getHermesData(chainID int64, hermesID, identity common.Address) (*HermesUserInfo, error) {
 	caller, err := aps.getHermesCaller(chainID, hermesID)
 	if err != nil {
 		return nil, err

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -74,8 +74,12 @@ func (mac *mockHermesCaller) UpdatePromiseFee(promise crypto.Promise, newFee *bi
 	return promise, nil
 }
 
-func (mac *mockHermesCaller) GetConsumerData(chainID int64, id string) (ConsumerData, error) {
-	return ConsumerData{}, nil
+func (mac *mockHermesCaller) GetConsumerData(chainID int64, id string) (HermesUserInfo, error) {
+	return HermesUserInfo{}, nil
+}
+
+func (mac *mockHermesCaller) GetProviderData(chainID int64, id string) (HermesUserInfo, error) {
+	return HermesUserInfo{}, nil
 }
 
 func Test_InvoiceTracker_Start_Stop(t *testing.T) {


### PR DESCRIPTION
Providers in mainnet migration auto register if:
* Current running chain is L2
* They have a promise of any amount. ( promise is not nil ) _OR_ They are in special list in transactor

Removed:
* Beneficiary (payout) address migration from provider auto registration. We just set channel as beneficiary and save nothing in bolt DB.
* Payout address sending to MMN.

Added temporary metadata var: `Testnet3HermesURL: "https://testnet3-hermes.mysterium.network/api/v1"`

If hermes in testnet3 dies, auto registration will only work for targets with bounty in transactor and that is ok imo.
Updates: https://github.com/mysteriumnetwork/node/issues/4075