### PR TITLE
Smart settle

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -782,6 +782,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 		di.SignerFactory,
 		di.EventBus,
 		di.BCHelper,
+		options.Transactor.TransactorFeesValidTime,
 	)
 	di.Affiliator = registry.NewAffiliator(di.HTTPClient, options.Affiliator.AffiliatorEndpointAddress)
 

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -161,12 +161,14 @@ func (di *Dependencies) bootstrapHermesPromiseSettler(nodeOptions node.Options) 
 		di.SettlementHistoryStorage,
 		di.EventBus,
 		pingpong.HermesPromiseSettlerConfig{
-			Threshold:                    nodeOptions.Payments.HermesPromiseSettlingThreshold,
-			SettlementCheckTimeout:       nodeOptions.Payments.SettlementTimeout,
-			SettlementCheckInterval:      nodeOptions.Payments.SettlementRecheckInterval,
-			L1ChainID:                    nodeOptions.Chains.Chain1.ChainID,
-			L2ChainID:                    nodeOptions.Chains.Chain2.ChainID,
-			ZeroStakeSettlementThreshold: nodeOptions.Payments.ZeroStakeSettlementThreshold,
+			BalanceThreshold:        nodeOptions.Payments.HermesPromiseSettlingThreshold,
+			MaxFeeThreshold:         nodeOptions.Payments.MaxFeeSettlingThreshold,
+			MinAutoSettleAmount:     nodeOptions.Payments.MinAutoSettleAmount,
+			MaxUnSettledAmount:      nodeOptions.Payments.MaxUnSettledAmount,
+			SettlementCheckTimeout:  nodeOptions.Payments.SettlementTimeout,
+			SettlementCheckInterval: nodeOptions.Payments.SettlementRecheckInterval,
+			L1ChainID:               nodeOptions.Chains.Chain1.ChainID,
+			L2ChainID:               nodeOptions.Chains.Chain2.ChainID,
 		},
 	)
 	if err := settler.Subscribe(di.EventBus); err != nil {

--- a/config/flags_payments.go
+++ b/config/flags_payments.go
@@ -79,11 +79,23 @@ var (
 		Usage:  "The duration we'll wait before giving up trying to fetch new balance.",
 		Hidden: true,
 	}
-	// FlagPaymentsZeroStakeUnsettledAmount determines the minimum amount of myst required before auto settling is triggered if zero stake is used.
+	// FlagPaymentsZeroStakeUnsettledAmount determines the minimum amount of myst that we will settle automatically if zero stake is used.
 	FlagPaymentsZeroStakeUnsettledAmount = cli.Float64Flag{
 		Name:  "payments.zero-stake-unsettled-amount",
 		Value: 5.0,
 		Usage: "The settling threshold if provider uses a zero stake",
+	}
+	// FlagPaymentsPromiseSettleMaxFeeThreshold represents the max percentage of the settlement that will be acceptable to pay in transaction fees.
+	FlagPaymentsPromiseSettleMaxFeeThreshold = cli.Float64Flag{
+		Name:  "payments.settle.max-fee-percentage",
+		Value: 0.05,
+		Usage: "The max percentage we allow to pay in fees when automatically settling promises.",
+	}
+	// FlagPaymentsUnsettledMaxAmount determines the maximum amount of myst for which we will consider the fee threshold.
+	FlagPaymentsUnsettledMaxAmount = cli.Float64Flag{
+		Name:  "payments.unsettled.max-amount",
+		Value: 20.0,
+		Usage: "The maximum amount of unsettled myst, after that we will always try to settle.",
 	}
 	// FlagPaymentsRegistryTransactorPollInterval The duration we'll wait before calling transactor to check for new status updates.
 	FlagPaymentsRegistryTransactorPollInterval = cli.DurationFlag{
@@ -179,6 +191,8 @@ func RegisterFlagsPayments(flags *[]cli.Flag) {
 		&FlagPaymentsMaxHermesFee,
 		&FlagPaymentsBCTimeout,
 		&FlagPaymentsHermesPromiseSettleThreshold,
+		&FlagPaymentsPromiseSettleMaxFeeThreshold,
+		&FlagPaymentsUnsettledMaxAmount,
 		&FlagPaymentsHermesPromiseSettleTimeout,
 		&FlagPaymentsHermesPromiseSettleCheckInterval,
 		&FlagPaymentsLongBalancePollInterval,
@@ -207,6 +221,8 @@ func ParseFlagsPayments(ctx *cli.Context) {
 	Current.ParseIntFlag(ctx, FlagPaymentsMaxHermesFee)
 	Current.ParseDurationFlag(ctx, FlagPaymentsBCTimeout)
 	Current.ParseFloat64Flag(ctx, FlagPaymentsHermesPromiseSettleThreshold)
+	Current.ParseFloat64Flag(ctx, FlagPaymentsPromiseSettleMaxFeeThreshold)
+	Current.ParseFloat64Flag(ctx, FlagPaymentsUnsettledMaxAmount)
 	Current.ParseDurationFlag(ctx, FlagPaymentsHermesPromiseSettleTimeout)
 	Current.ParseDurationFlag(ctx, FlagPaymentsHermesPromiseSettleCheckInterval)
 	Current.ParseDurationFlag(ctx, FlagPaymentsFastBalancePollInterval)

--- a/config/flags_transactor.go
+++ b/config/flags_transactor.go
@@ -18,6 +18,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/mysteriumnetwork/node/metadata"
 	"github.com/urfave/cli/v2"
 )
@@ -35,6 +37,13 @@ var (
 		Usage: "the max attempts the provider will make to register before giving up",
 		Value: 10,
 	}
+	// FlagTransactorFeesValidTime The duration we will consider transactor fees valid for.
+	FlagTransactorFeesValidTime = cli.DurationFlag{
+		Name:   "payments.transactor.fees-valid-time",
+		Value:  30 * time.Second,
+		Usage:  "The duration we will consider transactor fees valid for (more than 5 minutes is likely to fail)",
+		Hidden: true,
+	}
 )
 
 // RegisterFlagsTransactor function register network flags to flag list
@@ -43,6 +52,7 @@ func RegisterFlagsTransactor(flags *[]cli.Flag) {
 		*flags,
 		&FlagTransactorAddress,
 		&FlagTransactorProviderMaxRegistrationAttempts,
+		&FlagTransactorFeesValidTime,
 	)
 }
 
@@ -50,4 +60,5 @@ func RegisterFlagsTransactor(flags *[]cli.Flag) {
 func ParseFlagsTransactor(ctx *cli.Context) {
 	Current.ParseStringFlag(ctx, FlagTransactorAddress)
 	Current.ParseIntFlag(ctx, FlagTransactorProviderMaxRegistrationAttempts)
+	Current.ParseDurationFlag(ctx, FlagTransactorFeesValidTime)
 }

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -145,6 +145,7 @@ func GetOptions() *Options {
 		Transactor: OptionsTransactor{
 			TransactorEndpointAddress:       config.GetString(config.FlagTransactorAddress),
 			ProviderMaxRegistrationAttempts: config.GetInt(config.FlagTransactorProviderMaxRegistrationAttempts),
+			TransactorFeesValidTime:         config.GetDuration(config.FlagTransactorFeesValidTime),
 		},
 		Affiliator: OptionsAffiliator{
 			AffiliatorEndpointAddress: config.GetString(config.FlagAffiliatorAddress),
@@ -153,6 +154,8 @@ func GetOptions() *Options {
 			MaxAllowedPaymentPercentile:    config.GetInt(config.FlagPaymentsMaxHermesFee),
 			BCTimeout:                      config.GetDuration(config.FlagPaymentsBCTimeout),
 			HermesPromiseSettlingThreshold: config.GetFloat64(config.FlagPaymentsHermesPromiseSettleThreshold),
+			MaxFeeSettlingThreshold:        config.GetFloat64(config.FlagPaymentsPromiseSettleMaxFeeThreshold),
+			MaxUnSettledAmount:             config.GetFloat64(config.FlagPaymentsUnsettledMaxAmount),
 			SettlementTimeout:              config.GetDuration(config.FlagPaymentsHermesPromiseSettleTimeout),
 			SettlementRecheckInterval:      config.GetDuration(config.FlagPaymentsHermesPromiseSettleCheckInterval),
 			BalanceLongPollInterval:        config.GetDuration(config.FlagPaymentsLongBalancePollInterval),
@@ -162,7 +165,7 @@ func GetOptions() *Options {
 			RegistryTransactorPollTimeout:  config.GetDuration(config.FlagPaymentsRegistryTransactorPollTimeout),
 			ConsumerDataLeewayMegabytes:    config.GetUInt64(config.FlagPaymentsConsumerDataLeewayMegabytes),
 			HermesStatusRecheckInterval:    config.GetDuration(config.FlagPaymentsHermesStatusRecheckInterval),
-			ZeroStakeSettlementThreshold:   config.GetFloat64(config.FlagPaymentsZeroStakeUnsettledAmount),
+			MinAutoSettleAmount:            config.GetFloat64(config.FlagPaymentsZeroStakeUnsettledAmount),
 
 			ProviderInvoiceFrequency:      config.GetDuration(config.FlagPaymentsProviderInvoiceFrequency),
 			ProviderLimitInvoiceFrequency: config.GetDuration(config.FlagPaymentsLimitProviderInvoiceFrequency),

--- a/core/node/options_payments.go
+++ b/core/node/options_payments.go
@@ -27,6 +27,7 @@ type OptionsPayments struct {
 	MaxAllowedPaymentPercentile    int
 	BCTimeout                      time.Duration
 	HermesPromiseSettlingThreshold float64
+	MaxFeeSettlingThreshold        float64
 	SettlementTimeout              time.Duration
 	SettlementRecheckInterval      time.Duration
 	ConsumerDataLeewayMegabytes    uint64
@@ -36,7 +37,8 @@ type OptionsPayments struct {
 	BalanceLongPollInterval        time.Duration
 	RegistryTransactorPollInterval time.Duration
 	RegistryTransactorPollTimeout  time.Duration
-	ZeroStakeSettlementThreshold   float64
+	MinAutoSettleAmount            float64
+	MaxUnSettledAmount             float64
 
 	ProviderInvoiceFrequency      time.Duration
 	ProviderLimitInvoiceFrequency time.Duration

--- a/core/node/options_transactor.go
+++ b/core/node/options_transactor.go
@@ -17,8 +17,11 @@
 
 package node
 
+import "time"
+
 // OptionsTransactor describes possible parameters for interaction with transactor
 type OptionsTransactor struct {
 	TransactorEndpointAddress       string
 	ProviderMaxRegistrationAttempts int
+	TransactorFeesValidTime         time.Duration
 }

--- a/docker-compose.e2e-basic.yml
+++ b/docker-compose.e2e-basic.yml
@@ -359,7 +359,6 @@ services:
       --payments.provider.invoice-frequency=1s
       --access-policy.address=http://trust:8080/api/v1/access-policies/
       --access-policy.fetch=1s
-      --payments.hermes.promise.threshold=100
       --stun-servers=""
       --local-service-discovery=true
       --payments.hermes.settle.check-interval=1s

--- a/docker-compose.e2e-traversal.yml
+++ b/docker-compose.e2e-traversal.yml
@@ -782,7 +782,6 @@ services:
       --transactor.address=http://transactor:8888/api/v1
       --keystore.lightweight
       --log-level=debug
-      --payments.hermes.promise.threshold=100
       --quality.address=http://morqa:8085/api/v3
       --payments.provider.invoice-frequency=1s
       --access-policy.address=http://trust:8080/api/v1/access-policies/

--- a/identity/registry/transactor.go
+++ b/identity/registry/transactor.go
@@ -52,6 +52,58 @@ type AddressProvider interface {
 	GetRegistryAddress(chainID int64) (common.Address, error)
 }
 
+type feeType uint8
+
+const (
+	settleFeeType        feeType = iota
+	registrationFeeType          = 1
+	stakeDecreaseFeeType         = 2
+)
+
+type feeCacher struct {
+	validityDuration time.Duration
+	feesMap          map[int64]map[feeType]feeCache
+}
+
+type feeCache struct {
+	FeesResponse
+	CacheValidUntil time.Time
+}
+
+func newFeeCacher(validityDuration time.Duration) *feeCacher {
+	return &feeCacher{
+		validityDuration: validityDuration,
+		feesMap:          make(map[int64]map[feeType]feeCache),
+	}
+}
+
+func (f *feeCacher) getCachedFee(chainId int64, feeType feeType) *FeesResponse {
+	if chainFees, ok := f.feesMap[chainId]; ok {
+		if fees, ok := chainFees[feeType]; ok {
+			if fees.CacheValidUntil.After(time.Now()) {
+				return &fees.FeesResponse
+			}
+		}
+	}
+	return nil
+}
+
+func (f *feeCacher) cacheFee(chainId int64, ftype feeType, response FeesResponse) {
+	_, ok := f.feesMap[chainId]
+	if !ok {
+		f.feesMap[chainId] = make(map[feeType]feeCache)
+	}
+	cacheExpiration := time.Now().Add(f.validityDuration)
+	feeCache := feeCache{
+		FeesResponse:    response,
+		CacheValidUntil: cacheExpiration,
+	}
+	if feeCache.CacheValidUntil.After(response.ValidUntil) {
+		feeCache.CacheValidUntil = response.ValidUntil
+	}
+	f.feesMap[chainId][ftype] = feeCache
+}
+
 // Transactor allows for convenient calls to the transactor service
 type Transactor struct {
 	httpClient      *requests.HTTPClient
@@ -60,10 +112,11 @@ type Transactor struct {
 	publisher       eventbus.Publisher
 	bc              channelProvider
 	addresser       AddressProvider
+	feeCache        *feeCacher
 }
 
 // NewTransactor creates and returns new Transactor instance
-func NewTransactor(httpClient *requests.HTTPClient, endpointAddress string, addresser AddressProvider, signerFactory identity.SignerFactory, publisher eventbus.Publisher, bc channelProvider) *Transactor {
+func NewTransactor(httpClient *requests.HTTPClient, endpointAddress string, addresser AddressProvider, signerFactory identity.SignerFactory, publisher eventbus.Publisher, bc channelProvider, feesValidTime time.Duration) *Transactor {
 	return &Transactor{
 		httpClient:      httpClient,
 		endpointAddress: endpointAddress,
@@ -71,6 +124,7 @@ func NewTransactor(httpClient *requests.HTTPClient, endpointAddress string, addr
 		addresser:       addresser,
 		publisher:       publisher,
 		bc:              bc,
+		feeCache:        newFeeCacher(feesValidTime),
 	}
 }
 
@@ -117,40 +171,61 @@ type PromiseSettlementRequest struct {
 
 // FetchRegistrationFees fetches current transactor registration fees
 func (t *Transactor) FetchRegistrationFees(chainID int64) (FeesResponse, error) {
-	f := FeesResponse{}
+	cachedFees := t.feeCache.getCachedFee(chainID, registrationFeeType)
+	if cachedFees != nil {
+		return *cachedFees, nil
+	}
 
+	f := FeesResponse{}
 	req, err := requests.NewGetRequest(t.endpointAddress, fmt.Sprintf("fee/%v/register", chainID), nil)
 	if err != nil {
 		return f, errors.Wrap(err, "failed to fetch transactor fees")
 	}
 
 	err = t.httpClient.DoRequestAndParseResponse(req, &f)
+	if err == nil {
+		t.feeCache.cacheFee(chainID, registrationFeeType, f)
+	}
 	return f, err
 }
 
 // FetchSettleFees fetches current transactor settlement fees
 func (t *Transactor) FetchSettleFees(chainID int64) (FeesResponse, error) {
-	f := FeesResponse{}
+	cachedFees := t.feeCache.getCachedFee(chainID, settleFeeType)
+	if cachedFees != nil {
+		return *cachedFees, nil
+	}
 
+	f := FeesResponse{}
 	req, err := requests.NewGetRequest(t.endpointAddress, fmt.Sprintf("fee/%v/settle", chainID), nil)
 	if err != nil {
 		return f, errors.Wrap(err, "failed to fetch transactor fees")
 	}
 
 	err = t.httpClient.DoRequestAndParseResponse(req, &f)
+	if err == nil {
+		t.feeCache.cacheFee(chainID, settleFeeType, f)
+	}
 	return f, err
 }
 
 // FetchStakeDecreaseFee fetches current transactor stake decrease fees.
 func (t *Transactor) FetchStakeDecreaseFee(chainID int64) (FeesResponse, error) {
-	f := FeesResponse{}
+	cachedFees := t.feeCache.getCachedFee(chainID, stakeDecreaseFeeType)
+	if cachedFees != nil {
+		return *cachedFees, nil
+	}
 
+	f := FeesResponse{}
 	req, err := requests.NewGetRequest(t.endpointAddress, fmt.Sprintf("fee/%v/stake/decrease", chainID), nil)
 	if err != nil {
 		return f, errors.Wrap(err, "failed to fetch transactor fees")
 	}
 
 	err = t.httpClient.DoRequestAndParseResponse(req, &f)
+	if err == nil {
+		t.feeCache.cacheFee(chainID, stakeDecreaseFeeType, f)
+	}
 	return f, err
 }
 

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -241,12 +241,12 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		Transactor: node.OptionsTransactor{
 			TransactorEndpointAddress:       options.TransactorEndpointAddress,
 			ProviderMaxRegistrationAttempts: 10,
+			TransactorFeesValidTime:         time.Second * 30,
 		},
 		Affiliator: node.OptionsAffiliator{AffiliatorEndpointAddress: options.AffiliatorEndpointAddress},
 		Payments: node.OptionsPayments{
 			MaxAllowedPaymentPercentile:    1500,
 			BCTimeout:                      time.Second * 30,
-			HermesPromiseSettlingThreshold: 0.1,
 			SettlementTimeout:              time.Hour * 2,
 			HermesStatusRecheckInterval:    time.Hour * 2,
 			BalanceFastPollInterval:        time.Second * 30,

--- a/session/pingpong/hermes_promise_settler.go
+++ b/session/pingpong/hermes_promise_settler.go
@@ -96,6 +96,7 @@ type receivedPromise struct {
 	hermesID    common.Address
 	promise     crypto.Promise
 	beneficiary common.Address
+	maxFee      *big.Int
 }
 
 // HermesPromiseSettler is responsible for settling the hermes promises.
@@ -132,12 +133,14 @@ type hermesPromiseSettler struct {
 
 // HermesPromiseSettlerConfig configures the hermes promise settler accordingly.
 type HermesPromiseSettlerConfig struct {
-	Threshold                    float64
-	L1ChainID                    int64
-	L2ChainID                    int64
-	SettlementCheckInterval      time.Duration
-	SettlementCheckTimeout       time.Duration
-	ZeroStakeSettlementThreshold float64
+	MaxFeeThreshold         float64
+	MinAutoSettleAmount     float64
+	MaxUnSettledAmount      float64
+	L1ChainID               int64
+	L2ChainID               int64
+	SettlementCheckInterval time.Duration
+	SettlementCheckTimeout  time.Duration
+	BalanceThreshold        float64
 }
 
 var errFeeNotCovered = errors.New("fee not covered, cannot continue")
@@ -308,13 +311,14 @@ func (aps *hermesPromiseSettler) handleHermesPromiseReceived(apep event.AppEvent
 
 	log.Info().Msgf("Hermes %q promise state updated for provider %q", apep.HermesID.Hex(), id)
 
-	if s.needsSettling(aps.config.Threshold, aps.config.ZeroStakeSettlementThreshold, channel) {
+	needs, maxFee := aps.needsSettling(s, aps.config.BalanceThreshold, aps.config.MaxFeeThreshold, aps.config.MinAutoSettleAmount, aps.config.MaxUnSettledAmount, channel, apep.Promise.ChainID)
+	if needs {
 		log.Info().Msgf("Starting auto settle for provider %v", id)
-		aps.initiateSettling(channel)
+		aps.initiateSettling(channel, maxFee)
 	}
 }
 
-func (aps *hermesPromiseSettler) initiateSettling(channel HermesChannel) {
+func (aps *hermesPromiseSettler) initiateSettling(channel HermesChannel, maxFee *big.Int) {
 	hexR, err := hex.DecodeString(channel.lastPromise.R)
 	if err != nil {
 		log.Error().Err(fmt.Errorf("could encode R: %w", err))
@@ -327,6 +331,7 @@ func (aps *hermesPromiseSettler) initiateSettling(channel HermesChannel) {
 		provider:    channel.Identity,
 		promise:     channel.lastPromise.Promise,
 		beneficiary: channel.Beneficiary,
+		maxFee:      maxFee,
 	}
 }
 
@@ -352,6 +357,7 @@ func (aps *hermesPromiseSettler) listenForSettlementRequests() {
 				p.promise,
 				p.beneficiary,
 				channel.Channel.Settled,
+				p.maxFee,
 			)
 		}
 	}
@@ -379,6 +385,7 @@ func (aps *hermesPromiseSettler) SettleIntoStake(chainID int64, providerID ident
 			channel.lastPromise.Promise,
 			channel.Beneficiary,
 			channel.Channel.Settled,
+			nil,
 		)
 		if err != nil {
 			return err
@@ -415,6 +422,7 @@ func (aps *hermesPromiseSettler) ForceSettle(chainID int64, providerID identity.
 			channel.lastPromise.Promise,
 			channel.Beneficiary,
 			channel.Channel.Settled,
+			nil,
 		)
 		if err != nil {
 			if errors.Is(err, errFeeNotCovered) {
@@ -456,17 +464,22 @@ func (aps *hermesPromiseSettler) SettleWithBeneficiary(chainID int64, providerID
 		channel.lastPromise.Promise,
 		beneficiary,
 		channel.Channel.Settled,
+		nil,
 	)
 }
 
 // ErrSettleTimeout indicates that the settlement has timed out
 var ErrSettleTimeout = errors.New("settle timeout")
 
-func (aps *hermesPromiseSettler) updatePromiseWithLatestFee(hermesID common.Address, promise crypto.Promise) (crypto.Promise, error) {
+func (aps *hermesPromiseSettler) updatePromiseWithLatestFee(hermesID common.Address, promise crypto.Promise, maxFee *big.Int) (crypto.Promise, error) {
 	log.Debug().Msgf("Updating promise with latest fee. HermesID %v", hermesID.Hex())
 	fees, err := aps.transactor.FetchSettleFees(promise.ChainID)
 	if err != nil {
 		return crypto.Promise{}, fmt.Errorf("could not fetch settle fees: %w", err)
+	}
+
+	if maxFee != nil && fees.Fee.Cmp(maxFee) == 1 {
+		return crypto.Promise{}, fmt.Errorf("current fee is more than the max")
 	}
 
 	hermesCaller, err := aps.getHermesCaller(promise.ChainID, hermesID)
@@ -712,7 +725,7 @@ func (aps *hermesPromiseSettler) settlePayAndSettleWithRetry(
 	withdrawalAmount *big.Int,
 	promiseFromStorage HermesPromise,
 ) (string, error) {
-	promise, err := aps.updatePromiseWithLatestFee(promiseFromStorage.HermesID, promiseFromStorage.Promise)
+	promise, err := aps.updatePromiseWithLatestFee(promiseFromStorage.HermesID, promiseFromStorage.Promise, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not update promise fee")
 		return "", err
@@ -852,6 +865,7 @@ func (aps *hermesPromiseSettler) settle(
 	promise crypto.Promise,
 	beneficiary common.Address,
 	settled *big.Int,
+	maxFee *big.Int,
 ) error {
 	if aps.isSettling(provider, hermesID) {
 		return errors.New("provider already has settlement in progress")
@@ -861,7 +875,7 @@ func (aps *hermesPromiseSettler) settle(
 
 	log.Info().Msgf("Marked provider %v as requesting settlement", provider)
 
-	updatedPromise, err := aps.updatePromiseWithLatestFee(hermesID, promise)
+	updatedPromise, err := aps.updatePromiseWithLatestFee(hermesID, promise, maxFee)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not update promise fee")
 		return err
@@ -1163,33 +1177,50 @@ type settlementState struct {
 	settleInProgress map[common.Address]struct{}
 }
 
-func (ss settlementState) needsSettling(threshold float64, zeroStakeThreshold float64, channel HermesChannel) bool {
+func (aps *hermesPromiseSettler) needsSettling(ss settlementState, balanceThreshold float64, feeThreshold float64, minSettleAmount, maxUnSettledAmount float64, channel HermesChannel, chainID int64) (bool, *big.Int) {
 	if !ss.registered {
-		return false
+		return false, nil
 	}
 
 	if _, ok := ss.settleInProgress[channel.HermesID]; ok {
-		return false
+		return false, nil
 	}
 
 	if channel.Channel.Stake.Cmp(big.NewInt(0)) == 0 {
-		// if starting with zero stake, only settle predefined myst in config.
-		return channel.UnsettledBalance().Cmp(crypto.FloatToBigMyst(zeroStakeThreshold)) == 1
+		// no stake mode
+		unsettledAmount := channel.UnsettledBalance()
+		if unsettledAmount.Cmp(crypto.FloatToBigMyst(maxUnSettledAmount)) > 0 {
+			return true, nil
+		}
+		if unsettledAmount.Cmp(crypto.FloatToBigMyst(minSettleAmount)) >= 0 {
+			settleFees, err := aps.transactor.FetchSettleFees(chainID)
+			if err != nil {
+				log.Err(err).Msgf("will not use settlement fees to check if settling is needed")
+				return false, nil
+			}
+			//set max fee to 10% more than current
+			maxFee, _ := new(big.Float).Mul(new(big.Float).SetInt(settleFees.Fee), big.NewFloat(1.1)).Int(nil)
+			unsettledBalance := new(big.Float).SetInt(channel.UnsettledBalance())
+			calculatedFeesThreshold := new(big.Float).Mul(big.NewFloat(feeThreshold), unsettledBalance)
+			calculatedFeesThresholdInt, _ := calculatedFeesThreshold.Int(nil)
+			return settleFees.Fee.Cmp(calculatedFeesThresholdInt) < 0, maxFee
+		}
+		return false, nil
 	}
 
 	floated := new(big.Float).SetInt(channel.availableBalance())
-	calculatedThreshold := new(big.Float).Mul(big.NewFloat(threshold), floated)
+	calculatedThreshold := new(big.Float).Mul(big.NewFloat(balanceThreshold), floated)
 	possibleEarnings := channel.UnsettledBalance()
 	i, _ := calculatedThreshold.Int(nil)
 	if possibleEarnings.Cmp(i) == -1 {
-		return false
+		return false, nil
 	}
 
 	if channel.balance().Cmp(i) <= 0 {
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, nil
 }
 
 func formTXUrl(txHash string, chainID int64) (string, error) {

--- a/tequilapi/endpoints/transactor_test.go
+++ b/tequilapi/endpoints/transactor_test.go
@@ -57,7 +57,7 @@ func Test_RegisterIdentity(t *testing.T) {
 
 	router := summonTestGin()
 
-	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 	a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 	err := AddRoutesForTransactor(&registry.FakeRegistry{RegistrationStatus: registry.Unregistered}, tr, a, nil, &settlementHistoryProviderMock{}, &mockAddressProvider{}, nil, nil, &mockPilvytis{})(router)
 	assert.NoError(t, err)
@@ -82,7 +82,7 @@ func Test_Get_TransactorFees(t *testing.T) {
 
 	router := summonTestGin()
 
-	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 	a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 	err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, &mockSettler{
 		feeToReturn: 11_000,
@@ -133,7 +133,7 @@ func Test_SettleAsync_OK(t *testing.T) {
 
 	router := summonTestGin()
 
-	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 	a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 	err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, &mockSettler{}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, nil, nil, nil)(router)
 	assert.NoError(t, err)
@@ -159,7 +159,7 @@ func Test_SettleAsync_ReturnsError(t *testing.T) {
 
 	router := summonTestGin()
 
-	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 	a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 	err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, &mockSettler{errToReturn: errors.New("explosions everywhere")}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, nil, nil, nil)(router)
 	assert.NoError(t, err)
@@ -185,7 +185,7 @@ func Test_SettleSync_OK(t *testing.T) {
 
 	router := summonTestGin()
 
-	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 	a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 	err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, &mockSettler{}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, nil, nil, nil)(router)
 	assert.NoError(t, err)
@@ -211,7 +211,7 @@ func Test_SettleSync_ReturnsError(t *testing.T) {
 
 	router := summonTestGin()
 
-	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+	tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 	a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 	err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, &mockSettler{errToReturn: errors.New("explosions everywhere")}, &settlementHistoryProviderMock{}, &mockAddressProvider{}, nil, nil, nil)(router)
 	assert.NoError(t, err)
@@ -238,7 +238,7 @@ func Test_SettleHistory(t *testing.T) {
 		defer server.Close()
 
 		router := summonTestGin()
-		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 		a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 		err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, nil, &settlementHistoryProviderMock{errToReturn: errors.New("explosions everywhere")}, &mockAddressProvider{}, nil, nil, nil)(router)
 		assert.NoError(t, err)
@@ -275,7 +275,7 @@ func Test_SettleHistory(t *testing.T) {
 		defer server.Close()
 
 		router := summonTestGin()
-		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 		a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 		err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, nil, mockStorage, &mockAddressProvider{}, nil, nil, nil)(router)
 		assert.NoError(t, err)
@@ -333,7 +333,7 @@ func Test_SettleHistory(t *testing.T) {
 		server := newTestTransactorServer(http.StatusAccepted, "")
 		defer server.Close()
 		router := summonTestGin()
-		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil)
+		tr := registry.NewTransactor(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL, &mockAddressProvider{}, fakeSignerFactory, mocks.NewEventBus(), nil, time.Minute)
 		a := registry.NewAffiliator(requests.NewHTTPClient(server.URL, requests.DefaultTimeout), server.URL)
 		err := AddRoutesForTransactor(mockIdentityRegistryInstance, tr, a, nil, mockStorage, &mockAddressProvider{}, nil, nil, nil)(router)
 		assert.NoError(t, err)


### PR DESCRIPTION
Closes: #5067

Current problems:
- We settle at 5 MYST always and maybe fees are huge when we do, it's a matter of luck.
- You might force settle from frontend and realize you paid 10x more fees that what was displayed in UI if you are unlucky and do so just before a gas spike.
- We call transactor `/fee` endpoint a lot. In the last 3 minutes there are 1400 calls yet coming only from 550 different nodes.

Proposed solutions:
- Automatic settlements will be smarter now and work as follows:
  - We have 3 values: minimum to settle(5), max fee percentage(5%), and max unsettled(20)
  - If unsettled is below minimum we don't settle
  - If unsettled is above the maximum we always auto-settle
  - If it's somewhere in between we automatically settle if the transaction fees are less than the percentage (i.e. if we have 6 MYST unsettled we will settle as long as the fees are less than 0.3 MYST)
- ~~Now all settling functions allow an additional maxFee param so we can add it as optional parameter in tequilapi to prevent the user from finding himself on the 2nd problem mentioned above. (not in tequilapi yet, if we won't want to do this I can simplify the code before merging)~~
- Transactor fees are now cached for ~~3 minutes~~ 30 seconds (by default) instead of calling every time. Keep in mind that the smart settlement check requires a call there on every hermes promise received (only if we have more unsettled than 5), so with both changes, we might still call transactor `/fee` endpoint quite a lot but I think it should be less. We can discuss whether we should increase this cache amount a bit more (more than 10 mins will for sure be bad).

~~Additionally, I removed some old logic in the settler which auto-settled if the unsettled amount was more than 10% of the current balance (only if we had stake != 0 so it wasn't used now). I'm not sure if this is still useful now, it doesn't look like it is.~~

Signed-off-by: Guillem Bonet <guillem@mysterium.network>