### PR TITLE
Validate withdrawal request body

### DIFF
--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -383,9 +383,9 @@ func Test_Withdrawal(t *testing.T) {
 		t.Run(fmt.Sprintf("succeed withdrawal with fromChainID: %d, toChainID: %d", data.fromChainID, data.toChainID), func(t *testing.T) {
 			// when
 			body, err := json.Marshal(contract.WithdrawRequest{
-				HermesID:    "ignored",
-				ProviderID:  "ignored",
-				Beneficiary: "ignored",
+				HermesID:    "0xe948dae2ce1faf719ba1091d8c6664a46bab073d",
+				ProviderID:  "0xe948dae2ce1faf719ba1091d8c6664a46bab073d",
+				Beneficiary: "0xe948dae2ce1faf719ba1091d8c6664a46bab073d",
 				ToChainID:   data.toChainID,
 				FromChainID: data.fromChainID,
 			})
@@ -418,9 +418,9 @@ func Test_Withdrawal(t *testing.T) {
 		t.Run(fmt.Sprintf("fail withdrawal with unsuported fromChainID: %d, toChainID: %d", data.fromChainID, data.toChainID), func(t *testing.T) {
 			// when
 			body, err := json.Marshal(contract.WithdrawRequest{
-				HermesID:    "ignored",
-				ProviderID:  "ignored",
-				Beneficiary: "ignored",
+				HermesID:    "0xe948dae2ce1faf719ba1091d8c6664a46bab073d",
+				ProviderID:  "0xe948dae2ce1faf719ba1091d8c6664a46bab073d",
+				Beneficiary: "0xe948dae2ce1faf719ba1091d8c6664a46bab073d",
 				ToChainID:   data.toChainID,
 				FromChainID: data.fromChainID,
 			})


### PR DESCRIPTION
Seems like people are able to somehow make withdrawal to a zero address, but their money is still deducted from the channel  :)

Logs from transactor: 
```
json.beneficiary:0x0000000000000000000000000000000000000000
json.error:could not estimate gas: execution reverted: ERC20: transfer to the zero address
```

Updates: https://github.com/mysteriumnetwork/node/issues/4631