### PR TITLE
Withdrawal no amount given don't go out of bounds

### DIFF
--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -504,6 +504,12 @@ func (aps *hermesPromiseSettler) Withdraw(
 
 	if amountToWithdraw == nil {
 		amountToWithdraw = new(big.Int).Sub(data.Balance, new(big.Int).Sub(data.LatestPromise.Amount, data.Settled))
+
+		// TODO: Pull this from hermes contract in the future.
+		maxWithdraw := crypto.FloatToBigMyst(99)
+		if amountToWithdraw.Cmp(maxWithdraw) > 0 {
+			amountToWithdraw = maxWithdraw
+		}
 	}
 
 	err = aps.validateWithdrawalAmount(amountToWithdraw, toChainID)


### PR DESCRIPTION
If no amount is given and user has more than 100MYST it will l try to withdraw all of it, but user will only receive ~100 leading to confusion. This fixes it.