### PR TITLE
Fix typo in error

### DIFF
--- a/core/quality/mysterium_morqa.go
+++ b/core/quality/mysterium_morqa.go
@@ -133,7 +133,7 @@ func (m *MysteriumMORQA) signBatch(owner string, batch *metrics.Batch) (string, 
 
 	signature, err := m.signer(identity.FromAddress(owner)).Sign(bin)
 	if err != nil {
-		return "", fmt.Errorf("failed to sing metrics event: %w", err)
+		return "", fmt.Errorf("failed to sign metrics event: %w", err)
 	}
 
 	return signature.Base64(), nil


### PR DESCRIPTION
AFAIK mysterium is not a music game, so this one-line PR fixes a typo in an error about signing