### PR TITLE
fix testinstall for ubuntu impish

### DIFF
--- a/ci/test/testinstall/Dockerfile.ubuntu-impish
+++ b/ci/test/testinstall/Dockerfile.ubuntu-impish
@@ -4,8 +4,6 @@ ENV container docker
 ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
-
 RUN apt update \
     && apt install -y systemd \
     && apt-get clean


### PR DESCRIPTION
testinstall broke again, same as last time for ubuntu jammy. it seems buggy package appeared in proposed packages repo for impish as well.