### PR TITLE
Fix timer

### DIFF
--- a/session/pingpong/factory.go
+++ b/session/pingpong/factory.go
@@ -87,7 +87,7 @@ func InvoiceFactoryCreator(
 			MaxNotPaidInvoice:          maxUnpaidInvoiceValue,
 			LimitNotPaidInvoice:        limitUnpaidInvoiceValue,
 			ChargePeriod:               balanceSendPeriod,
-			LimitChargePeriod:          balanceSendPeriod,
+			LimitChargePeriod:          limitBalanceSendPeriod,
 			ChargePeriodLeeway:         2 * time.Minute,
 			Observer:                   observer,
 		}

--- a/session/pingpong/invoice_tracker.go
+++ b/session/pingpong/invoice_tracker.go
@@ -387,6 +387,7 @@ func (it *InvoiceTracker) updateMaxUnpaid() {
 	}
 
 	it.deps.MaxNotPaidInvoice = bigger
+	log.Debug().Str("invoice_amount", it.deps.MaxNotPaidInvoice.String()).Msg("Max invoice amount increased")
 }
 
 func (it *InvoiceTracker) updateTimer() {
@@ -400,6 +401,7 @@ func (it *InvoiceTracker) updateTimer() {
 		newMaxTime = maxTime
 	}
 	it.deps.ChargePeriod = newMaxTime
+	log.Debug().Int64("change_period (ms)", it.deps.ChargePeriod.Milliseconds()).Msg("Max charge period increased")
 }
 
 // WaitFirstInvoice waits for a first invoice to be paid.


### PR DESCRIPTION
Charge period increase func snippet:
```go
func (it *InvoiceTracker) updateTimer() {
	maxTime := it.deps.LimitChargePeriod
	if it.deps.ChargePeriod >= maxTime {
		return
	}
// ..
```

Because this was miss configured session invoice timer never increasing leading to less session stability and increase load on our payment service.

Closes: https://github.com/mysteriumnetwork/node/issues/5237