### PR TITLE
Make debugging payments in sessions easier

### DIFF
--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -139,6 +139,13 @@ var (
 		Value:  metadata.Testnet3Definition.Testnet3HermesURL,
 		Hidden: true,
 	}
+	// FlagPaymentsDuringSessionDebug sets if we're in debug more for the payments done in a VPN session.
+	FlagPaymentsDuringSessionDebug = cli.BoolFlag{
+		Name:   "payments.during-session-debug",
+		Usage:  "Set debug mode for payments made during a session, it will bypass any price validation and allow absurd prices during sessions",
+		Value:  false,
+		Hidden: true,
+	}
 )
 
 // RegisterFlagsPayments function register payments flags to flag list.
@@ -162,6 +169,7 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagOffchainBalanceExpiration,
 		&FlagTestnet3HermesURL,
 		&FlagPaymentsZeroStakeUnsettledAmount,
+		&FlagPaymentsDuringSessionDebug,
 	)
 }
 
@@ -185,4 +193,5 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseDurationFlag(ctx, FlagOffchainBalanceExpiration)
 	Current.ParseStringFlag(ctx, FlagTestnet3HermesURL)
 	Current.ParseFloat64Flag(ctx, FlagPaymentsZeroStakeUnsettledAmount)
+	Current.ParseBoolFlag(ctx, FlagPaymentsDuringSessionDebug)
 }

--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -146,6 +146,13 @@ var (
 		Value:  false,
 		Hidden: true,
 	}
+	// FlagPaymentsAmountDuringSessionDebug sets the amount of MYST sent during session debug
+	FlagPaymentsAmountDuringSessionDebug = cli.Uint64Flag{
+		Name:   "payments.amount-during-session-debug-amount",
+		Usage:  "Set amount to pay during session debug",
+		Value:  5000000000000000000,
+		Hidden: true,
+	}
 )
 
 // RegisterFlagsPayments function register payments flags to flag list.
@@ -170,6 +177,7 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagTestnet3HermesURL,
 		&FlagPaymentsZeroStakeUnsettledAmount,
 		&FlagPaymentsDuringSessionDebug,
+		&FlagPaymentsAmountDuringSessionDebug,
 	)
 }
 
@@ -194,4 +202,5 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseStringFlag(ctx, FlagTestnet3HermesURL)
 	Current.ParseFloat64Flag(ctx, FlagPaymentsZeroStakeUnsettledAmount)
 	Current.ParseBoolFlag(ctx, FlagPaymentsDuringSessionDebug)
+	Current.ParseUInt64Flag(ctx, FlagPaymentsAmountDuringSessionDebug)
 }

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"sync"
 	"time"
 
@@ -324,10 +325,21 @@ func (m *connectionManager) autoReconnect() (err error) {
 }
 
 func (m *connectionManager) priceFromProposal(proposal proposal.PricedServiceProposal) market.Price {
-	return market.Price{
+	p := market.Price{
 		PricePerHour: proposal.Price.PricePerHour,
 		PricePerGiB:  proposal.Price.PricePerGiB,
 	}
+
+	if config.GetBool(config.FlagPaymentsDuringSessionDebug) {
+		log.Info().Msg("Payments debug bas been enabled, will use absurd amounts for the proposal price")
+		p = market.Price{
+			PricePerHour: new(big.Int).SetInt64(5000000000000000000),
+			PricePerGiB:  new(big.Int).SetInt64(5000000000000000000),
+		}
+	}
+
+	return p
+
 }
 
 func (m *connectionManager) initSession(tracer *trace.Tracer, prc market.Price) (sessionID session.ID, err error) {

--- a/core/connection/manager.go
+++ b/core/connection/manager.go
@@ -332,9 +332,14 @@ func (m *connectionManager) priceFromProposal(proposal proposal.PricedServicePro
 
 	if config.GetBool(config.FlagPaymentsDuringSessionDebug) {
 		log.Info().Msg("Payments debug bas been enabled, will use absurd amounts for the proposal price")
+		amount := config.GetUInt64(config.FlagPaymentsAmountDuringSessionDebug)
+		if amount == 0 {
+			amount = 5000000000000000000
+		}
+
 		p = market.Price{
-			PricePerHour: new(big.Int).SetInt64(5000000000000000000),
-			PricePerGiB:  new(big.Int).SetInt64(5000000000000000000),
+			PricePerHour: new(big.Int).SetUint64(amount),
+			PricePerGiB:  new(big.Int).SetUint64(amount),
 		}
 	}
 

--- a/session/pingpong/pricing.go
+++ b/session/pingpong/pricing.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mysteriumnetwork/node/config"
 	nodevent "github.com/mysteriumnetwork/node/core/node/event"
 	"github.com/mysteriumnetwork/node/eventbus"
 	"github.com/mysteriumnetwork/node/market"
@@ -105,6 +106,11 @@ func (p *Pricer) getPreviousByType(pricing market.LatestPrices, nodeType string,
 
 // IsPriceValid checks if the given price is valid or not.
 func (p *Pricer) IsPriceValid(in market.Price, nodeType string, country string) bool {
+	if config.GetBool(config.FlagPaymentsDuringSessionDebug) {
+		log.Info().Msg("Payments debug bas been enabled, will agree with any price given")
+		return true
+	}
+
 	pricing := p.getPricing()
 	if p.pricesEqual(p.getCurrentByType(pricing, nodeType, country), in) {
 		return true

--- a/tequilapi/endpoints/pilvytis.go
+++ b/tequilapi/endpoints/pilvytis.go
@@ -23,14 +23,15 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/mysteriumnetwork/node/core/location/locationstate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/pilvytis"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
+
+	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 type api interface {

--- a/tequilapi/endpoints/pilvytis.go
+++ b/tequilapi/endpoints/pilvytis.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 )
 
 type api interface {


### PR DESCRIPTION
Using this you can start two nodes. 1 in client and 1 in provider mode with `noop` service both on the same machine.
You can then connect to your own node and pump MYST really fast.

Closes: https://github.com/mysteriumnetwork/node/issues/4140