### PR TITLE
Dont error on status 200 or 202

### DIFF
--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -227,8 +227,10 @@ func (client *Client) RegisterIdentity(address string, token *string) error {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("expected 202 got %v", response.StatusCode)
+	switch response.StatusCode {
+	case http.StatusOK, http.StatusAccepted:
+	default:
+		return fmt.Errorf("expected 200 or 202 got %v", response.StatusCode)
 	}
 
 	return nil


### PR DESCRIPTION
Seems that some people try to register a few times and they receive an error when node returns `200` status code. This should reduce the confusion a bit.