### PR TITLE
Revert "Attempt to avoid ghost sessions in NodeUI"

### DIFF
--- a/core/state/state.go
+++ b/core/state/state.go
@@ -173,7 +173,7 @@ func (k *Keeper) Subscribe(bus eventbus.Subscriber) error {
 	if err := bus.SubscribeAsync(servicestate.AppTopicServiceStatus, k.consumeServiceStateEvent); err != nil {
 		return err
 	}
-	if err := bus.Subscribe(sevent.AppTopicSession, k.consumeServiceSessionEvent); err != nil {
+	if err := bus.SubscribeAsync(sevent.AppTopicSession, k.consumeServiceSessionEvent); err != nil {
 		return err
 	}
 	if err := bus.SubscribeAsync(sevent.AppTopicDataTransferred, k.consumeServiceSessionStatisticsEvent); err != nil {


### PR DESCRIPTION
Reverts mysteriumnetwork/node#4053

synchronous subscribe causes bus lock to be held while message is getting processed
message handler calls consumeServiceSessionEvent
which calls announceState
which calls bus.Publish
which want to enter lock
what causes deadlock on message bus