### PR TITLE
Fix config in mainnet

### DIFF
--- a/config/urfavecli/clicontext/user.go
+++ b/config/urfavecli/clicontext/user.go
@@ -58,7 +58,7 @@ func LoadUserConfigQuietly(ctx *cli.Context) error {
 
 func resolveLocation(ctx *cli.Context) (configDir string, configFilePath string) {
 	configDir = ctx.String("config-dir")
-	configFilePath = path.Join(configDir, "config.toml")
+	configFilePath = path.Join(configDir, "config-mainnet.toml")
 	return configDir, configFilePath
 }
 


### PR DESCRIPTION
Because of how the config is loaded it's impossible to know how many times we've already started the node in mainnet without some hacks. This makes it hard to determine if we need to reset the config or if its been reset.

Easiest and least hacky way to do this is to just rename the config.
Closes: https://github.com/mysteriumnetwork/node/issues/4130