### PR TITLE
Add space to status and  address in getIdentity

### DIFF
--- a/cmd/commands/cli/command_identities.go
+++ b/cmd/commands/cli/command_identities.go
@@ -164,8 +164,8 @@ func (c *cliApp) getIdentity(actionArgs []string) (err error) {
 	if err != nil {
 		return err
 	}
-	clio.Info("Registration Status: ", identityStatus.RegistrationStatus)
-	clio.Info("Channel address: ", identityStatus.ChannelAddress)
+	clio.Info("Registration Status: %s", identityStatus.RegistrationStatus)
+	clio.Info("Channel address: %s", identityStatus.ChannelAddress)
 	clio.Info(fmt.Sprintf("Balance: %s MYST", identityStatus.BalanceTokens))
 	clio.Info(fmt.Sprintf("Earnings: %s", money.New(identityStatus.Earnings)))
 	clio.Info(fmt.Sprintf("Earnings total: %s", money.New(identityStatus.EarningsTotal)))


### PR DESCRIPTION
Adding space for better readability and easier copy and paste in Channel address and registration status