### PR TITLE
Fix cli stop command

### DIFF
--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -455,7 +455,7 @@ func (client *Client) GetPayout(identity string) (contract.PayoutAddressRequest,
 // Stop kills mysterium client
 func (client *Client) Stop() error {
 	emptyPayload := struct{}{}
-	response, err := client.http.Post("/stop", emptyPayload)
+	response, err := client.http.Post("stop", emptyPayload)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
» stop
[ERROR] Cannot stop the client: server response invalid: 404 Not Found (http://127.0.0.1:4050//stop). Possible error: json: cannot unmarshal number into Go value of type client.errorBody
```