### PR TITLE
Pass transactor errors to the caller if possible

### DIFF
--- a/core/policy/oracle_test.go
+++ b/core/policy/oracle_test.go
@@ -83,7 +83,7 @@ func Test_Oracle_SubscribePolicies_WhenEndpointFails(t *testing.T) {
 	assert.EqualError(
 		t,
 		err,
-		fmt.Sprintf("initial fetch failed: failed to fetch policy rule {1 %s/1}: server responded with an error: 500 (%s/1) [internal] Something wong", server.URL, server.URL),
+		fmt.Sprintf("initial fetch failed: failed to fetch policy rule {1 %s/1}: Something wong", server.URL),
 	)
 	assert.Equal(t, []market.AccessPolicy{}, repo.Policies())
 }

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/mysteriumnetwork/go-ci v0.0.0-20220328103729-c16a61419959
 	github.com/mysteriumnetwork/go-dvpn-web v1.15.0
 	github.com/mysteriumnetwork/go-openvpn v0.0.23
-	github.com/mysteriumnetwork/go-rest v0.2.2
+	github.com/mysteriumnetwork/go-rest v0.3.0
 	github.com/mysteriumnetwork/go-wondershaper v1.0.1
 	github.com/mysteriumnetwork/gowinlog v0.0.0-20220318151501-96eedb692646
 	github.com/mysteriumnetwork/metrics v0.0.19

--- a/go.sum
+++ b/go.sum
@@ -1043,6 +1043,10 @@ github.com/mysteriumnetwork/go-openvpn v0.0.23 h1:6BKoTwU9CpJL/Na9M9a0uaelAaVIo/
 github.com/mysteriumnetwork/go-openvpn v0.0.23/go.mod h1:YDjnxC/3sGNecq/f6GM0BGz7nnGPTPIGtQjHaoLf8UE=
 github.com/mysteriumnetwork/go-rest v0.2.2 h1:TO3HmNwKVHBOLQfPXrOtZQTL0r/m9Hjjrsuw1VH5qk4=
 github.com/mysteriumnetwork/go-rest v0.2.2/go.mod h1:35tE+2RLjD/f2jeF71Hc2R01yyTRpBkwMkParuvj32s=
+github.com/mysteriumnetwork/go-rest v0.2.3-0.20220524101913-0b44d14bd672 h1:bjBt56JmsRZf1dvCetKulVSFXXNGwgy6qIYg63w1/dY=
+github.com/mysteriumnetwork/go-rest v0.2.3-0.20220524101913-0b44d14bd672/go.mod h1:35tE+2RLjD/f2jeF71Hc2R01yyTRpBkwMkParuvj32s=
+github.com/mysteriumnetwork/go-rest v0.3.0 h1:VhvivEt066jpleSQJAVv4NS5M9xO/U7Jal+zuDy6H3U=
+github.com/mysteriumnetwork/go-rest v0.3.0/go.mod h1:35tE+2RLjD/f2jeF71Hc2R01yyTRpBkwMkParuvj32s=
 github.com/mysteriumnetwork/go-wondershaper v1.0.1 h1:vHfeQ5siADk7AOlbEBe6FLRu8N1RaVBCEBLi1VhmIrI=
 github.com/mysteriumnetwork/go-wondershaper v1.0.1/go.mod h1:pWWNkO73g3vPSVb+6O+GzjG8lqv4ByNHR6thSG7WmtY=
 github.com/mysteriumnetwork/gowinlog v0.0.0-20220318151501-96eedb692646 h1:/zKpFjML3m1nFA62OBtx2ejoijwBOzdzpFHAppNe/vM=

--- a/requests/client.go
+++ b/requests/client.go
@@ -182,7 +182,7 @@ func ParseResponseJSON(response *http.Response, dto interface{}) error {
 // ParseResponseError parses http.Response error.
 func ParseResponseError(response *http.Response) error {
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return apierror.Parse(response)
+		return apierror.TryParse(response)
 	}
 	return nil
 }

--- a/tequilapi/contract/errcodes.go
+++ b/tequilapi/contract/errcodes.go
@@ -106,6 +106,8 @@ const (
 	// Transactor
 
 	ErrCodeTransactorRegistration          = "err_transactor_registration"
+	ErrCodeTransactorFetchFees             = "err_transactor_fetch_fees"
+	ErrCodeTransactorDecreaseStake         = "err_transactor_decrease_stake"
 	ErrCodeTransactorSettleHistory         = "err_transactor_settle_history"
 	ErrCodeTransactorSettleHistoryPaginate = "err_transactor_settle_history_paginate"
 	ErrCodeTransactorWithdraw              = "err_transactor_withdraw"
@@ -118,6 +120,7 @@ const (
 	// Affiliator
 
 	ErrCodeAffiliatorNoReward = "err_affiliator_no_reward"
+	ErrCodeAffiliatorFailed   = "err_affiliator_failed"
 
 	// Other
 

--- a/tequilapi/endpoints/affiliator.go
+++ b/tequilapi/endpoints/affiliator.go
@@ -63,7 +63,7 @@ func (a *affiliatorEndpoint) TokenRewardAmount(c *gin.Context) {
 	token := c.Param("token")
 	reward, err := a.affiliator.RegistrationTokenReward(token)
 	if err != nil {
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Could not fetch reward", contract.ErrCodeAffiliatorFailed))
 		return
 	}
 	if reward == nil {

--- a/tequilapi/endpoints/transactor.go
+++ b/tequilapi/endpoints/transactor.go
@@ -141,7 +141,8 @@ func (te *transactorEndpoint) TransactorFeesV2(c *gin.Context) {
 
 	fees, err := te.transactor.FetchCombinedFees(chainID)
 	if err != nil {
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Failed to fetch fees", contract.ErrCodeTransactorFetchFees))
+		return
 	}
 
 	hermes, err := te.addressProvider.GetActiveHermes(chainID)
@@ -190,16 +191,17 @@ func (te *transactorEndpoint) TransactorFees(c *gin.Context) {
 
 	registrationFees, err := te.transactor.FetchRegistrationFees(chainID)
 	if err != nil {
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Failed to fetch fees", contract.ErrCodeTransactorFetchFees))
+		return
 	}
 	settlementFees, err := te.transactor.FetchSettleFees(chainID)
 	if err != nil {
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Failed to fetch fees", contract.ErrCodeTransactorFetchFees))
 		return
 	}
 	decreaseStakeFees, err := te.transactor.FetchStakeDecreaseFee(chainID)
 	if err != nil {
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Failed to fetch fees", contract.ErrCodeTransactorFetchFees))
 		return
 	}
 
@@ -251,7 +253,7 @@ func (te *transactorEndpoint) SettleSync(c *gin.Context) {
 	err := te.settle(c.Request, te.promiseSettler.ForceSettle)
 	if err != nil {
 		log.Err(err).Msg("Settle failed")
-		c.Error(apierror.Internal("Could not settle sync: "+err.Error(), contract.ErrCodeHermesSettle))
+		utils.ForwardError(c, err, apierror.Internal("Could not force settle", contract.ErrCodeHermesSettle))
 		return
 	}
 	c.Status(http.StatusOK)
@@ -285,7 +287,7 @@ func (te *transactorEndpoint) SettleAsync(c *gin.Context) {
 		return nil
 	})
 	if err != nil {
-		c.Error(apierror.Internal("Could not settle async: "+err.Error(), contract.ErrCodeHermesSettleAsync))
+		utils.ForwardError(c, err, apierror.Internal("Failed to force settle async", contract.ErrCodeHermesSettleAsync))
 		return
 	}
 
@@ -314,7 +316,7 @@ func (te *transactorEndpoint) settle(request *http.Request, settler func(int64, 
 	}
 
 	chainID := config.GetInt64(config.FlagChainID)
-	return errors.Wrap(settler(chainID, identity.FromAddress(req.ProviderID), hermesIDs...), "settling failed")
+	return settler(chainID, identity.FromAddress(req.ProviderID), hermesIDs...)
 }
 
 // swagger:operation POST /identities/{id}/register Identity RegisterIdentity
@@ -382,7 +384,7 @@ func (te *transactorEndpoint) RegisterIdentity(c *gin.Context) {
 		if req.Fee == nil || req.Fee.Cmp(big.NewInt(0)) == 0 {
 			rf, err := te.transactor.FetchRegistrationFees(chainID)
 			if err != nil {
-				c.Error(err)
+				utils.ForwardError(c, err, apierror.Internal("Failed to fetch fees", contract.ErrCodeTransactorFetchFees))
 				return
 			}
 
@@ -395,7 +397,7 @@ func (te *transactorEndpoint) RegisterIdentity(c *gin.Context) {
 	err = te.transactor.RegisterIdentity(id.Address, big.NewInt(0), regFee, req.Beneficiary, chainID, req.ReferralToken)
 	if err != nil {
 		log.Err(err).Msgf("Failed identity registration request for ID: %s, %+v", id.Address, req)
-		c.Error(apierror.Internal("Could not register identity: "+err.Error(), contract.ErrCodeTransactorRegistration))
+		utils.ForwardError(c, err, apierror.Internal("Failed to register identity", contract.ErrCodeTransactorRegistration))
 		return
 	}
 
@@ -489,7 +491,7 @@ func (te *transactorEndpoint) DecreaseStake(c *gin.Context) {
 	err = te.transactor.DecreaseStake(req.ID, chainID, req.Amount, fees.Fee)
 	if err != nil {
 		log.Err(err).Msgf("Failed decreases stake request for ID: %s, %+v", req.ID, req)
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Failed to decrease stake: "+err.Error(), contract.ErrCodeTransactorDecreaseStake))
 		return
 	}
 
@@ -566,7 +568,7 @@ func (te *transactorEndpoint) Withdraw(c *gin.Context) {
 			"beneficiary":   req.Beneficiary,
 			"amount":        amount.String(),
 		}).Msg("Withdrawal failed")
-		c.Error(apierror.Internal("Could not withdraw: "+err.Error(), contract.ErrCodeTransactorWithdraw))
+		utils.ForwardError(c, err, apierror.Internal("Could not withdraw", contract.ErrCodeTransactorWithdraw))
 		return
 	}
 
@@ -607,7 +609,7 @@ func (te *transactorEndpoint) SettleIntoStakeSync(c *gin.Context) {
 	err := te.settle(c.Request, te.promiseSettler.SettleIntoStake)
 	if err != nil {
 		log.Err(err).Msg("Settle into stake failed")
-		c.Error(apierror.Internal("Failed to settle into stake: "+err.Error(), contract.ErrCodeTransactorSettle))
+		utils.ForwardError(c, err, apierror.Internal("Could not settle into stake", contract.ErrCodeTransactorSettle))
 		return
 	}
 
@@ -642,7 +644,7 @@ func (te *transactorEndpoint) SettleIntoStakeAsync(c *gin.Context) {
 		return nil
 	})
 	if err != nil {
-		c.Error(apierror.Internal("Could not settle into stake async: "+err.Error(), contract.ErrCodeTransactorSettleAsync))
+		utils.ForwardError(c, err, apierror.Internal("Could not settle into stake async", contract.ErrCodeTransactorSettle))
 		return
 	}
 
@@ -741,7 +743,7 @@ func (te *transactorEndpoint) FreeRegistrationEligibility(c *gin.Context) {
 
 	res, err := te.transactor.GetFreeRegistrationEligibility(id)
 	if err != nil {
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Failed to check if free registration is possible", contract.ErrCodeTransactorRegistration))
 		return
 	}
 
@@ -763,7 +765,7 @@ func (te *transactorEndpoint) FreeRegistrationEligibility(c *gin.Context) {
 func (te *transactorEndpoint) FreeProviderRegistrationEligibility(c *gin.Context) {
 	res, err := te.transactor.GetFreeProviderRegistrationEligibility()
 	if err != nil {
-		c.Error(err)
+		utils.ForwardError(c, err, apierror.Internal("Failed to check if free registration is possible", contract.ErrCodeTransactorRegistration))
 		return
 	}
 


### PR DESCRIPTION
If possible we should pass transactor errors to the caller.
This allows us to return custom errors straight from transactor if
needed. For example we should be able to handle fee errors with custom
`code` field.

This change comes before actual new values are being returned from
transactor as to no break the UI too much.

If no updated error is returned and cannot be forwarded old API errors are used, so this does not break the API.

Updates: https://github.com/mysteriumnetwork/transactor/issues/422