### PR TITLE
omit empty access policies

### DIFF
--- a/cmd/commands/cli/command_service.go
+++ b/cmd/commands/cli/command_service.go
@@ -71,7 +71,7 @@ func (c *cliApp) serviceStart(providerID, serviceType string, args ...string) (e
 	service, err := c.tequilapi.ServiceStart(contract.ServiceStartRequest{
 		ProviderID:     providerID,
 		Type:           serviceType,
-		AccessPolicies: contract.ServiceAccessPolicies{IDs: serviceOpts.AccessPolicyList},
+		AccessPolicies: &contract.ServiceAccessPolicies{IDs: serviceOpts.AccessPolicyList},
 		Options:        serviceOpts.TypeOptions,
 	})
 	if err != nil {

--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -141,7 +141,7 @@ func (sc *serviceCommand) Run(ctx *cli.Context) (err error) {
 		startRequest := contract.ServiceStartRequest{
 			ProviderID:     providerID,
 			Type:           serviceType,
-			AccessPolicies: contract.ServiceAccessPolicies{IDs: serviceOpts.AccessPolicyList},
+			AccessPolicies: &contract.ServiceAccessPolicies{IDs: serviceOpts.AccessPolicyList},
 			Options:        serviceOpts,
 		}
 

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -280,7 +280,7 @@ func TestConsumerConnectsToProvider(t *testing.T) {
 		req := contract.ServiceStartRequest{
 			ProviderID:     providerID,
 			Type:           "noop",
-			AccessPolicies: contract.ServiceAccessPolicies{IDs: []string{"mysterium"}},
+			AccessPolicies: &contract.ServiceAccessPolicies{IDs: []string{"mysterium"}},
 		}
 
 		_, err := tequilapiProvider.ServiceStart(req)

--- a/tequilapi/contract/service.go
+++ b/tequilapi/contract/service.go
@@ -32,7 +32,7 @@ type ServiceStartRequest struct {
 
 	// access list which determines which identities will be able to receive the service
 	// required: false
-	AccessPolicies ServiceAccessPolicies `json:"access_policies"`
+	AccessPolicies *ServiceAccessPolicies `json:"access_policies,omitempty"`
 
 	// service options. Every service has a unique list of allowed options.
 	// required: false

--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -304,12 +304,12 @@ func (se *ServiceEndpoint) toServiceRequest(req *http.Request) (contract.Service
 		ProviderID: jsonData.ProviderID,
 		Type:       se.toServiceType(jsonData.Type),
 		Options:    se.toServiceOptions(jsonData.Type, jsonData.Options),
-		AccessPolicies: contract.ServiceAccessPolicies{
+		AccessPolicies: &contract.ServiceAccessPolicies{
 			IDs: serviceOpts.AccessPolicyList,
 		},
 	}
 	if jsonData.AccessPolicies != nil {
-		sr.AccessPolicies = *jsonData.AccessPolicies
+		sr.AccessPolicies = jsonData.AccessPolicies
 	}
 	return sr, nil
 }


### PR DESCRIPTION
Was sending empty and causing it to not use any access policy therefore launching the service but everyone could connect

Signed-off-by: Guillem Bonet <guillem@mysterium.network>