### PR TITLE
Use forked library for log rotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/mysteriumnetwork/node
 
 go 1.17
 
+replace github.com/arthurkiller/rollingwriter => github.com/mysteriumnetwork/rollingwriter v1.1.5
+
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/Microsoft/go-winio v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VT
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/arthurkiller/rollingwriter v1.1.2 h1:pFUJUJT8rh4nYf5C6K+Xxq4wUyUL1JvHdFbjNodAH8I=
-github.com/arthurkiller/rollingwriter v1.1.2/go.mod h1:dBwrzt1kWSwBrvlZMAwGKZz7nHyhfgYuGuJON2oEOhs=
 github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05 h1:Shem5lRG4gJyrrg9YMIl7dOQazyWCq0Daz4LjompZ28=
 github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -994,6 +992,8 @@ github.com/mysteriumnetwork/metrics v0.0.18 h1:K/tfP4k9UTW0YPT0PuAcRAC3E5fr5j95x
 github.com/mysteriumnetwork/metrics v0.0.18/go.mod h1:QQHdm9M0p42hESbtM0dxyeooH66QTGtXAArz8qsi4Ds=
 github.com/mysteriumnetwork/payments v1.0.1-0.20211025073343-0b355972a602 h1:Su9N4SQca2OICEPLXTNfMHTKJrPFPKwm0E4HX2XZ7jY=
 github.com/mysteriumnetwork/payments v1.0.1-0.20211025073343-0b355972a602/go.mod h1:dS9ux8H00YhsgBrsqT5pAcaQrcnSGHdLrwy+e+8a7U0=
+github.com/mysteriumnetwork/rollingwriter v1.1.5 h1:FjRpUf5dKv2AcxY9rrTChxPWkH6PGSd52jdeAw9gk0w=
+github.com/mysteriumnetwork/rollingwriter v1.1.5/go.mod h1:dBwrzt1kWSwBrvlZMAwGKZz7nHyhfgYuGuJON2oEOhs=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nats-io/jwt v1.2.2 h1:w3GMTO969dFg+UOKTmmyuu7IGdusK+7Ytlt//OYH/uU=


### PR DESCRIPTION
I forked the library to stop doing rename and delete operations with open files which failed on windows. Now it rotates correctly both in linux and windows, I also created [a PR](https://github.com/arthurkiller/rollingwriter/pull/39) to merge it in the original repo so we can switch back eventually.

To review this PR I suggest looking at [this commit](https://github.com/mysteriumnetwork/rollingwriter/commit/fecb3a316460e60b259149618061bde6de8b3b94).

Closes: #4630 

Signed-off-by: Guillem Bonet <guillem@mysterium.network>