### PR TITLE
disable testinstall for now

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,12 +77,12 @@ test-e2e-nat:
 #   tags: [go,high_performance]
 #   script: go run mage.go -v TestE2ECompatibility
 
-test-install-script:
-  stage: test
-  tags: [go,dedicated]
-  script: go run mage.go -v TestInstallScript
-  only:
-    - master
+#test-install-script:
+#  stage: test
+#  tags: [go,dedicated]
+#  script: go run mage.go -v TestInstallScript
+#  only:
+#    - master
 
 create-bucket:
   stage: pre-release


### PR DESCRIPTION
Got broken too many times. Now we've found out it also depends on kernel parameters and sysfs structure, so it's not entirely portable. We can't proceed like this, so we have to disable this test until we will find how to make it better. Maybe running separate system in QEMU is more portable option. QEMU doesn't sound too bad there, we already use it for cross-platform docker image builds anyway.