### PR TITLE
Speedup CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,11 +135,6 @@ package:android:
   tags: [go]
   script: go run mage.go -v PackageAndroid
 
-package:docker-alpine:
-  stage: build
-  tags: [go,high_performance]
-  script: go run mage.go -v PackageDockerAlpine
-
 package:swagger-redoc-docker:
   stage: build
   tags: [go]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,7 +191,7 @@ release-tag:avado:
 
 release-tag:docker:
   stage: release-tag
-  tags: [go]
+  tags: [go,high_performance]
   script: go run mage.go -v ReleaseDockerTag
 
 release-tag:debian-ppa:


### PR DESCRIPTION
Skip heavy docker image build on regular tests run.

Removed step is optional because it's a dry-run version of release job. These two jobs both build same docker context and use same image registry for cache (hence on actual release it's not built twice), the only difference between them is that later one also pushes image tag into registry.

@mdomasevicius This one should address one of your items for tech-lead meeting.