### PR TITLE
session report: use UTC time for filter condition

### DIFF
--- a/tequilapi/endpoints/sessions.go
+++ b/tequilapi/endpoints/sessions.go
@@ -150,8 +150,8 @@ func (endpoint *sessionsEndpoint) StatsDaily(c *gin.Context) {
 	request := c.Request
 
 	query := contract.SessionQuery{
-		DateFrom: conv.Date(strfmt.Date(time.Now().AddDate(0, 0, -30))),
-		DateTo:   conv.Date(strfmt.Date(time.Now())),
+		DateFrom: conv.Date(strfmt.Date(time.Now().UTC().AddDate(0, 0, -30))),
+		DateTo:   conv.Date(strfmt.Date(time.Now().UTC())),
 	}
 	if errors := query.Bind(request); errors.HasErrors() {
 		utils.SendValidationErrorMessage(resp, errors)


### PR DESCRIPTION
Finally fixes test which fails only at night.

Interesting precondition: in fails only between 00:00 and 01:00 UTC because CI servers are set to CET time (UTC+01:00 at this moment).