### PR TITLE
fix tests and return to using original log library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,11 @@ module github.com/mysteriumnetwork/node
 
 go 1.17
 
-replace github.com/arthurkiller/rollingwriter => github.com/mysteriumnetwork/rollingwriter v1.1.5
-
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/Microsoft/go-winio v0.5.0
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
-	github.com/arthurkiller/rollingwriter v1.1.2
+	github.com/arthurkiller/rollingwriter v1.1.3-0.20220211070658-c19a8e8b35be
 	github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05
 	github.com/asdine/storm/v3 v3.1.1
 	github.com/aws/aws-sdk-go-v2 v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VT
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/arthurkiller/rollingwriter v1.1.3-0.20220211070658-c19a8e8b35be h1:Y0ZHMob+cMAkrXROBTHTdxu1OBQrI60iayrRqZMjLOw=
+github.com/arthurkiller/rollingwriter v1.1.3-0.20220211070658-c19a8e8b35be/go.mod h1:dBwrzt1kWSwBrvlZMAwGKZz7nHyhfgYuGuJON2oEOhs=
 github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05 h1:Shem5lRG4gJyrrg9YMIl7dOQazyWCq0Daz4LjompZ28=
 github.com/asaskevich/EventBus v0.0.0-20180315140547-d46933a94f05/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -992,8 +994,6 @@ github.com/mysteriumnetwork/metrics v0.0.18 h1:K/tfP4k9UTW0YPT0PuAcRAC3E5fr5j95x
 github.com/mysteriumnetwork/metrics v0.0.18/go.mod h1:QQHdm9M0p42hESbtM0dxyeooH66QTGtXAArz8qsi4Ds=
 github.com/mysteriumnetwork/payments v1.0.1-0.20211025073343-0b355972a602 h1:Su9N4SQca2OICEPLXTNfMHTKJrPFPKwm0E4HX2XZ7jY=
 github.com/mysteriumnetwork/payments v1.0.1-0.20211025073343-0b355972a602/go.mod h1:dS9ux8H00YhsgBrsqT5pAcaQrcnSGHdLrwy+e+8a7U0=
-github.com/mysteriumnetwork/rollingwriter v1.1.5 h1:FjRpUf5dKv2AcxY9rrTChxPWkH6PGSd52jdeAw9gk0w=
-github.com/mysteriumnetwork/rollingwriter v1.1.5/go.mod h1:dBwrzt1kWSwBrvlZMAwGKZz7nHyhfgYuGuJON2oEOhs=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nats-io/jwt v1.2.2 h1:w3GMTO969dFg+UOKTmmyuu7IGdusK+7Ytlt//OYH/uU=

--- a/logconfig/collector_test.go
+++ b/logconfig/collector_test.go
@@ -46,7 +46,7 @@ func TestCollector_List_ListsAllLogFilesMatchingPattern(t *testing.T) {
 	defer os.Remove(fn3)
 
 	// ensure this is the file with the most recent modified time
-	time.Sleep(time.Millisecond * 2)
+	time.Sleep(time.Millisecond * 10)
 	fn4 := NewTempFileName(t, dn1, logFilename+".gz")
 	defer os.Remove(fn4)
 


### PR DESCRIPTION
A test where file creation time is needed to be accurate seems to still fail sometimes in the pipeline. If this doesn't solve it I suggest we just do a simpler test with just one file. Also, we can now return to the original library for rollingwriter.
Signed-off-by: Guillem Bonet <guillem@mysterium.network>