### PR TITLE
Multi hermes balance

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -241,10 +241,10 @@ func (c *cliApp) registerIdentity(actionArgs []string) error {
 	return nil
 }
 
-const usageSettle = "settle <providerIdentity>"
+const usageSettle = "settle <providerIdentity> [hermesID]"
 
 func (c *cliApp) settle(args []string) (err error) {
-	if len(args) != 1 {
+	if len(args) == 0 || len(args) > 2 {
 		clio.Info("Usage: " + usageSettle)
 		fees, err := c.tequilapi.GetTransactorFees()
 		if err != nil {
@@ -259,10 +259,16 @@ func (c *cliApp) settle(args []string) (err error) {
 		clio.Info(fmt.Sprintf("Hermes fee: %s%%", hermesPct.Mul(decimal.NewFromInt(100)).StringFixed(2)))
 		return errWrongArgumentCount
 	}
+
 	hermesID, err := c.config.GetHermesID()
 	if err != nil {
 		return fmt.Errorf("could not get Hermes ID: %w", err)
 	}
+	if len(args) == 2 {
+		hermesID = args[1]
+	}
+
+	clio.Infof("Will settle with hermes: %s", hermesID)
 	clio.Info("Waiting for settlement to complete")
 	errChan := make(chan error)
 

--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -275,7 +275,7 @@ func (c *cliApp) settle(args []string) (err error) {
 		hermesIDs = append(hermesIDs, common.HexToAddress(hermesID))
 	}
 
-	clio.Infof("Will settle with hermes: %v", hermesIDs)
+	clio.Infof("Will settle with hermes: %v\n", hermesIDs)
 	clio.Info("Waiting for settlement to complete")
 	errChan := make(chan error)
 

--- a/core/state/event/event.go
+++ b/core/state/event/event.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mysteriumnetwork/node/identity/registry"
 	"github.com/mysteriumnetwork/node/money"
 	"github.com/mysteriumnetwork/node/session/pingpong"
+	pingpongEvent "github.com/mysteriumnetwork/node/session/pingpong/event"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/payments/crypto"
 )
@@ -51,10 +52,13 @@ type Identity struct {
 	Address            string
 	RegistrationStatus registry.RegistrationStatus
 	ChannelAddress     common.Address
-	Balance            *big.Int
-	Earnings           *big.Int
-	EarningsTotal      *big.Int
-	HermesID           common.Address
+
+	Balance           *big.Int
+	Earnings          *big.Int
+	EarningsTotal     *big.Int
+	EarningsPerHermes map[common.Address]pingpongEvent.Earnings
+
+	HermesID common.Address
 }
 
 // Connection represents consumer connection state.

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -478,8 +478,13 @@ func Test_ConsumesEarningsChangeEvent(t *testing.T) {
 	}
 	eventBus.Publish(pingpongEvent.AppTopicEarningsChanged, pingpongEvent.AppEventEarningsChanged{
 		Identity: identity.Identity{Address: "0x000000000000000000000000000000000000000a"},
-		Previous: pingpongEvent.Earnings{},
-		Current:  pingpongEvent.Earnings{LifetimeBalance: big.NewInt(100), UnsettledBalance: big.NewInt(10)},
+		Previous: pingpongEvent.EarningsDetailed{},
+		Current: pingpongEvent.EarningsDetailed{
+			Total: pingpongEvent.Earnings{
+				LifetimeBalance:  big.NewInt(100),
+				UnsettledBalance: big.NewInt(10),
+			},
+		},
 	})
 
 	// then
@@ -609,7 +614,7 @@ func (mbp *mockBalanceProvider) GetBalance(_ int64, _ identity.Identity) *big.In
 }
 
 type mockEarningsProvider struct {
-	Earnings pingpongEvent.Earnings
+	Earnings pingpongEvent.EarningsDetailed
 	Channels []pingpong.HermesChannel
 }
 
@@ -619,8 +624,8 @@ func (mep *mockEarningsProvider) List(chainID int64) []pingpong.HermesChannel {
 }
 
 // GetEarnings returns a pre-defined settlement state.
-func (mep *mockEarningsProvider) GetEarnings(chainID int64, _ identity.Identity) pingpongEvent.Earnings {
-	return mep.Earnings
+func (mep *mockEarningsProvider) GetEarningsDetailed(chainID int64, _ identity.Identity) *pingpongEvent.EarningsDetailed {
+	return &mep.Earnings
 }
 
 func serviceByID(services []contract.ServiceInfoDTO, id string) (se contract.ServiceInfoDTO, found bool) {

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -191,11 +191,11 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 		assert.Equal(t, balanceAfterRegistration, providerStatus.Balance)
 
 		// settle hermes 1
-		err = tequilapiProvider.Settle(identity.FromAddress(providerID), identity.FromAddress(hermesID), true)
-		assert.NoError(t, err)
-
-		// settle hermes 2
-		err = tequilapiProvider.Settle(identity.FromAddress(providerID), identity.FromAddress(hermes2ID), true)
+		hermeses := []common.Address{
+			common.HexToAddress(hermesID),
+			common.HexToAddress(hermes2ID),
+		}
+		err = tequilapiProvider.Settle(identity.FromAddress(providerID), hermeses, true)
 		assert.NoError(t, err)
 
 		providerStatus, err = tequilapiProvider.Identity(providerID)

--- a/session/pingpong/event/event.go
+++ b/session/pingpong/event/event.go
@@ -66,8 +66,14 @@ type AppEventBalanceChanged struct {
 // AppEventEarningsChanged represents a balance change event
 type AppEventEarningsChanged struct {
 	Identity identity.Identity
-	Previous Earnings
-	Current  Earnings
+	Previous EarningsDetailed
+	Current  EarningsDetailed
+}
+
+// EarningsDetailed returns total and split per hermes earnings
+type EarningsDetailed struct {
+	Total     Earnings
+	PerHermes map[common.Address]Earnings
 }
 
 // Earnings represents current identity earnings

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -136,6 +136,7 @@ func (hcr *HermesChannelRepository) GetEarnings(chainID int64, id identity.Ident
 	return hcr.sumChannels(chainID, id)
 }
 
+// GetEarningsDetailed returns earnings in a detailed format grouping them by hermes ID but also providing totals.
 func (hcr *HermesChannelRepository) GetEarningsDetailed(chainID int64, id identity.Identity) *event.EarningsDetailed {
 	hcr.lock.RLock()
 	defer hcr.lock.RUnlock()

--- a/session/pingpong/hermes_channel_repository.go
+++ b/session/pingpong/hermes_channel_repository.go
@@ -136,20 +136,15 @@ func (hcr *HermesChannelRepository) GetEarnings(chainID int64, id identity.Ident
 	return hcr.sumChannels(chainID, id)
 }
 
-type EarningsDetailed struct {
-	Total     event.Earnings
-	PerHermes map[common.Address]event.Earnings
-}
-
-func (hcr *HermesChannelRepository) GetEarningsDetailed(chainID int64, id identity.Identity) *EarningsDetailed {
+func (hcr *HermesChannelRepository) GetEarningsDetailed(chainID int64, id identity.Identity) *event.EarningsDetailed {
 	hcr.lock.RLock()
 	defer hcr.lock.RUnlock()
 
 	return hcr.sumChannelsDetailed(chainID, id)
 }
 
-func (hcr *HermesChannelRepository) sumChannelsDetailed(chainID int64, id identity.Identity) *EarningsDetailed {
-	result := &EarningsDetailed{
+func (hcr *HermesChannelRepository) sumChannelsDetailed(chainID int64, id identity.Identity) *event.EarningsDetailed {
+	result := &event.EarningsDetailed{
 		Total: event.Earnings{
 			LifetimeBalance:  new(big.Int),
 			UnsettledBalance: new(big.Int),
@@ -328,7 +323,7 @@ func (hcr *HermesChannelRepository) updateChannelWithLatestPromise(chainID int64
 }
 
 func (hcr *HermesChannelRepository) updateChannel(chainID int64, new HermesChannel) {
-	earningsOld := hcr.sumChannels(chainID, new.Identity)
+	earningsOld := hcr.sumChannelsDetailed(chainID, new.Identity)
 
 	updated := false
 
@@ -354,10 +349,10 @@ func (hcr *HermesChannelRepository) updateChannel(chainID int64, new HermesChann
 		new.UnsettledBalance(),
 	)
 
-	earningsNew := hcr.sumChannels(chainID, new.Identity)
+	earningsNew := hcr.sumChannelsDetailed(chainID, new.Identity)
 	go hcr.publisher.Publish(event.AppTopicEarningsChanged, event.AppEventEarningsChanged{
 		Identity: new.Identity,
-		Previous: earningsOld,
-		Current:  earningsNew,
+		Previous: *earningsOld,
+		Current:  *earningsNew,
 	})
 }

--- a/session/pingpong/hermes_channel_repository_test.go
+++ b/session/pingpong/hermes_channel_repository_test.go
@@ -164,13 +164,24 @@ func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
 			t,
 			event.AppEventEarningsChanged{
 				Identity: id,
-				Previous: event.Earnings{
-					LifetimeBalance:  big.NewInt(0),
-					UnsettledBalance: big.NewInt(0),
+				Previous: event.EarningsDetailed{
+					Total: event.Earnings{
+						LifetimeBalance:  big.NewInt(0),
+						UnsettledBalance: big.NewInt(0),
+					},
+					PerHermes: map[common.Address]event.Earnings{},
 				},
-				Current: event.Earnings{
-					LifetimeBalance:  expectedChannel1.LifetimeBalance(),
-					UnsettledBalance: expectedChannel1.UnsettledBalance(),
+				Current: event.EarningsDetailed{
+					Total: event.Earnings{
+						LifetimeBalance:  expectedChannel1.LifetimeBalance(),
+						UnsettledBalance: expectedChannel1.UnsettledBalance(),
+					},
+					PerHermes: map[common.Address]event.Earnings{
+						hermesID: {
+							LifetimeBalance:  expectedChannel1.LifetimeBalance(),
+							UnsettledBalance: expectedChannel1.UnsettledBalance(),
+						},
+					},
 				},
 			},
 			lastEvent,
@@ -196,13 +207,29 @@ func TestHermesChannelRepository_Fetch_publishesEarningChanges(t *testing.T) {
 			t,
 			event.AppEventEarningsChanged{
 				Identity: id,
-				Previous: event.Earnings{
-					LifetimeBalance:  expectedChannel1.LifetimeBalance(),
-					UnsettledBalance: expectedChannel1.UnsettledBalance(),
+				Previous: event.EarningsDetailed{
+					Total: event.Earnings{
+						LifetimeBalance:  expectedChannel1.LifetimeBalance(),
+						UnsettledBalance: expectedChannel1.UnsettledBalance(),
+					},
+					PerHermes: map[common.Address]event.Earnings{
+						hermesID: {
+							LifetimeBalance:  expectedChannel1.LifetimeBalance(),
+							UnsettledBalance: expectedChannel1.UnsettledBalance(),
+						},
+					},
 				},
-				Current: event.Earnings{
-					LifetimeBalance:  expectedChannel2.LifetimeBalance(),
-					UnsettledBalance: expectedChannel2.UnsettledBalance(),
+				Current: event.EarningsDetailed{
+					Total: event.Earnings{
+						LifetimeBalance:  expectedChannel2.LifetimeBalance(),
+						UnsettledBalance: expectedChannel2.UnsettledBalance(),
+					},
+					PerHermes: map[common.Address]event.Earnings{
+						hermesID: {
+							LifetimeBalance:  expectedChannel2.LifetimeBalance(),
+							UnsettledBalance: expectedChannel2.UnsettledBalance(),
+						},
+					},
 				},
 			},
 			lastEvent,

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -189,7 +189,8 @@ func (aps *hermesPromiseSettler) loadInitialState(chainID int64, id identity.Ide
 	}
 
 	aps.currentState[id] = settlementState{
-		registered: true,
+		registered:       true,
+		settleInProgress: make(map[common.Address]struct{}),
 	}
 	return nil
 }

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -1082,6 +1082,11 @@ func (aps *hermesPromiseSettler) isSettling(id identity.Identity, hermesID commo
 		return false
 	}
 
+	if v.settleInProgress == nil {
+		v.settleInProgress = make(map[common.Address]struct{})
+		aps.currentState[id] = v
+	}
+
 	_, ok = v.settleInProgress[hermesID]
 
 	return ok
@@ -1091,6 +1096,10 @@ func (aps *hermesPromiseSettler) setSettling(id identity.Identity, hermesID comm
 	aps.lock.Lock()
 	defer aps.lock.Unlock()
 	v := aps.currentState[id]
+
+	if v.settleInProgress == nil {
+		v.settleInProgress = make(map[common.Address]struct{})
+	}
 
 	if settling {
 		v.settleInProgress[hermesID] = struct{}{}

--- a/session/pingpong/noop/hermes_promise_settler.go
+++ b/session/pingpong/noop/hermes_promise_settler.go
@@ -29,12 +29,12 @@ type NoopHermesPromiseSettler struct {
 }
 
 // ForceSettle does nothing.
-func (n *NoopHermesPromiseSettler) ForceSettle(chainID int64, _ identity.Identity, _ common.Address) error {
+func (n *NoopHermesPromiseSettler) ForceSettle(chainID int64, _ identity.Identity, _ ...common.Address) error {
 	return nil
 }
 
 // SettleIntoStake does nothing.
-func (n *NoopHermesPromiseSettler) SettleIntoStake(chainID int64, providerID identity.Identity, accountantID common.Address) error {
+func (n *NoopHermesPromiseSettler) SettleIntoStake(chainID int64, providerID identity.Identity, accountantID ...common.Address) error {
 	return nil
 }
 

--- a/tequilapi/client/client.go
+++ b/tequilapi/client/client.go
@@ -620,10 +620,10 @@ func (client *Client) Withdraw(providerID identity.Identity, hermesID, beneficia
 }
 
 // Settle requests the settling of hermes promises
-func (client *Client) Settle(providerID, hermesID identity.Identity, waitForBlockchain bool) error {
+func (client *Client) Settle(providerID identity.Identity, hermesIDs []common.Address, waitForBlockchain bool) error {
 	settleRequest := contract.SettleRequest{
 		ProviderID: providerID.Address,
-		HermesID:   hermesID.Address,
+		HermesIDs:  hermesIDs,
 	}
 
 	path := "transactor/settle/"

--- a/tequilapi/contract/identity.go
+++ b/tequilapi/contract/identity.go
@@ -20,8 +20,10 @@ package contract
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/mysteriumnetwork/go-rest/apierror"
 	"github.com/mysteriumnetwork/node/identity"
+	pingpong_event "github.com/mysteriumnetwork/node/session/pingpong/event"
 )
 
 // IdentityRefDTO represents unique identity reference.
@@ -70,6 +72,19 @@ type IdentityDTO struct {
 type EarningsDTO struct {
 	Earnings      Tokens `json:"earnings"`
 	EarningsTotal Tokens `json:"earnings_total"`
+}
+
+// NewEarningsPerHermesDTO transforms the pingong value in a public one.
+func NewEarningsPerHermesDTO(earnings map[common.Address]pingpong_event.Earnings) map[string]EarningsDTO {
+	settlementsPerHermes := make(map[string]EarningsDTO)
+	for h, earn := range earnings {
+		settlementsPerHermes[h.Hex()] = EarningsDTO{
+			Earnings:      NewTokens(earn.UnsettledBalance),
+			EarningsTotal: NewTokens(earn.LifetimeBalance),
+		}
+	}
+
+	return settlementsPerHermes
 }
 
 // NewIdentityDTO maps to API identity.

--- a/tequilapi/contract/identity.go
+++ b/tequilapi/contract/identity.go
@@ -52,18 +52,24 @@ type IdentityDTO struct {
 
 	// deprecated
 	Balance       *big.Int `json:"balance"`
-	BalanceTokens Tokens   `json:"balance_tokens"`
+	Earnings      *big.Int `json:"earnings"`
+	EarningsTotal *big.Int `json:"earnings_total"`
+	// ===========
 
-	// deprecated
-	Earnings       *big.Int `json:"earnings"`
-	EarningsTokens Tokens   `json:"earnings_tokens"`
+	BalanceTokens       Tokens `json:"balance_tokens"`
+	EarningsTokens      Tokens `json:"earnings_tokens"`
+	EarningsTotalTokens Tokens `json:"earnings_total_tokens"`
 
-	// deprecated
-	EarningsTotal       *big.Int `json:"earnings_total"`
-	EarningsTotalTokens Tokens   `json:"earnings_total_tokens"`
+	Stake             *big.Int               `json:"stake"`
+	HermesID          string                 `json:"hermes_id"`
+	EarningsPerHermes map[string]EarningsDTO `json:"earnings_per_hermes"`
+}
 
-	Stake    *big.Int `json:"stake"`
-	HermesID string   `json:"hermes_id"`
+// EarningsDTO holds earnings data.
+// swagger:model EarningsDTO
+type EarningsDTO struct {
+	Earnings      Tokens `json:"earnings"`
+	EarningsTotal Tokens `json:"earnings_total"`
 }
 
 // NewIdentityDTO maps to API identity.

--- a/tequilapi/contract/transactor.go
+++ b/tequilapi/contract/transactor.go
@@ -232,8 +232,10 @@ type SettlementDTO struct {
 // swagger:model SettleRequestDTO
 type SettleRequest struct {
 	HermesIDs  []common.Address `json:"hermes_ids"`
-	HermesID   string           `json:"hermes_id"`
 	ProviderID string           `json:"provider_id"`
+
+	// Deprecated
+	HermesID string `json:"hermes_id"`
 }
 
 // WithdrawRequest represents the request to withdraw earnings to l1.

--- a/tequilapi/contract/transactor.go
+++ b/tequilapi/contract/transactor.go
@@ -231,8 +231,9 @@ type SettlementDTO struct {
 // SettleRequest represents the request to settle hermes promises
 // swagger:model SettleRequestDTO
 type SettleRequest struct {
-	HermesID   string `json:"hermes_id"`
-	ProviderID string `json:"provider_id"`
+	HermesIDs  []common.Address `json:"hermes_ids"`
+	HermesID   string           `json:"hermes_id"`
+	ProviderID string           `json:"provider_id"`
 }
 
 // WithdrawRequest represents the request to withdraw earnings to l1.

--- a/tequilapi/docs/swagger.json
+++ b/tequilapi/docs/swagger.json
@@ -2835,6 +2835,15 @@
       },
       "x-go-package": "github.com/mysteriumnetwork/node/market"
     },
+    "Address": {
+      "type": "array",
+      "title": "Address represents the 20 byte address of an Ethereum account.",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      },
+      "x-go-package": "github.com/ethereum/go-ethereum/common"
+    },
     "AuthRequest": {
       "type": "object",
       "title": "AuthRequest request used to authenticate to API.",
@@ -3256,6 +3265,19 @@
       "x-go-name": "Status",
       "x-go-package": "github.com/mysteriumnetwork/node/ui/versionmanager"
     },
+    "EarningsDTO": {
+      "type": "object",
+      "title": "EarningsDTO holds earnings data.",
+      "properties": {
+        "earnings": {
+          "$ref": "#/definitions/Tokens"
+        },
+        "earnings_total": {
+          "$ref": "#/definitions/Tokens"
+        }
+      },
+      "x-go-package": "github.com/mysteriumnetwork/node/tequilapi/contract"
+    },
     "EligibilityResponse": {
       "description": "EligibilityResponse represents the eligibility response",
       "type": "object",
@@ -3520,6 +3542,13 @@
         },
         "earnings": {
           "$ref": "#/definitions/Int"
+        },
+        "earnings_per_hermes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/EarningsDTO"
+          },
+          "x-go-name": "EarningsPerHermes"
         },
         "earnings_tokens": {
           "$ref": "#/definitions/Tokens"
@@ -4678,8 +4707,16 @@
       "type": "object",
       "properties": {
         "hermes_id": {
+          "description": "Deprecated",
           "type": "string",
           "x-go-name": "HermesID"
+        },
+        "hermes_ids": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Address"
+          },
+          "x-go-name": "HermesIDs"
         },
         "provider_id": {
           "type": "string",

--- a/tequilapi/endpoints/identities.go
+++ b/tequilapi/endpoints/identities.go
@@ -31,7 +31,6 @@ import (
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/identity/registry"
 	identity_selector "github.com/mysteriumnetwork/node/identity/selector"
-	"github.com/mysteriumnetwork/node/session/pingpong"
 	pingpong_event "github.com/mysteriumnetwork/node/session/pingpong/event"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
@@ -46,7 +45,7 @@ type balanceProvider interface {
 
 type earningsProvider interface {
 	GetEarnings(chainID int64, id identity.Identity) pingpong_event.Earnings
-	GetEarningsDetailed(chainID int64, id identity.Identity) *pingpong.EarningsDetailed
+	GetEarningsDetailed(chainID int64, id identity.Identity) *pingpong_event.EarningsDetailed
 }
 
 type beneficiaryProvider interface {

--- a/tequilapi/endpoints/identities.go
+++ b/tequilapi/endpoints/identities.go
@@ -31,6 +31,7 @@ import (
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/identity/registry"
 	identity_selector "github.com/mysteriumnetwork/node/identity/selector"
+	"github.com/mysteriumnetwork/node/session/pingpong"
 	pingpong_event "github.com/mysteriumnetwork/node/session/pingpong/event"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 	"github.com/mysteriumnetwork/node/tequilapi/utils"
@@ -45,6 +46,7 @@ type balanceProvider interface {
 
 type earningsProvider interface {
 	GetEarnings(chainID int64, id identity.Identity) pingpong_event.Earnings
+	GetEarningsDetailed(chainID int64, id identity.Identity) *pingpong.EarningsDetailed
 }
 
 type beneficiaryProvider interface {
@@ -331,15 +333,15 @@ func (ia *identitiesAPI) Get(c *gin.Context) {
 		return
 	}
 
-	var stake = new(big.Int)
-	hermesID, err := ia.channelCalculator.GetActiveHermes(chainID)
+	defaultHermesID, err := ia.channelCalculator.GetActiveHermes(chainID)
 	if err != nil {
 		c.Error(apierror.Internal("Could not get active hermes: "+err.Error(), contract.ErrCodeActiveHermes))
 		return
 	}
 
+	var stake = new(big.Int)
 	if regStatus == registry.Registered {
-		data, err := ia.bc.GetProviderChannel(chainID, hermesID, common.HexToAddress(address), false)
+		data, err := ia.bc.GetProviderChannel(chainID, defaultHermesID, common.HexToAddress(address), false)
 		if err != nil {
 			c.Error(apierror.Internal("Failed to check blockchain registration status: "+err.Error(), contract.ErrCodeIDBlockchainRegistrationCheck))
 			return
@@ -348,19 +350,29 @@ func (ia *identitiesAPI) Get(c *gin.Context) {
 	}
 
 	balance := ia.balanceProvider.GetBalance(chainID, id)
-	settlement := ia.earningsProvider.GetEarnings(chainID, id)
+	earnings := ia.earningsProvider.GetEarningsDetailed(chainID, id)
+
+	settlementsPerHermes := make(map[string]contract.EarningsDTO)
+	for h, earn := range earnings.PerHermes {
+		settlementsPerHermes[h.Hex()] = contract.EarningsDTO{
+			Earnings:      contract.NewTokens(earn.UnsettledBalance),
+			EarningsTotal: contract.NewTokens(earn.LifetimeBalance),
+		}
+	}
+
 	status := contract.IdentityDTO{
 		Address:             address,
 		RegistrationStatus:  regStatus.String(),
 		ChannelAddress:      channelAddress.Hex(),
 		Balance:             balance,
 		BalanceTokens:       contract.NewTokens(balance),
-		Earnings:            settlement.UnsettledBalance,
-		EarningsTokens:      contract.NewTokens(settlement.UnsettledBalance),
-		EarningsTotal:       settlement.LifetimeBalance,
-		EarningsTotalTokens: contract.NewTokens(settlement.LifetimeBalance),
+		Earnings:            earnings.Total.UnsettledBalance,
+		EarningsTokens:      contract.NewTokens(earnings.Total.UnsettledBalance),
+		EarningsTotal:       earnings.Total.LifetimeBalance,
+		EarningsTotalTokens: contract.NewTokens(earnings.Total.LifetimeBalance),
 		Stake:               stake,
-		HermesID:            hermesID.Hex(),
+		HermesID:            defaultHermesID.Hex(),
+		EarningsPerHermes:   settlementsPerHermes,
 	}
 	utils.WriteAsJSON(status, c.Writer)
 }

--- a/tequilapi/endpoints/identities.go
+++ b/tequilapi/endpoints/identities.go
@@ -44,7 +44,6 @@ type balanceProvider interface {
 }
 
 type earningsProvider interface {
-	GetEarnings(chainID int64, id identity.Identity) pingpong_event.Earnings
 	GetEarningsDetailed(chainID int64, id identity.Identity) *pingpong_event.EarningsDetailed
 }
 
@@ -371,7 +370,7 @@ func (ia *identitiesAPI) Get(c *gin.Context) {
 		EarningsTotalTokens: contract.NewTokens(earnings.Total.LifetimeBalance),
 		Stake:               stake,
 		HermesID:            defaultHermesID.Hex(),
-		EarningsPerHermes:   settlementsPerHermes,
+		EarningsPerHermes:   contract.NewEarningsPerHermesDTO(earnings.PerHermes),
 	}
 	utils.WriteAsJSON(status, c.Writer)
 }

--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -246,6 +246,7 @@ func mapState(event stateEvent.State) stateRes {
 			EarningsTotalTokens: contract.NewTokens(identity.EarningsTotal),
 			Stake:               stake,
 			HermesID:            identity.HermesID.Hex(),
+			EarningsPerHermes:   contract.NewEarningsPerHermesDTO(identity.EarningsPerHermes),
 		}
 	}
 

--- a/tequilapi/endpoints/sse_handler_test.go
+++ b/tequilapi/endpoints/sse_handler_test.go
@@ -35,6 +35,7 @@ import (
 	nodeEvent "github.com/mysteriumnetwork/node/core/node/event"
 	stateEvent "github.com/mysteriumnetwork/node/core/state/event"
 	"github.com/mysteriumnetwork/node/identity/registry"
+	"github.com/mysteriumnetwork/node/session/pingpong/event"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -195,6 +196,12 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
 			Balance:            big.NewInt(50),
 			Earnings:           big.NewInt(1),
 			EarningsTotal:      big.NewInt(100),
+			EarningsPerHermes: map[common.Address]event.Earnings{
+				common.HexToAddress("0x200000000000000000000000000000000000000a"): {
+					LifetimeBalance:  big.NewInt(100),
+					UnsettledBalance: big.NewInt(50),
+				},
+			},
 		},
 	}
 	h.ConsumeStateEvent(changedState)
@@ -204,52 +211,66 @@ func TestHandler_SendsInitialAndFollowingStates(t *testing.T) {
 	msgJSON = strings.TrimPrefix(msg, "data: ")
 	expectJSON = `
 {
-  "payload": {
-    "service_info": null,
-    "sessions": [],
-    "sessions_stats": {
-      "count": 0,
-      "count_consumers": 0,
-      "sum_bytes_received": 0,
-      "sum_bytes_sent": 0,
-      "sum_duration": 0,
-      "sum_tokens": 0
+	"payload": {
+		"service_info": null,
+		"sessions": [],
+		"sessions_stats": {
+			"count": 0,
+			"count_consumers": 0,
+			"sum_bytes_received": 0,
+			"sum_bytes_sent": 0,
+			"sum_duration": 0,
+			"sum_tokens": 0
+		},
+		"consumer": {
+			"connection": {
+				"status": "Connecting"
+			}
+		},
+		"identities": [
+			{
+				"id": "0xd535eba31e9bd2d7a4e34852e6292b359e5c77f7",
+				"registration_status": "Registered",
+				"channel_address": "0x000000000000000000000000000000000000000A",
+				"balance": 50,
+				"earnings": 1,
+				"earnings_total": 100,
+				"balance_tokens": {
+					"wei": "50",
+					"ether": "0.00000000000000005",
+					"human": "0"
+				},
+				"earnings_tokens": {
+					"wei": "1",
+					"ether": "0.000000000000000001",
+					"human": "0"
+				},
+				"earnings_total_tokens": {
+					"wei": "100",
+					"ether": "0.0000000000000001",
+					"human": "0"
+				},
+				"stake": 0,
+				"hermes_id": "0x0000000000000000000000000000000000000000",
+				"earnings_per_hermes": {
+					"0x200000000000000000000000000000000000000A": {
+						"earnings": {
+							"wei": "50",
+							"ether": "0.00000000000000005",
+							"human": "0"
+						},
+						"earnings_total": {
+							"wei": "100",
+							"ether": "0.0000000000000001",
+							"human": "0"
+						}
+					}
+				}
+			}
+		],
+		"channels": []
 	},
-    "consumer": {
-      "connection": {
-        "status": "Connecting"
-      }
-    },
-    "identities": [
-      {
-        "id": "0xd535eba31e9bd2d7a4e34852e6292b359e5c77f7",
-        "registration_status": "Registered",
-        "channel_address": "0x000000000000000000000000000000000000000A",
-        "hermes_id": "0x0000000000000000000000000000000000000000",
-        "balance": 50,
-		"balance_tokens": {
-			"wei": "50",
-			"ether": "0.00000000000000005",
-			"human": "0"
-		},
-        "earnings": 1,
-		"earnings_tokens": {
-			"wei": "1",
-			"ether": "0.000000000000000001",
-			"human": "0"
-		},
-		"earnings_total": 100,
-		"earnings_total_tokens": {
-			"wei": "100",
-			"ether": "0.0000000000000001",
-			"human": "0"
-		},
-		"stake": 0
-      }
-    ],
-    "channels": []
-  },
-  "type": "state-change"
+	"type": "state-change"
 }`
 	assert.JSONEq(t, expectJSON, msgJSON)
 

--- a/tequilapi/endpoints/transactor.go
+++ b/tequilapi/endpoints/transactor.go
@@ -243,8 +243,21 @@ func (te *transactorEndpoint) settle(request *http.Request, settler func(int64, 
 		return errors.Wrap(err, "failed to unmarshal settle request")
 	}
 
+	hermesIDs := []common.Address{
+		// TODO: Remove this ant just use req.HermesIDs when UI upgrades.
+		common.HexToAddress(req.HermesID),
+	}
+
+	if len(req.HermesIDs) > 0 {
+		hermesIDs = req.HermesIDs
+	}
+
+	if len(hermesIDs) == 0 {
+		return errors.New("must specify a hermes to settle with")
+	}
+
 	chainID := config.GetInt64(config.FlagChainID)
-	return errors.Wrap(settler(chainID, identity.FromAddress(req.ProviderID), req.HermesIDs...), "settling failed")
+	return errors.Wrap(settler(chainID, identity.FromAddress(req.ProviderID), hermesIDs...), "settling failed")
 }
 
 // swagger:operation POST /identities/{id}/register Identity RegisterIdentity

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -502,11 +502,11 @@ type mockSettler struct {
 	capturedFromChainID int64
 }
 
-func (ms *mockSettler) ForceSettle(_ int64, _ identity.Identity, _ common.Address) error {
+func (ms *mockSettler) ForceSettle(_ int64, _ identity.Identity, _ ...common.Address) error {
 	return ms.errToReturn
 }
 
-func (ms *mockSettler) SettleIntoStake(_ int64, providerID identity.Identity, hermesID common.Address) error {
+func (ms *mockSettler) SettleIntoStake(_ int64, providerID identity.Identity, hermesID ...common.Address) error {
 	return nil
 }
 


### PR DESCRIPTION
* Node is now aware of earnings per hermes
* TequilaAPI now allows to settle with any number of hermeses
* Transactor has been updated to lock provider settlements per identity+hermesID
* Tests now also test for multiple settlements from a single API request

Closes: https://github.com/mysteriumnetwork/hermes/issues/303