### PR TITLE
Replace whitelist migration for service command

### DIFF
--- a/cmd/commands/service/command.go
+++ b/cmd/commands/service/command.go
@@ -35,9 +35,6 @@ import (
 	"github.com/mysteriumnetwork/node/config/urfavecli/clicontext"
 	"github.com/mysteriumnetwork/node/core/node"
 	"github.com/mysteriumnetwork/node/services"
-	"github.com/mysteriumnetwork/node/services/datatransfer"
-	"github.com/mysteriumnetwork/node/services/scraping"
-	"github.com/mysteriumnetwork/node/services/wireguard"
 	"github.com/mysteriumnetwork/node/tequilapi/client"
 	"github.com/mysteriumnetwork/node/tequilapi/contract"
 )
@@ -114,16 +111,9 @@ type serviceCommand struct {
 func (sc *serviceCommand) Run(ctx *cli.Context) (err error) {
 	serviceTypes := make([]string, 0)
 
-	// TODO: migration. remove later https://github.com/mysteriumnetwork/payments/issues/234
 	activeServices := config.Current.GetString(config.FlagActiveServices.Name)
-	if len(activeServices) > 0 {
+	if len(activeServices) != 0 {
 		serviceTypes = strings.Split(activeServices, ",")
-	} else { // start migration
-		if len(config.Current.GetString(config.FlagWireguardAccessPolicies.Name)) > 0 || len(config.Current.GetString(config.FlagAccessPolicyList.Name)) > 0 {
-			serviceTypes = []string{scraping.ServiceType, datatransfer.ServiceType}
-		} else {
-			serviceTypes = []string{wireguard.ServiceType, scraping.ServiceType, datatransfer.ServiceType}
-		}
 	}
 
 	sc.tryRememberTOS(ctx, sc.errorChannel)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mysteriumnetwork/node/services/datatransfer"
+	"github.com/mysteriumnetwork/node/services/scraping"
+	"github.com/mysteriumnetwork/node/services/wireguard"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
@@ -230,6 +234,11 @@ func TestUserConfig_GetConfig(t *testing.T) {
 		},
 		cfg.GetConfig(),
 	)
+}
+
+func TestHardcodedServicesNameFlagValues(t *testing.T) {
+	// importing these constants into config package create cyclic dependency
+	assert.Equal(t, strings.Join([]string{wireguard.ServiceType, scraping.ServiceType, datatransfer.ServiceType}, ","), FlagActiveServices.Value)
 }
 
 func must(t *testing.T, err error) {

--- a/config/flags_service_start.go
+++ b/config/flags_service_start.go
@@ -18,6 +18,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -65,6 +67,7 @@ var (
 	FlagActiveServices = cli.StringFlag{
 		Name:  "active-services",
 		Usage: "Comma separated list of active services.",
+		Value: strings.Join([]string{"wireguard", "scraping", "data_transfer"}, ","),
 	}
 )
 


### PR DESCRIPTION
First time start will enable all services.
This will also make services complete sticky. For example - if all disabled, none will be started after restart.