### PR TITLE
Don't require authorization to call `/tequilapi/healthcheck`

### DIFF
--- a/ui/reverse_proxy.go
+++ b/ui/reverse_proxy.go
@@ -156,5 +156,8 @@ func isTequilapiProtectedUrl(url string) bool {
 	if isTequilapiURL(url, "/auth/login") {
 		return false
 	}
+	if isTequilapiURL(url, "/healthcheck") {
+		return false
+	}
 	return true
 }


### PR DESCRIPTION
Intent here is not to fail healthcheck for MMN 2.0 FE app on localhost:4449/tequilapi/healthcheck