### PR TITLE
workaround for containerd < 1.5.0

### DIFF
--- a/bin/helpers/prepare-run-env.sh
+++ b/bin/helpers/prepare-run-env.sh
@@ -23,7 +23,7 @@ function ensure_paths {
 
     iptables_required_path="/usr/sbin/iptables"
 
-    if ! [[ -x ${iptables_required_path} ]]; then
+    if ! command [ -x "${iptables_required_path}" ]; then
         ln -s ${iptables_path} ${iptables_required_path}
     fi
 }


### PR DESCRIPTION
From chat with dappnode devs struggling to run it on docker with containerd 1.4.3:

Vladislav Yarmak, [22.01.2022 18:45]
so

Vladislav Yarmak, [22.01.2022 18:46]
I've removed symlink from writable layer of container to make it running:

```
rm /var/lib/docker/overlay2/151cd117c75149e1e5f20fbb9d906a6b6284d82e7aea21df8e07d70c4c22471e/diff/usr/sbin/iptables
```

Vladislav Yarmak, [22.01.2022 18:46]
and then I was able to exec into running container

Vladislav Yarmak, [22.01.2022 18:47]
long story short, I've narrowed issue down to incorrect result of -x test in bash script

Vladislav Yarmak, [22.01.2022 18:48]
it looked like buggy shell which returns nonsense result:

Vladislav Yarmak, [22.01.2022 18:48]
```
root@vmi778777:~# docker exec -it fcdba4191df0 /bin/bash -c "if [[ -x /bin/bash ]] ; then echo TRUE ; else echo FALSE ; fi"
FALSE
```

Vladislav Yarmak, [22.01.2022 18:49]
however

Vladislav Yarmak, [22.01.2022 18:49]

```
root@vmi778777:~# docker exec -it fcdba4191df0 /bin/bash -c "if command [[ -x /bin/bash ]] ; then echo TRUE ; else echo FALSE ; fi"
TRUE
```

Vladislav Yarmak, [22.01.2022 18:49]
with that it gets more interesting

Vladislav Yarmak, [22.01.2022 18:50]
what I've done in second command is forced shell to use external `/usr/bin/[[` binary instead of `[[` builtin

Vladislav Yarmak, [22.01.2022 18:51]
what's the difference? these two are completely different implementations of permissions test

Vladislav Yarmak, [22.01.2022 18:51]
strace time then: https://gist.github.com/Snawoot/0d2385fdfbfd15cf3bbbcce04efc10ed

Vladislav Yarmak, [22.01.2022 18:52]
in the first case we see that builtin uses faccessat2 syscall: https://gist.github.com/Snawoot/0d2385fdfbfd15cf3bbbcce04efc10ed#file-1-strace-log-L89

Vladislav Yarmak, [22.01.2022 18:52]
in second case we see it interprets result of regular stat syscall: https://gist.github.com/Snawoot/0d2385fdfbfd15cf3bbbcce04efc10ed#file-2-strace-log-L138

Vladislav Yarmak, [22.01.2022 18:53]
in first case we see that it returns EPERM error for some reason, while file is executable and there should be no issue

Vladislav Yarmak, [22.01.2022 18:56]
clearly syscalls go directly to kernel, no other software is involved. so I see two possibilities there: it's either kernel bug in pretty old kernel, or an issue with container runtime which configures container namespace permissions incorrectly

Vladislav Yarmak, [22.01.2022 20:51]
one-liner to reproduce with just docker:

```
docker run -it --rm ubuntu:21.04 /bin/bash -c "if [[ -x /proc/self/exe ]] ; then echo OK ; else echo FAULTY ; fi"
```

confirmed that it's docker's fault:

```
admin@vmi778777:~$ docker run -it --rm ubuntu:21.04 /bin/bash -c "if [[ -x /proc/self/exe ]] ; then echo OK ; else echo FAULTY ; fi"
FAULTY
admin@vmi778777:~$ docker run --security-opt seccomp=unconfined -it --rm ubuntu:21.04 /bin/bash -c "if [[ -x /proc/self/exe ]] ; then echo OK ; else echo FAULTY ; fi"
OK
```

relevant pull request into container engine with fix: https://github.com/containerd/containerd/pull/4481/files

this change was introduced in containerd 1.5.0, you're running 1.4.3:

```
[20:48:40] dt1:~/src/containerd> git merge-base --is-ancestor 6a915a1453a5bfd859664679e1ac478a7022c7f6 269548fa27e0089a8b8278fc4fc781d7f65a939b && echo TRUE || echo FALSE
FALSE
```

I think the case is closed