### PR TITLE
fix reconnection state

### DIFF
--- a/tequilapi/endpoints/sse_handler.go
+++ b/tequilapi/endpoints/sse_handler.go
@@ -270,9 +270,13 @@ func mapState(state stateEvent.State) stateRes {
 	}
 
 	conn := event.Connection{Session: connectionstate.Status{State: connectionstate.NotConnected}}
-	for _, c := range state.Connections {
-		if len(c.Session.State) > 0 {
-			conn = c
+
+	for k, c := range state.Connections {
+		if c.Session.State == "" {
+			c.Session.State = connectionstate.NotConnected
+		}
+		conn = c
+		if len(k) > 0 {
 			break
 		}
 	}


### PR DESCRIPTION
We have several connections  and some of them can be Connected, but some in Connecting state.  So during map loop we can randomly get different state. I fix it by return any connection with session id, otherwise it will be a Connecting state.