### PR TITLE
Replace policy fetching with specific identity check request

### DIFF
--- a/cmd/di.go
+++ b/cmd/di.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/mysteriumnetwork/node/core/policy"
+	"github.com/mysteriumnetwork/node/core/policy/localcopy"
+
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -47,7 +50,6 @@ import (
 	"github.com/mysteriumnetwork/node/core/node"
 	nodevent "github.com/mysteriumnetwork/node/core/node/event"
 	"github.com/mysteriumnetwork/node/core/payout"
-	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/core/port"
 	"github.com/mysteriumnetwork/node/core/quality"
 	"github.com/mysteriumnetwork/node/core/service"
@@ -141,7 +143,8 @@ type Dependencies struct {
 
 	dnsProxy *dns.Proxy
 
-	PolicyOracle *policy.Oracle
+	PolicyOracle   *localcopy.Oracle
+	PolicyProvider policy.Provider
 
 	SessionStorage                   *consumer_session.Storage
 	SessionConnectivityStatusStorage connectivity.StatusStorage

--- a/cmd/di_desktop.go
+++ b/cmd/di_desktop.go
@@ -20,13 +20,15 @@ package cmd
 import (
 	"time"
 
+	"github.com/mysteriumnetwork/node/core/policy/requested"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/mysteriumnetwork/node/config"
 	"github.com/mysteriumnetwork/node/core/connection"
 	"github.com/mysteriumnetwork/node/core/node"
-	"github.com/mysteriumnetwork/node/core/policy"
+	"github.com/mysteriumnetwork/node/core/policy/localcopy"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/dns"
@@ -249,12 +251,18 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 
 	di.ServiceSessions = service.NewSessionPool(di.EventBus)
 
-	di.PolicyOracle = policy.NewOracle(
+	di.PolicyOracle = localcopy.NewOracle(
 		di.HTTPClient,
 		config.GetString(config.FlagAccessPolicyAddress),
 		config.GetDuration(config.FlagAccessPolicyFetchInterval),
+		config.GetBool(config.FlagAccessPolicyFetchingEnabled),
 	)
 	go di.PolicyOracle.Start()
+
+	di.PolicyProvider = requested.NewRequestedProvider(
+		di.HTTPClient,
+		config.GetString(config.FlagAccessPolicyAddress),
+	)
 
 	di.HermesStatusChecker = pingpong.NewHermesStatusChecker(di.BCHelper, di.ObserverAPI, nodeOptions.Payments.HermesStatusRecheckInterval)
 
@@ -288,6 +296,7 @@ func (di *Dependencies) bootstrapServiceComponents(nodeOptions node.Options) err
 		di.DiscoveryFactory,
 		di.EventBus,
 		di.PolicyOracle,
+		di.PolicyProvider,
 		di.P2PListener,
 		newP2PSessionHandler,
 		di.SessionConnectivityStatusStorage,

--- a/config/flags_policy.go
+++ b/config/flags_policy.go
@@ -37,6 +37,12 @@ var (
 		Usage: `Proposal fetch interval { "30s", "3m", "1h20m30s" }`,
 		Value: 10 * time.Minute,
 	}
+	// FlagAccessPolicyFetchingEnabled policy list fetch enable
+	FlagAccessPolicyFetchingEnabled = cli.BoolFlag{
+		Name:  "access-policy.fetching-enabled",
+		Usage: "Enable periodic fetching of access policies and saving to memory (allows support for whitelist types other than identity)",
+		Value: false,
+	}
 )
 
 // RegisterFlagsPolicy function registers Policy Oracle flags to flag list.
@@ -44,6 +50,7 @@ func RegisterFlagsPolicy(flags *[]cli.Flag) {
 	*flags = append(*flags,
 		&FlagAccessPolicyAddress,
 		&FlagAccessPolicyFetchInterval,
+		&FlagAccessPolicyFetchingEnabled,
 	)
 }
 
@@ -51,4 +58,5 @@ func RegisterFlagsPolicy(flags *[]cli.Flag) {
 func ParseFlagsPolicy(ctx *cli.Context) {
 	Current.ParseStringFlag(ctx, FlagAccessPolicyAddress)
 	Current.ParseDurationFlag(ctx, FlagAccessPolicyFetchInterval)
+	Current.ParseBoolFlag(ctx, FlagAccessPolicyFetchingEnabled)
 }

--- a/core/policy/localcopy/oracle_test.go
+++ b/core/policy/localcopy/oracle_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package policy
+package localcopy
 
 import (
 	"fmt"
@@ -180,7 +180,12 @@ func Test_Oracle_StartSyncsPolicies(t *testing.T) {
 }
 
 func Test_PolicyRepository_StartMultipleTimes(t *testing.T) {
-	oracle := NewOracle(requests.NewHTTPClient("0.0.0.0", time.Second), "http://policy.localhost", time.Minute)
+	oracle := NewOracle(
+		requests.NewHTTPClient("0.0.0.0", time.Second),
+		"http://policy.localhost",
+		time.Minute,
+		true,
+	)
 	go oracle.Start()
 	oracle.Stop()
 
@@ -193,6 +198,7 @@ func createEmptyOracle(mockServerURL string) *Oracle {
 		requests.NewHTTPClient("0.0.0.0", 100*time.Millisecond),
 		mockServerURL+"/",
 		time.Minute,
+		true,
 	)
 }
 
@@ -201,6 +207,7 @@ func createFilledOracle(mockServerURL string, interval time.Duration, repo *Repo
 		requests.NewHTTPClient("0.0.0.0", time.Second),
 		mockServerURL+"/",
 		interval,
+		true,
 	)
 	oracle.SubscribePolicies(
 		[]market.AccessPolicy{oracle.Policy("1"), oracle.Policy("2")},

--- a/core/policy/localcopy/repository.go
+++ b/core/policy/localcopy/repository.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package policy
+package localcopy
 
 import (
 	"fmt"

--- a/core/policy/localcopy/repository_test.go
+++ b/core/policy/localcopy/repository_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package policy
+package localcopy
 
 import (
 	"testing"

--- a/core/policy/provider.go
+++ b/core/policy/provider.go
@@ -1,7 +1,5 @@
-//go:build ignore
-
 /*
- * Copyright (C) 2019 The "MysteriumNetwork/node" Authors.
+ * Copyright (C) 2023 The "MysteriumNetwork/node" Authors.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,16 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package main
+package policy
 
-import (
-	"os"
+import "github.com/mysteriumnetwork/node/identity"
 
-	"github.com/magefile/mage/mage"
-)
-
-// Zero install option.
-// Usage example:
-//
-//	go run mage.go test
-func main() { os.Exit(mage.Main()) }
+// Provider interface defines policy provider
+type Provider interface {
+	IsIdentityAllowed(identity identity.Identity) bool
+	HasDNSRules() bool
+	IsHostAllowed(host string) bool
+}

--- a/core/policy/requested/provider.go
+++ b/core/policy/requested/provider.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package requested
+
+import (
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/requests"
+	"github.com/rs/zerolog/log"
+)
+
+// Provider defines the requested provider structure.
+type Provider struct {
+	client   *requests.HTTPClient
+	fetchURL string
+}
+
+// NewRequestedProvider creates a policy provider
+func NewRequestedProvider(client *requests.HTTPClient, policyURL string) *Provider {
+	return &Provider{
+		client:   client,
+		fetchURL: policyURL,
+	}
+}
+
+// IsIdentityAllowed returns if provided identity exists in any access policy.
+func (o *Provider) IsIdentityAllowed(identity identity.Identity) bool {
+	req, err := requests.NewGetRequest(o.fetchURL, "", nil)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to create policy request")
+		return false
+	}
+
+	queryValues := req.URL.Query()
+	queryValues.Add("identity-value", identity.Address)
+	req.URL.RawQuery = queryValues.Encode()
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to make policy request")
+		return false
+	}
+
+	return resp.StatusCode >= 200 && resp.StatusCode <= 299
+}
+
+// HasDNSRules returns if dns rules exist. Currently unsupported with this implemenetation
+func (o *Provider) HasDNSRules() bool {
+	return false
+}
+
+// IsHostAllowed returns if provided host is allowed. Currently unsupported with this implemenetation
+func (o *Provider) IsHostAllowed(host string) bool {
+	return false
+}

--- a/core/policy/requested/provider_test.go
+++ b/core/policy/requested/provider_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package requested_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mysteriumnetwork/node/core/policy/requested"
+	"github.com/mysteriumnetwork/node/identity"
+	"github.com/mysteriumnetwork/node/requests"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_RequestedProvider_GetIdentityAllowed(t *testing.T) {
+	policyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("identity-value") {
+		case "0x1":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "1",
+				"title": "One",
+				"description": "",
+				"allow": [
+					{"type": "identity", "value": "0x1"}
+				]
+			}`))
+		case "0x2":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "2",
+				"title": "Two",
+				"description": "",
+				"allow": [
+					{"type": "identity", "value": "0x2"}
+				]
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer policyServer.Close()
+
+	oracle := requested.NewRequestedProvider(requests.NewHTTPClient("0.0.0.0", 100*time.Millisecond), policyServer.URL+"/")
+
+	assert.True(t, oracle.IsIdentityAllowed(identity.Identity{Address: "0x1"}))
+	assert.True(t, oracle.IsIdentityAllowed(identity.Identity{Address: "0x2"}))
+	assert.False(t, oracle.IsIdentityAllowed(identity.Identity{Address: "0x3"}))
+}

--- a/core/service/manager_test.go
+++ b/core/service/manager_test.go
@@ -22,8 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mysteriumnetwork/node/core/policy/localcopy"
+	"github.com/mysteriumnetwork/node/core/policy/requested"
+
 	"github.com/mysteriumnetwork/node/core/location/locationstate"
-	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/identity"
 	"github.com/mysteriumnetwork/node/market"
@@ -35,8 +37,9 @@ import (
 )
 
 var (
-	serviceType      = "the-very-awesome-test-service-type"
-	mockPolicyOracle = policy.NewOracle(requests.NewHTTPClient("0.0.0.0", requests.DefaultTimeout), "http://policy.localhost/", 1*time.Minute)
+	serviceType        = "the-very-awesome-test-service-type"
+	mockPolicyOracle   = localcopy.NewOracle(requests.NewHTTPClient("0.0.0.0", requests.DefaultTimeout), "http://policy.localhost/", 1*time.Minute, true)
+	mockPolicyProvider = requested.NewRequestedProvider(requests.NewHTTPClient("0.0.0.0", requests.DefaultTimeout), "http://policy.localhost/")
 )
 
 func init() {
@@ -58,6 +61,7 @@ func TestManager_StartRemovesServiceFromPoolIfServiceCrashes(t *testing.T) {
 		discoveryFactory,
 		mocks.NewEventBus(),
 		mockPolicyOracle,
+		mockPolicyProvider,
 		&mockP2PListener{}, nil, nil, mockLocationResolver{},
 	)
 	_, err := manager.Start(identity.FromAddress(proposalMock.ProviderID), serviceType, nil, struct{}{})
@@ -82,6 +86,7 @@ func TestManager_StartDoesNotCrashIfStoppedByUser(t *testing.T) {
 		discoveryFactory,
 		mocks.NewEventBus(),
 		mockPolicyOracle,
+		mockPolicyProvider,
 		&mockP2PListener{}, nil, nil,
 		mockLocationResolver{},
 	)
@@ -109,6 +114,7 @@ func TestManager_StopSendsEvent_SucceedsAndPublishesEvent(t *testing.T) {
 		discoveryFactory,
 		eventBus,
 		mockPolicyOracle,
+		mockPolicyProvider,
 		&mockP2PListener{}, nil, nil,
 		mockLocationResolver{},
 	)

--- a/core/service/pool.go
+++ b/core/service/pool.go
@@ -132,18 +132,18 @@ func NewInstance(
 	proposal market.ServiceProposal,
 	state servicestate.State,
 	service Service,
-	policies *policy.Repository,
+	policyProvider policy.Provider,
 	discovery Discovery,
 ) *Instance {
 	return &Instance{
-		ProviderID: providerID,
-		Type:       serviceType,
-		Options:    options,
-		Proposal:   proposal,
-		state:      state,
-		service:    service,
-		policies:   policies,
-		discovery:  discovery,
+		ProviderID:     providerID,
+		Type:           serviceType,
+		Options:        options,
+		Proposal:       proposal,
+		state:          state,
+		service:        service,
+		policyProvider: policyProvider,
+		discovery:      discovery,
 	}
 }
 
@@ -157,7 +157,7 @@ type Instance struct {
 	Options         Options
 	service         Service
 	Proposal        market.ServiceProposal
-	policies        *policy.Repository
+	policyProvider  policy.Provider
 	discovery       Discovery
 	eventPublisher  Publisher
 	p2pChannelsLock sync.Mutex
@@ -170,9 +170,9 @@ func (i *Instance) Service() Service {
 	return i.service
 }
 
-// Policies returns service policies of the running service instance.
-func (i *Instance) Policies() *policy.Repository {
-	return i.policies
+// PolicyProvider returns policy provider implementation.
+func (i *Instance) PolicyProvider() policy.Provider {
+	return i.policyProvider
 }
 
 // State returns the service instance state.

--- a/dns/handler_whitelist.go
+++ b/dns/handler_whitelist.go
@@ -20,8 +20,9 @@ package dns
 import (
 	"strings"
 
-	"github.com/miekg/dns"
 	"github.com/mysteriumnetwork/node/core/policy"
+
+	"github.com/miekg/dns"
 	"github.com/mysteriumnetwork/node/firewall"
 	"github.com/rs/zerolog/log"
 )
@@ -30,7 +31,7 @@ import (
 func WhitelistAnswers(
 	resolver dns.Handler,
 	trafficBlocker firewall.IncomingTrafficFirewall,
-	policies *policy.Repository,
+	policies policy.Provider,
 ) dns.Handler {
 	return &whitelistHandler{
 		resolver:       resolver,
@@ -42,7 +43,7 @@ func WhitelistAnswers(
 type whitelistHandler struct {
 	resolver       dns.Handler
 	trafficBlocker firewall.IncomingTrafficFirewall
-	policies       *policy.Repository
+	policies       policy.Provider
 }
 
 func (wh *whitelistHandler) ServeDNS(writer dns.ResponseWriter, req *dns.Msg) {

--- a/dns/handler_whitelist_test.go
+++ b/dns/handler_whitelist_test.go
@@ -21,8 +21,9 @@ import (
 	"net"
 	"testing"
 
+	"github.com/mysteriumnetwork/node/core/policy/localcopy"
+
 	"github.com/miekg/dns"
-	"github.com/mysteriumnetwork/node/core/policy"
 	"github.com/mysteriumnetwork/node/firewall"
 	"github.com/mysteriumnetwork/node/market"
 	"github.com/stretchr/testify/assert"
@@ -164,8 +165,8 @@ func Test_WhitelistAnswers(t *testing.T) {
 	}
 }
 
-func createPolicies() *policy.Repository {
-	repo := policy.NewRepository()
+func createPolicies() *localcopy.Repository {
+	repo := localcopy.NewRepository()
 	repo.SetPolicyRules(policyDNSZone, policyDNSZoneRules)
 	repo.SetPolicyRules(policyDNSHostname, policyDNSHostnameRules)
 	return repo

--- a/e2e/connection_test.go
+++ b/e2e/connection_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -566,7 +568,7 @@ func consumerConnectFlow(t *testing.T, tequilapi *tequilapi_client.Client, consu
 	sessionsDTO, err := tequilapi.SessionsByServiceType(serviceType)
 	assert.NoError(t, err)
 
-	assert.True(t, len(sessionsDTO.Items) >= 1)
+	require.True(t, len(sessionsDTO.Items) >= 1)
 	se := sessionsDTO.Items[0]
 	assert.Equal(t, "e2e-land", se.ProviderCountry)
 	assert.Equal(t, serviceType, se.ServiceType)

--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -222,6 +222,7 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		config.Current.SetDefault(config.FlagDiscoveryPingInterval.Name, "3m")
 		config.Current.SetDefault(config.FlagDiscoveryFetchInterval.Name, "3m")
 		config.Current.SetDefault(config.FlagAccessPolicyFetchInterval.Name, "10m")
+		config.Current.SetDefault(config.FlagAccessPolicyFetchingEnabled.Name, "false")
 		config.Current.SetDefault(config.FlagPaymentsZeroStakeUnsettledAmount.Name, "5.0")
 		config.Current.SetDefault(config.FlagShaperBandwidth.Name, "6250")
 

--- a/services/openvpn/service/manager.go
+++ b/services/openvpn/service/manager.go
@@ -83,8 +83,8 @@ func (m *Manager) Serve(instance *service.Instance) (err error) {
 	dnsPort := 11153
 	dnsHandler, err := dns.ResolveViaSystem()
 	if err == nil {
-		if instance.Policies().HasDNSRules() {
-			dnsHandler = dns.WhitelistAnswers(dnsHandler, m.trafficFirewall, instance.Policies())
+		if instance.PolicyProvider().HasDNSRules() {
+			dnsHandler = dns.WhitelistAnswers(dnsHandler, m.trafficFirewall, instance.PolicyProvider())
 			removeRule, err := m.trafficFirewall.BlockIncomingTraffic(m.vpnNetwork)
 			if err != nil {
 				return fmt.Errorf("failed to enable traffic blocking: %w", err)

--- a/services/wireguard/service/service.go
+++ b/services/wireguard/service/service.go
@@ -129,7 +129,7 @@ func (m *Manager) ProvideConfig(sessionID string, sessionConfig json.RawMessage,
 
 	var dnsIP net.IP
 	var releaseTrafficFirewall firewall.IncomingRuleRemove
-	if m.serviceInstance.Policies().HasDNSRules() {
+	if m.serviceInstance.PolicyProvider().HasDNSRules() {
 		releaseTrafficFirewall, err = m.trafficFirewall.BlockIncomingTraffic(providerConfig.Subnet)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to enable traffic blocking")

--- a/services/wireguard/service/service_test.go
+++ b/services/wireguard/service/service_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mysteriumnetwork/node/core/ip"
-	"github.com/mysteriumnetwork/node/core/policy"
+	"github.com/mysteriumnetwork/node/core/policy/localcopy"
 	"github.com/mysteriumnetwork/node/core/service"
 	"github.com/mysteriumnetwork/node/core/service/servicestate"
 	"github.com/mysteriumnetwork/node/dns"
@@ -46,6 +46,7 @@ var connectionEndpointStub = &mockConnectionEndpoint{}
 
 func Test_Manager_Stop(t *testing.T) {
 	manager := newManagerStub(pubIP, outIP, country)
+
 	service := service.NewInstance(
 		identity.FromAddress("0x1"),
 		"",
@@ -53,7 +54,7 @@ func Test_Manager_Stop(t *testing.T) {
 		market.ServiceProposal{},
 		servicestate.Running,
 		nil,
-		policy.NewRepository(),
+		localcopy.NewRepository(),
 		nil,
 	)
 


### PR DESCRIPTION
Related issue: https://github.com/mysteriumnetwork/node/issues/5793

Trust oracle supports fetching trust policies with identity-value filtering through URL query parameters. This allows node to replace cron like fetching of all trust policies and storing them locally logic with a simple HTTP request. This change should reduce the memory footprint of the application. 
However, node's whitelist logic has support for types of whitelist entries other than identity, like "dns_zone" and "dns_hostname". To still have this support as an option (until trust oracle adds more filtering options) a new flag was added to disable continuous fetching of access policies. By default the fetching is disabled and new flow is used.