### PR TITLE
Fix settlement matching

### DIFF
--- a/session/pingpong/event/event.go
+++ b/session/pingpong/event/event.go
@@ -96,11 +96,9 @@ type AppEventGrandTotalChanged struct {
 
 // AppEventSettlementComplete represent a completed settlement.
 type AppEventSettlementComplete struct {
-	ProviderID       identity.Identity
-	TxHash           string
-	HermesID         common.Address
-	BlockExplorerURL string
-	ChainID          int64
+	ProviderID identity.Identity
+	HermesID   common.Address
+	ChainID    int64
 }
 
 // AppEventWithdrawalRequested represents a request for withdrawal.


### PR DESCRIPTION
This PR fixes:
* Doing settlements/withdrawal back to back will no longer save incorrect event from BC. Tracking is now accurate and will match the correct transaction, though I would still not use it for accounting purposes.
* If someone front runs us, we should save both the front runners tx and ours and display both of them in the UI. Should reduce on the confusion and make the wallet log more accurate.

Closes: https://github.com/mysteriumnetwork/node/issues/4645