### PR TITLE
Preserve state of services for mobile app

### DIFF
--- a/mobile/mysterium/entrypoint.go
+++ b/mobile/mysterium/entrypoint.go
@@ -373,7 +373,7 @@ func NewNode(appPath string, options *MobileNodeOptions) (*MobileNode, error) {
 		nodeOptions.Chains.Chain1.KnownHermeses = config.GetStringSlice(config.FlagChain1KnownHermeses)
 		nodeOptions.Chains.Chain1.KnownHermeses = config.GetStringSlice(config.FlagChain2KnownHermeses)
 		nodeOptions.Consumer = false
-		nodeOptions.TequilapiEnabled = true
+		nodeOptions.TequilapiEnabled = options.TequilapiSecured
 		nodeOptions.TequilapiPort = 4050
 		nodeOptions.TequilapiAddress = "127.0.0.1"
 		nodeOptions.TequilapiSecured = options.TequilapiSecured

--- a/mobile/mysterium/mobile_provider.go
+++ b/mobile/mysterium/mobile_provider.go
@@ -38,7 +38,7 @@ import (
 func DefaultProviderNodeOptions() *MobileNodeOptions {
 	options := DefaultNodeOptionsByNetwork(string(config.Mainnet))
 	options.IsProvider = true
-	options.TequilapiSecured = false
+	options.TequilapiSecured = true
 	return options
 }
 

--- a/tequilapi/tequil/routes.go
+++ b/tequilapi/tequil/routes.go
@@ -23,7 +23,7 @@ import "strings"
 const TequilapiURLPrefix = "/tequilapi"
 
 // UnprotectedRoutes these routes are not protected by reverse proxy
-var UnprotectedRoutes = []string{"/auth/authenticate", "/auth/login", "/healthcheck"}
+var UnprotectedRoutes = []string{"/auth/authenticate", "/auth/login", "/healthcheck", "/config/user"}
 
 // IsUnprotectedRoute helper method for checking if route is unprotected
 func IsUnprotectedRoute(url string) bool {


### PR DESCRIPTION
Services state (active-services in user config) should be preserved during restarts for mobile app.

Related to https://github.com/mysteriumnetwork/mmn/issues/843
