### PR TITLE
Increase invoice timers during session

### DIFF
--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -213,11 +213,12 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 
 	newP2PSessionHandler := func(serviceInstance *service.Instance, channel p2p.Channel) *service.SessionManager {
 		paymentEngineFactory := pingpong.InvoiceFactoryCreator(
-			channel, nodeOptions.Payments.ProviderInvoiceFrequency,
+			channel, nodeOptions.Payments.ProviderInvoiceFrequency, nodeOptions.Payments.ProviderLimitInvoiceFrequency,
 			pingpong.PromiseWaitTimeout, di.ProviderInvoiceStorage,
 			pingpong.DefaultHermesFailureCount,
 			uint16(nodeOptions.Payments.MaxAllowedPaymentPercentile),
 			nodeOptions.Payments.MaxUnpaidInvoiceValue,
+			nodeOptions.Payments.LimitUnpaidInvoiceValue,
 			di.HermesStatusChecker,
 			di.EventBus,
 			di.HermesPromiseHandler,

--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -99,23 +99,11 @@ var (
 		Usage:  "The duration we'll wait before giving up on transactors registration status",
 		Hidden: true,
 	}
-	// FlagPaymentsProviderInvoiceFrequency determines how often the provider sends invoices.
-	FlagPaymentsProviderInvoiceFrequency = cli.DurationFlag{
-		Name:  "payments.provider.invoice-frequency",
-		Value: time.Minute,
-		Usage: "Determines how often the provider sends invoices.",
-	}
 	// FlagPaymentsConsumerDataLeewayMegabytes sets the data amount the consumer agrees to pay before establishing a session
 	FlagPaymentsConsumerDataLeewayMegabytes = cli.Uint64Flag{
 		Name:  "payments.consumer.data-leeway-megabytes",
 		Usage: "sets the data amount the consumer agrees to pay before establishing a session",
 		Value: metadata.MainnetDefinition.Payments.Consumer.DataLeewayMegabytes,
-	}
-	// FlagPaymentsMaxUnpaidInvoiceValue sets the upper limit of session payment value before forcing an invoice
-	FlagPaymentsMaxUnpaidInvoiceValue = cli.StringFlag{
-		Name:  "payments.provider.max-unpaid-invoice-value",
-		Usage: "sets the upper limit of session payment value before forcing an invoice. If this value is exceeded before a payment interval is reached, an invoice is sent.",
-		Value: "3000000000000000",
 	}
 	// FlagPaymentsHermesStatusRecheckInterval sets how often we re-check the hermes status on bc. Higher values allow for less bc lookups but increase the risk for provider.
 	FlagPaymentsHermesStatusRecheckInterval = cli.DurationFlag{
@@ -152,6 +140,36 @@ var (
 		Usage: "full address of the observer service",
 		Value: metadata.DefaultNetwork.ObserverAddress,
 	}
+
+	// FlagPaymentsLimitUnpaidInvoiceValue sets the upper limit of session payment value before forcing an invoice
+	FlagPaymentsLimitUnpaidInvoiceValue = cli.StringFlag{
+		Name:  "payments.provider.max-unpaid-invoice-value-limit",
+		Usage: "sets the max upper limit of session payment value before forcing an invoice. If this value is exceeded before a payment interval is reached, an invoice is sent.",
+		Value: "30000000000000000",
+	}
+
+	// FlagPaymentsUnpaidInvoiceValue sets the starting max limit of session payment value before forcing an invoice
+	FlagPaymentsUnpaidInvoiceValue = cli.StringFlag{
+		Name:   "payments.provider.max-unpaid-invoice-value",
+		Usage:  "sets the starting upper limit of session payment value before forcing an invoice. If this value is exceeded before a payment interval is reached, an invoice is sent.",
+		Value:  "3000000000000000",
+		Hidden: true,
+	}
+
+	// FlagPaymentsProviderInvoiceFrequency determines how often the provider sends invoices.
+	FlagPaymentsProviderInvoiceFrequency = cli.DurationFlag{
+		Name:   "payments.provider.invoice-frequency",
+		Value:  time.Second * 30,
+		Usage:  "Determines how often the provider sends invoices.",
+		Hidden: true,
+	}
+
+	// FlagPaymentsLimitProviderInvoiceFrequency determines how often the provider sends invoices.
+	FlagPaymentsLimitProviderInvoiceFrequency = cli.DurationFlag{
+		Name:  "payments.provider.invoice-frequency-limit",
+		Value: time.Minute * 5,
+		Usage: "Determines how often the provider sends invoices.",
+	}
 )
 
 // RegisterFlagsPayments function register payments flags to flag list.
@@ -168,15 +186,19 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagPaymentsFastBalancePollTimeout,
 		&FlagPaymentsRegistryTransactorPollTimeout,
 		&FlagPaymentsRegistryTransactorPollInterval,
-		&FlagPaymentsProviderInvoiceFrequency,
 		&FlagPaymentsConsumerDataLeewayMegabytes,
-		&FlagPaymentsMaxUnpaidInvoiceValue,
 		&FlagPaymentsHermesStatusRecheckInterval,
 		&FlagOffchainBalanceExpiration,
 		&FlagPaymentsZeroStakeUnsettledAmount,
 		&FlagPaymentsDuringSessionDebug,
 		&FlagPaymentsAmountDuringSessionDebug,
 		&FlagObserverAddress,
+
+		&FlagPaymentsProviderInvoiceFrequency,
+		&FlagPaymentsLimitProviderInvoiceFrequency,
+
+		&FlagPaymentsUnpaidInvoiceValue,
+		&FlagPaymentsLimitUnpaidInvoiceValue,
 	)
 }
 
@@ -187,7 +209,6 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseFloat64Flag(ctx, FlagPaymentsHermesPromiseSettleThreshold)
 	Current.ParseDurationFlag(ctx, FlagPaymentsHermesPromiseSettleTimeout)
 	Current.ParseDurationFlag(ctx, FlagPaymentsHermesPromiseSettleCheckInterval)
-	Current.ParseDurationFlag(ctx, FlagPaymentsProviderInvoiceFrequency)
 	Current.ParseDurationFlag(ctx, FlagPaymentsFastBalancePollInterval)
 	Current.ParseDurationFlag(ctx, FlagPaymentsFastBalancePollTimeout)
 	Current.ParseDurationFlag(ctx, FlagPaymentsLongBalancePollInterval)
@@ -195,11 +216,16 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseDurationFlag(ctx, FlagPaymentsRegistryTransactorPollInterval)
 	Current.ParseDurationFlag(ctx, FlagPaymentsRegistryTransactorPollTimeout)
 	Current.ParseUInt64Flag(ctx, FlagPaymentsConsumerDataLeewayMegabytes)
-	Current.ParseStringFlag(ctx, FlagPaymentsMaxUnpaidInvoiceValue)
 	Current.ParseDurationFlag(ctx, FlagPaymentsHermesStatusRecheckInterval)
 	Current.ParseDurationFlag(ctx, FlagOffchainBalanceExpiration)
 	Current.ParseFloat64Flag(ctx, FlagPaymentsZeroStakeUnsettledAmount)
 	Current.ParseBoolFlag(ctx, FlagPaymentsDuringSessionDebug)
 	Current.ParseUInt64Flag(ctx, FlagPaymentsAmountDuringSessionDebug)
 	Current.ParseStringFlag(ctx, FlagObserverAddress)
+
+	Current.ParseDurationFlag(ctx, FlagPaymentsProviderInvoiceFrequency)
+	Current.ParseDurationFlag(ctx, FlagPaymentsLimitProviderInvoiceFrequency)
+
+	Current.ParseStringFlag(ctx, FlagPaymentsLimitUnpaidInvoiceValue)
+	Current.ParseStringFlag(ctx, FlagPaymentsUnpaidInvoiceValue)
 }

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -162,10 +162,13 @@ func GetOptions() *Options {
 			RegistryTransactorPollInterval: config.GetDuration(config.FlagPaymentsRegistryTransactorPollInterval),
 			RegistryTransactorPollTimeout:  config.GetDuration(config.FlagPaymentsRegistryTransactorPollTimeout),
 			ConsumerDataLeewayMegabytes:    config.GetUInt64(config.FlagPaymentsConsumerDataLeewayMegabytes),
-			ProviderInvoiceFrequency:       config.GetDuration(config.FlagPaymentsProviderInvoiceFrequency),
-			MaxUnpaidInvoiceValue:          config.GetBigInt(config.FlagPaymentsMaxUnpaidInvoiceValue),
 			HermesStatusRecheckInterval:    config.GetDuration(config.FlagPaymentsHermesStatusRecheckInterval),
 			ZeroStakeSettlementThreshold:   config.GetFloat64(config.FlagPaymentsZeroStakeUnsettledAmount),
+
+			ProviderInvoiceFrequency:      config.GetDuration(config.FlagPaymentsProviderInvoiceFrequency),
+			ProviderLimitInvoiceFrequency: config.GetDuration(config.FlagPaymentsLimitProviderInvoiceFrequency),
+			MaxUnpaidInvoiceValue:         config.GetBigInt(config.FlagPaymentsUnpaidInvoiceValue),
+			LimitUnpaidInvoiceValue:       config.GetBigInt(config.FlagPaymentsLimitUnpaidInvoiceValue),
 		},
 		Chains: OptionsChains{
 			Chain1: metadata.ChainDefinition{

--- a/core/node/options_payments.go
+++ b/core/node/options_payments.go
@@ -30,8 +30,6 @@ type OptionsPayments struct {
 	SettlementTimeout              time.Duration
 	SettlementRecheckInterval      time.Duration
 	ConsumerDataLeewayMegabytes    uint64
-	ProviderInvoiceFrequency       time.Duration
-	MaxUnpaidInvoiceValue          *big.Int
 	HermesStatusRecheckInterval    time.Duration
 	BalanceFastPollInterval        time.Duration
 	BalanceFastPollTimeout         time.Duration
@@ -39,4 +37,10 @@ type OptionsPayments struct {
 	RegistryTransactorPollInterval time.Duration
 	RegistryTransactorPollTimeout  time.Duration
 	ZeroStakeSettlementThreshold   float64
+
+	ProviderInvoiceFrequency      time.Duration
+	ProviderLimitInvoiceFrequency time.Duration
+
+	MaxUnpaidInvoiceValue   *big.Int
+	LimitUnpaidInvoiceValue *big.Int
 }

--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -53,11 +53,11 @@ const (
 // InvoiceFactoryCreator returns a payment engine factory.
 func InvoiceFactoryCreator(
 	channel p2p.Channel,
-	balanceSendPeriod, promiseTimeout time.Duration,
+	balanceSendPeriod, limitBalanceSendPeriod, promiseTimeout time.Duration,
 	invoiceStorage providerInvoiceStorage,
 	maxHermesFailureCount uint64,
 	maxAllowedHermesFee uint16,
-	maxUnpaidInvoiceValue *big.Int,
+	maxUnpaidInvoiceValue, limitUnpaidInvoiceValue *big.Int,
 	hermesStatusChecker hermesStatusChecker,
 	eventBus eventbus.EventBus,
 	promiseHandler promiseHandler,
@@ -71,8 +71,6 @@ func InvoiceFactoryCreator(
 			PeerInvoiceSender:          NewInvoiceSender(channel),
 			InvoiceStorage:             invoiceStorage,
 			TimeTracker:                &timeTracker,
-			ChargePeriod:               balanceSendPeriod,
-			ChargePeriodLeeway:         2 * time.Minute,
 			ExchangeMessageChan:        exchangeChan,
 			ExchangeMessageWaitTimeout: promiseTimeout,
 			ProviderID:                 providerID,
@@ -83,9 +81,14 @@ func InvoiceFactoryCreator(
 			EventBus:                   eventBus,
 			SessionID:                  sessionID,
 			PromiseHandler:             promiseHandler,
-			MaxNotPaidInvoice:          maxUnpaidInvoiceValue,
 			ChainID:                    chainID,
 			AddressProvider:            addressProvider,
+
+			MaxNotPaidInvoice:   maxUnpaidInvoiceValue,
+			LimitNotPaidInvoice: limitUnpaidInvoiceValue,
+			ChargePeriod:        balanceSendPeriod,
+			LimitChargePeriod:   balanceSendPeriod,
+			ChargePeriodLeeway:  2 * time.Minute,
 		}
 		paymentEngine := NewInvoiceTracker(deps)
 		return paymentEngine, nil


### PR DESCRIPTION
Very basic increase logic for invoices being sent.

New charge period or charge limit is calculated by dividing the current
limit from 3 and adding it on top. 3 is a magic number I came up with,
open to suggestions here.

What this solves:

Currently most of our sessions are long running superproxy sessions, if
we increase the time between invoices for long running or heavy traffic
usage sessions we will decrease the need to hit hermes as much.
This also ensures that at the session start we do more invoices further
decreasing underpaid sessions.

For long running sessions with no traffic, current approach reduces
invoices up to 5 times. For ones sending traffic 10.