### PR TITLE
single wireguard client factory

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -76,6 +76,7 @@ import (
 	"github.com/mysteriumnetwork/node/router"
 	service_noop "github.com/mysteriumnetwork/node/services/noop"
 	service_openvpn "github.com/mysteriumnetwork/node/services/openvpn"
+	"github.com/mysteriumnetwork/node/services/wireguard/endpoint"
 	"github.com/mysteriumnetwork/node/session/connectivity"
 	"github.com/mysteriumnetwork/node/session/pingpong"
 	"github.com/mysteriumnetwork/node/sleep"
@@ -149,6 +150,8 @@ type Dependencies struct {
 	ServiceRegistry *service.Registry
 	ServiceSessions *service.SessionPool
 	ServiceFirewall firewall.IncomingTrafficFirewall
+
+	WireguardClientFactory *endpoint.WgClientFactory
 
 	PortPool   *port.Pool
 	PortMapper mapping.PortMapper
@@ -830,6 +833,9 @@ func (di *Dependencies) bootstrapNetworkComponents(options node.Options) (err er
 	if err := di.AllowURLAccess(allow...); err != nil {
 		return err
 	}
+
+	di.WireguardClientFactory = endpoint.NewWGClientFactory()
+
 	return di.IdentityRegistry.Subscribe(di.EventBus)
 }
 

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -60,14 +60,14 @@ func (di *Dependencies) bootstrapServices(nodeOptions node.Options) error {
 	di.bootstrapServiceOpenvpn(nodeOptions)
 	di.bootstrapServiceNoop(nodeOptions)
 	resourcesAllocator := resources.NewAllocator(di.PortPool, wireguard_service.GetOptions().Subnet)
-	di.bootstrapServiceWireguard(nodeOptions, resourcesAllocator)
-	di.bootstrapServiceScraping(nodeOptions, resourcesAllocator)
-	di.bootstrapServiceDataTransfer(nodeOptions, resourcesAllocator)
+	di.bootstrapServiceWireguard(nodeOptions, resourcesAllocator, di.WireguardClientFactory)
+	di.bootstrapServiceScraping(nodeOptions, resourcesAllocator, di.WireguardClientFactory)
+	di.bootstrapServiceDataTransfer(nodeOptions, resourcesAllocator, di.WireguardClientFactory)
 
 	return nil
 }
 
-func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options, resourcesAllocator *resources.Allocator) {
+func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options, resourcesAllocator *resources.Allocator, wgClientFactory *endpoint.WgClientFactory) {
 	di.ServiceRegistry.Register(
 		wireguard.ServiceType,
 		func(serviceOptions service.Options) (service.Service, error) {
@@ -83,13 +83,14 @@ func (di *Dependencies) bootstrapServiceWireguard(nodeOptions node.Options, reso
 				di.EventBus,
 				di.ServiceFirewall,
 				resourcesAllocator,
+				wgClientFactory,
 			)
 			return svc, nil
 		},
 	)
 }
 
-func (di *Dependencies) bootstrapServiceScraping(nodeOptions node.Options, resourcesAllocator *resources.Allocator) {
+func (di *Dependencies) bootstrapServiceScraping(nodeOptions node.Options, resourcesAllocator *resources.Allocator, wgClientFactory *endpoint.WgClientFactory) {
 	di.ServiceRegistry.Register(
 		scraping.ServiceType,
 		func(serviceOptions service.Options) (service.Service, error) {
@@ -105,13 +106,14 @@ func (di *Dependencies) bootstrapServiceScraping(nodeOptions node.Options, resou
 				di.EventBus,
 				di.ServiceFirewall,
 				resourcesAllocator,
+				wgClientFactory,
 			)
 			return svc, nil
 		},
 	)
 }
 
-func (di *Dependencies) bootstrapServiceDataTransfer(nodeOptions node.Options, resourcesAllocator *resources.Allocator) {
+func (di *Dependencies) bootstrapServiceDataTransfer(nodeOptions node.Options, resourcesAllocator *resources.Allocator, wgClientFactory *endpoint.WgClientFactory) {
 	di.ServiceRegistry.Register(
 		datatransfer.ServiceType,
 		func(serviceOptions service.Options) (service.Service, error) {
@@ -127,6 +129,7 @@ func (di *Dependencies) bootstrapServiceDataTransfer(nodeOptions node.Options, r
 				di.EventBus,
 				di.ServiceFirewall,
 				resourcesAllocator,
+				wgClientFactory,
 			)
 			return svc, nil
 		},
@@ -292,16 +295,16 @@ func (di *Dependencies) registerConnections(nodeOptions node.Options) {
 
 	resourceAllocator := resources.NewAllocator(nil, wireguard_service.DefaultOptions.Subnet)
 
-	di.registerWireguardConnection(nodeOptions, resourceAllocator)
-	di.registerScrapingConnection(nodeOptions, resourceAllocator)
-	di.registerDataTransferConnection(nodeOptions, resourceAllocator)
+	di.registerWireguardConnection(nodeOptions, resourceAllocator, di.WireguardClientFactory)
+	di.registerScrapingConnection(nodeOptions, resourceAllocator, di.WireguardClientFactory)
+	di.registerDataTransferConnection(nodeOptions, resourceAllocator, di.WireguardClientFactory)
 }
 
-func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options, resourceAllocator *resources.Allocator) {
+func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options, resourceAllocator *resources.Allocator, wgClientFactory *endpoint.WgClientFactory) {
 	wireguard.Bootstrap()
 	handshakeWaiter := wireguard_connection.NewHandshakeWaiter()
 	endpointFactory := func() (wireguard.ConnectionEndpoint, error) {
-		return endpoint.NewConnectionEndpoint(resourceAllocator)
+		return endpoint.NewConnectionEndpoint(resourceAllocator, wgClientFactory)
 	}
 	connFactory := func() (connection.Connection, error) {
 		opts := wireguard_connection.Options{
@@ -313,11 +316,11 @@ func (di *Dependencies) registerWireguardConnection(nodeOptions node.Options, re
 	di.ConnectionRegistry.Register(wireguard.ServiceType, connFactory)
 }
 
-func (di *Dependencies) registerScrapingConnection(nodeOptions node.Options, resourceAllocator *resources.Allocator) {
+func (di *Dependencies) registerScrapingConnection(nodeOptions node.Options, resourceAllocator *resources.Allocator, wgClientFactory *endpoint.WgClientFactory) {
 	scraping.Bootstrap()
 	handshakeWaiter := wireguard_connection.NewHandshakeWaiter()
 	endpointFactory := func() (wireguard.ConnectionEndpoint, error) {
-		return endpoint.NewConnectionEndpoint(resourceAllocator)
+		return endpoint.NewConnectionEndpoint(resourceAllocator, wgClientFactory)
 	}
 	connFactory := func() (connection.Connection, error) {
 		opts := wireguard_connection.Options{
@@ -329,11 +332,11 @@ func (di *Dependencies) registerScrapingConnection(nodeOptions node.Options, res
 	di.ConnectionRegistry.Register(scraping.ServiceType, connFactory)
 }
 
-func (di *Dependencies) registerDataTransferConnection(nodeOptions node.Options, resourceAllocator *resources.Allocator) {
+func (di *Dependencies) registerDataTransferConnection(nodeOptions node.Options, resourceAllocator *resources.Allocator, wgClientFactory *endpoint.WgClientFactory) {
 	datatransfer.Bootstrap()
 	handshakeWaiter := wireguard_connection.NewHandshakeWaiter()
 	endpointFactory := func() (wireguard.ConnectionEndpoint, error) {
-		return endpoint.NewConnectionEndpoint(resourceAllocator)
+		return endpoint.NewConnectionEndpoint(resourceAllocator, wgClientFactory)
 	}
 	connFactory := func() (connection.Connection, error) {
 		opts := wireguard_connection.Options{

--- a/services/wireguard/endpoint/endpoint.go
+++ b/services/wireguard/endpoint/endpoint.go
@@ -32,8 +32,8 @@ import (
 )
 
 // NewConnectionEndpoint returns new connection endpoint instance.
-func NewConnectionEndpoint(resourceAllocator *resources.Allocator) (wg.ConnectionEndpoint, error) {
-	wgClient, err := newWGClient()
+func NewConnectionEndpoint(resourceAllocator *resources.Allocator, wgClientFactory *WgClientFactory) (wg.ConnectionEndpoint, error) {
+	wgClient, err := wgClientFactory.NewWGClient()
 	if err != nil {
 		return nil, err
 	}

--- a/services/wireguard/service/service.go
+++ b/services/wireguard/service/service.go
@@ -50,6 +50,7 @@ func NewManager(
 	eventBus eventbus.EventBus,
 	trafficFirewall firewall.IncomingTrafficFirewall,
 	resourcesAllocator *resources.Allocator,
+	wgClientFactory *endpoint.WgClientFactory,
 ) *Manager {
 	return &Manager{
 		done:               make(chan struct{}),
@@ -60,7 +61,7 @@ func NewManager(
 		trafficFirewall:    trafficFirewall,
 
 		connEndpointFactory: func() (wg.ConnectionEndpoint, error) {
-			return endpoint.NewConnectionEndpoint(resourcesAllocator)
+			return endpoint.NewConnectionEndpoint(resourcesAllocator, wgClientFactory)
 		},
 		country:        country,
 		sessionCleanup: map[string]func(){},


### PR DESCRIPTION
no collisions when checking for kernel space implementation of wireguard + cached response

Signed-off-by: Guillem Bonet <guillem@mysterium.network>