### PR TITLE
Hermes migration: add blockchain check for open channel

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -1013,6 +1013,7 @@ func (di *Dependencies) bootstrapHermesMigrator() *migration.HermesMigrator {
 		di.IdentityRegistry,
 		di.ConsumerBalanceTracker,
 		migration.NewStorage(di.Storage, di.AddressProvider),
+		di.BCHelper,
 	)
 }
 

--- a/cmd/di.go
+++ b/cmd/di.go
@@ -624,6 +624,9 @@ func (di *Dependencies) bootstrapNodeComponents(nodeOptions node.Options, tequil
 	)
 
 	di.HermesMigrator = di.bootstrapHermesMigrator()
+	if err := di.HermesMigrator.Subscribe(di.EventBus); err != nil {
+		return fmt.Errorf("error during subscribe: %w", err)
+	}
 
 	tequilapiHTTPServer, err := di.bootstrapTequilapi(nodeOptions, tequilaListener)
 	if err != nil {
@@ -794,11 +797,7 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 		TransactorPollTimeout:  options.Payments.RegistryTransactorPollTimeout,
 	}
 
-	migrationStorage := migration.NewStorage(di.Storage, di.AddressProvider)
-	registerCallback := func(chainID int64, identity string) {
-		migrationStorage.MarkAsMigrated(chainID, identity)
-	}
-	if di.IdentityRegistry, err = registry.NewIdentityRegistryContract(di.EtherClientL2, di.AddressProvider, registryStorage, di.EventBus, di.HermesCaller, di.Transactor, registryCfg, registerCallback); err != nil {
+	if di.IdentityRegistry, err = registry.NewIdentityRegistryContract(di.EtherClientL2, di.AddressProvider, registryStorage, di.EventBus, di.HermesCaller, di.Transactor, registryCfg); err != nil {
 		return err
 	}
 

--- a/consumer/migration/hermes_migrator.go
+++ b/consumer/migration/hermes_migrator.go
@@ -293,6 +293,7 @@ func (m *HermesMigrator) IsMigrationRequired(id string) (bool, error) {
 	return required, nil
 }
 
+// Subscribe for EventBus events
 func (m *HermesMigrator) Subscribe(eb eventbus.Subscriber) error {
 	return eb.Subscribe(registry.AppTopicTransactorRegistration, m.handleRegistrationEvent)
 }

--- a/consumer/migration/hermes_migrator.go
+++ b/consumer/migration/hermes_migrator.go
@@ -123,6 +123,15 @@ func (m *HermesMigrator) Start(id string) error {
 	// get data from old hermes
 	data, err := m.getUserData(chainID, oldHermes.Hex(), id)
 	if err != nil {
+		newHermesData, err := m.getUserData(chainID, activeHermes.Hex(), id)
+		if err != nil {
+			return fmt.Errorf("error during getting balance from hermes: %w", err)
+		}
+		// old hermes unavailable, but user already using new hermes
+		if newHermesData.Balance.Cmp(big.NewInt(0)) > 0 || (newHermesData.LatestPromise.Amount != nil && newHermesData.LatestPromise.Amount.Cmp(big.NewInt(0)) > 0) {
+			m.st.MarkAsMigrated(chainID, id)
+			return nil
+		}
 		return fmt.Errorf("error during getting balance: %w", err)
 	}
 	// skip migration for offchain identities

--- a/consumer/migration/migrator_storage.go
+++ b/consumer/migration/migrator_storage.go
@@ -48,7 +48,7 @@ func NewStorage(db respository, ap registry.AddressProvider) *Storage {
 	}
 }
 
-func (s *Storage) markAsMigrated(chainID int64, identity string) {
+func (s *Storage) MarkAsMigrated(chainID int64, identity string) {
 	activeHermes, err := s.ap.GetActiveHermes(chainID)
 	if err != nil {
 		log.Err(err).Msg("No active hermes set, will skip marking migration status")

--- a/consumer/migration/migrator_storage.go
+++ b/consumer/migration/migrator_storage.go
@@ -48,6 +48,7 @@ func NewStorage(db respository, ap registry.AddressProvider) *Storage {
 	}
 }
 
+// MarkAsMigrated set migration flag do not try to migrate again
 func (s *Storage) MarkAsMigrated(chainID int64, identity string) {
 	activeHermes, err := s.ap.GetActiveHermes(chainID)
 	if err != nil {

--- a/identity/registry/registry_contract.go
+++ b/identity/registry/registry_contract.go
@@ -48,6 +48,7 @@ type transactor interface {
 	FetchRegistrationStatus(id string) ([]TransactorStatusResponse, error)
 }
 
+// RegisterCallback calls when registration is finished
 type RegisterCallback = func(chainID int64, identity string)
 
 type contractRegistry struct {

--- a/identity/registry/transactor.go
+++ b/identity/registry/transactor.go
@@ -51,6 +51,8 @@ type AddressProvider interface {
 	GetActiveHermes(chainID int64) (common.Address, error)
 	GetRegistryAddress(chainID int64) (common.Address, error)
 	GetKnownHermeses(chainID int64) ([]common.Address, error)
+	GetChannelImplementationForHermes(chainID int64, hermes common.Address) (common.Address, error)
+	GetMystAddress(chainID int64) (common.Address, error)
 }
 
 type feeType uint8

--- a/tequilapi/endpoints/identities_test.go
+++ b/tequilapi/endpoints/identities_test.go
@@ -25,19 +25,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/mysteriumnetwork/go-rest/apierror"
-	"github.com/mysteriumnetwork/payments/client"
-
-	"github.com/mysteriumnetwork/node/session/pingpong"
-	pingpongEvent "github.com/mysteriumnetwork/node/session/pingpong/event"
-
-	"github.com/gin-gonic/gin"
-
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
-
+	"github.com/gin-gonic/gin"
+	"github.com/mysteriumnetwork/go-rest/apierror"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/identity/registry"
+	"github.com/mysteriumnetwork/node/session/pingpong"
+	pingpongEvent "github.com/mysteriumnetwork/node/session/pingpong/event"
+	"github.com/mysteriumnetwork/payments/client"
+	"github.com/stretchr/testify/assert"
 )
 
 const identityUrl = "/irrelevant"
@@ -500,6 +496,14 @@ type mockAddressProvider struct {
 }
 
 func (ma *mockAddressProvider) GetActiveChannelImplementation(chainID int64) (common.Address, error) {
+	return ma.channelToReturn, nil
+}
+
+func (ma *mockAddressProvider) GetChannelImplementationForHermes(chainID int64, hermes common.Address) (common.Address, error) {
+	return ma.channelToReturn, nil
+}
+
+func (ma *mockAddressProvider) GetMystAddress(chainID int64) (common.Address, error) {
 	return ma.channelToReturn, nil
 }
 


### PR DESCRIPTION
For freshly registered users:
* Add subscription to registration event. Mark as no registration is needed.
* If local db (boltdb) in some case not available and old Hermes down - skip migration and mark it as 'done'
* Add preceding call to blockchain: if channel for old Hermes not opened - skip
For users who are using old Hermes:
* if old Hermes is down - still open new payment channel in new Hermes