### PR TITLE
beneficiary set with optional hermes id

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -339,7 +339,7 @@ func (c *cliApp) setPayoutAddress(args []string) error {
 	return nil
 }
 
-const usageSetBeneficiary = "beneficiary-set <providerIdentity> <beneficiary>"
+const usageSetBeneficiary = "beneficiary-set <providerIdentity> <beneficiary> [hermesID]"
 
 func (c *cliApp) setBeneficiary(actionArgs []string) error {
 	if len(actionArgs) < 2 || len(actionArgs) > 3 {
@@ -349,12 +349,12 @@ func (c *cliApp) setBeneficiary(actionArgs []string) error {
 
 	address := actionArgs[0]
 	benef := actionArgs[1]
-	hermesID, err := c.config.GetHermesID()
-	if err != nil {
-		return err
+	hermesID := ""
+	if len(actionArgs) == 3 {
+		hermesID = actionArgs[2]
 	}
 
-	err = c.tequilapi.SettleWithBeneficiary(address, benef, hermesID)
+	err := c.tequilapi.SettleWithBeneficiary(address, benef, hermesID)
 	if err != nil {
 		return err
 	}

--- a/core/beneficiary/saver.go
+++ b/core/beneficiary/saver.go
@@ -41,7 +41,7 @@ type multiChainBC interface {
 }
 
 type settler interface {
-	SettleWithBeneficiary(chainID int64, id identity.Identity, beneficiary common.Address, hermeses []common.Address, preferredHermes common.Address) error
+	SettleWithBeneficiary(chainID int64, id identity.Identity, beneficiary common.Address, hermeses []common.Address) error
 }
 
 type addressProvider interface {
@@ -61,8 +61,8 @@ func NewSaver(currentChain int64, ad addressProvider, st storage, bc multiChainB
 }
 
 // SettleAndSaveBeneficiary executes a settlement transaction saving the beneficiary to the blockchain.
-func (b *Saver) SettleAndSaveBeneficiary(id identity.Identity, hermeses []common.Address, beneficiary common.Address, preferredHermes common.Address) error {
+func (b *Saver) SettleAndSaveBeneficiary(id identity.Identity, hermeses []common.Address, beneficiary common.Address) error {
 	return b.executeWithStatusTracking(id, beneficiary, func() error {
-		return b.set.SettleWithBeneficiary(b.chainID, id, beneficiary, hermeses, preferredHermes)
+		return b.set.SettleWithBeneficiary(b.chainID, id, beneficiary, hermeses)
 	})
 }


### PR DESCRIPTION
hermes id is now fully optional, if none is provided it will use the one with the most unsettled funds.

Signed-off-by: Guillem Bonet <guillem@mysterium.network>