### PR TITLE
new containerd workaround

### DIFF
--- a/bin/helpers/prepare-run-env.sh
+++ b/bin/helpers/prepare-run-env.sh
@@ -23,7 +23,7 @@ function ensure_paths {
 
     iptables_required_path="/usr/sbin/iptables"
 
-    if ! command [ -x "${iptables_required_path}" ]; then
+    if ! env [ -x "${iptables_required_path}" ]; then
         ln -s ${iptables_path} ${iptables_required_path}
     fi
 }


### PR DESCRIPTION
It turns out that bash `command` builtin works to override **keyword** `[[`, but doesn't work to override **builtin** `[` with corresponding external command. However, we can't rely on `/usr/bin/[[` because it exists only on alpine while prepare-run-env.sh is used somewhere else. This PR uses `env` to run actual `[` external binary shadowed by `[` builtin of bash.