### PR TITLE
Fix withdrawals one more time

### DIFF
--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -504,8 +504,6 @@ func (aps *hermesPromiseSettler) Withdraw(
 
 	if amountToWithdraw == nil {
 		amountToWithdraw = new(big.Int).Sub(data.Balance, new(big.Int).Sub(data.LatestPromise.Amount, data.Settled))
-	} else {
-		amountToWithdraw = new(big.Int).Add(data.LatestPromise.Amount, amountToWithdraw)
 	}
 
 	err = aps.validateWithdrawalAmount(amountToWithdraw, toChainID)


### PR DESCRIPTION
This completely fixes the spooky double spend withdrawal "bug"

Hermes already adds this amount by itself, so what would happen is this:
* Create 1 withdrawal -> amount is correct
* Create 2 withdrawal -> amount is wrong from the one asked in UI. Withdrawal is still completed

Another scenario: submit 1 OK, submit 2 and 3 in a row: 3rd withdrawal gets rejected, 2nd has the bug mentioned above resulting in "double withdrawal"
After this change I've tested all possible reported issues, by withdrawing 0.1 MYST
![image](https://user-images.githubusercontent.com/40318863/142437586-8a703e74-40bd-453d-81e6-8292690c868c.png)


Closes: https://github.com/mysteriumnetwork/node/issues/4291