### PR TITLE
Allow providers to sync their promises in case of hermes data corruption

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -536,6 +536,7 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 		FeeProvider:     di.Transactor,
 		Encryption:      di.Keystore,
 		EventBus:        di.EventBus,
+		Signer:          di.SignerFactory,
 	})
 
 	if err := di.HermesPromiseHandler.Subscribe(di.EventBus); err != nil {

--- a/session/pingpong/hermes_promise_handler.go
+++ b/session/pingpong/hermes_promise_handler.go
@@ -40,6 +40,7 @@ import (
 
 type hermesPromiseStorage interface {
 	Store(promise HermesPromise) error
+	Get(chainID int64, channelID string) (HermesPromise, error)
 }
 
 type feeProvider interface {
@@ -54,6 +55,7 @@ type HermesHTTPRequester interface {
 	UpdatePromiseFee(promise crypto.Promise, newFee *big.Int) (crypto.Promise, error)
 	GetConsumerData(chainID int64, id string) (HermesUserInfo, error)
 	GetProviderData(chainID int64, id string) (HermesUserInfo, error)
+	SyncProviderPromise(promise crypto.Promise, signer identity.Signer) error
 }
 
 type encryption interface {
@@ -72,6 +74,7 @@ type HermesPromiseHandlerDeps struct {
 	EventBus             eventbus.Publisher
 	HermesURLGetter      hermesURLGetter
 	HermesCallerFactory  HermesCallerFactory
+	Signer               identity.SignerFactory
 }
 
 // HermesPromiseHandler handles the hermes promises for ongoing sessions.
@@ -126,10 +129,45 @@ func (aph *HermesPromiseHandler) RequestPromise(r []byte, em crypto.ExchangeMess
 		return er.errChan
 	}
 
-	er.requestFunc = hermesCaller.RequestPromise
+	er.requestFunc = aph.makeRequestPromiseFunc(providerID, hermesCaller)
 
 	aph.queue <- er
 	return er.errChan
+}
+
+func (aph *HermesPromiseHandler) makeRequestPromiseFunc(providerID identity.Identity, caller HermesHTTPRequester) func(rp RequestPromise) (crypto.Promise, error) {
+	return func(rp RequestPromise) (crypto.Promise, error) {
+		p, err := caller.RequestPromise(rp)
+		if err == nil {
+			return p, nil
+		}
+
+		if !stdErr.Is(err, ErrInvalidPreviuosLatestPromise) {
+			// We can only really handle the previuos promise is invalid error.
+			return crypto.Promise{}, err
+		}
+
+		chid, err := crypto.GenerateProviderChannelID(providerID.Address, rp.ExchangeMessage.HermesID)
+		if err != nil {
+			return crypto.Promise{}, fmt.Errorf("failed to generate provider ID in promise sync: %w", err)
+		}
+
+		stored, err := aph.deps.HermesPromiseStorage.Get(rp.ExchangeMessage.ChainID, chid)
+		if err != nil {
+			return crypto.Promise{}, fmt.Errorf("failed to get last known promise from bolt: %w", err)
+		}
+
+		signer := aph.deps.Signer(providerID)
+		if err := caller.SyncProviderPromise(stored.Promise, signer); err != nil {
+			return crypto.Promise{}, fmt.Errorf("failed to sync to last known promise: %w", err)
+		}
+
+		if err := caller.RevealR(stored.R, providerID.Address, stored.AgreementID); err != nil {
+			return crypto.Promise{}, fmt.Errorf("failed to reveal R after sync: %w", err)
+		}
+
+		return caller.RequestPromise(rp)
+	}
 }
 
 // PayAndSettle adds the request to the queue.
@@ -348,6 +386,7 @@ func (aph *HermesPromiseHandler) revealR(hermesPromise HermesPromise) error {
 }
 
 var errRrecovered = errors.New("R recovered")
+var errPreviuosPromise = errors.New("action cannot be performed as previuos promise is invalid")
 
 func (aph *HermesPromiseHandler) handleHermesError(err error, providerID identity.Identity, chainID int64, hermesID common.Address) error {
 	if err == nil {

--- a/session/pingpong/invoice_tracker_test.go
+++ b/session/pingpong/invoice_tracker_test.go
@@ -82,6 +82,10 @@ func (mac *mockHermesCaller) GetProviderData(chainID int64, id string) (HermesUs
 	return HermesUserInfo{}, nil
 }
 
+func (mac *mockHermesCaller) SyncProviderPromise(promise crypto.Promise, signer identity.Signer) error {
+	return nil
+}
+
 func Test_InvoiceTracker_Start_Stop(t *testing.T) {
 	dir, err := ioutil.TempDir("", "invoice_tracker_test")
 	assert.Nil(t, err)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/40318863/142198695-86cadf1d-eff9-4138-a9b5-2cb93d910750.png)
After: https://hermes.mysterium.network/api/v1/data/provider/0xcae5abb88651d283a05efab93a271d2861c08973


Closes: https://github.com/mysteriumnetwork/node/issues/4270