### PR TITLE
Handle missing consumer promise when setting withdrawal amount

### DIFF
--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -512,7 +512,13 @@ func (aps *hermesPromiseSettler) Withdraw(
 	}
 
 	// 2. issue a self promise
-	msg, err := aps.issueSelfPromise(fromChainID, toChainID, amountToWithdraw, data.LatestPromise.Amount, providerID, consumerChannelAddress, hermesID)
+	promisedAmount := data.LatestPromise.Amount
+	if promisedAmount.Cmp(data.Settled) < 0 {
+		// If consumer has an incorrect promise. Issue a correct one
+		// together with a withdrawal request.
+		promisedAmount = data.Settled
+	}
+	msg, err := aps.issueSelfPromise(fromChainID, toChainID, amountToWithdraw, promisedAmount, providerID, consumerChannelAddress, hermesID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If latest promise is invalid, issue a new promise with amount equal to settled+amount to withdraw. This way we can still recover and withdraw even though provider is has corrupted data.
On hermes side we will also be able to recover withdraw promises using the help of this change.