### PR TITLE
Allow localhost-only routes to be used from host

### DIFF
--- a/tequilapi/http_api_server.go
+++ b/tequilapi/http_api_server.go
@@ -80,6 +80,10 @@ func NewServer(
 		g.Use(middlewares.ApplyMiddlewareTokenAuth(authenticator))
 	}
 
+	// Set to protect localhost-only endpoints due to use of nodeUI proxy
+	// With this set, context.ClientIP() will return only IP set by trusted proxy, not by a client!
+	g.SetTrustedProxies([]string{"127.0.0.1"})
+
 	for _, h := range handlers {
 		err := h(g)
 		if err != nil {

--- a/tequilapi/middlewares/http_middlewares.go
+++ b/tequilapi/middlewares/http_middlewares.go
@@ -20,7 +20,6 @@ package middlewares
 import (
 	"net"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -65,16 +64,12 @@ func NewHostFilter() func(*gin.Context) {
 
 // NewLocalhostOnlyFilter returns instance of middleware allowing only requests
 // with local client IP.
-// Don't forget to Engine.SetTrustedProxies() if reverse proxy is used.
 func NewLocalhostOnlyFilter() func(*gin.Context) {
 	return func(c *gin.Context) {
 
 		// ClientIP() parses the headers defined in Engine.RemoteIPHeaders if there is
 		// so it handles clients behind proxy
 		isLocal := net.ParseIP(c.ClientIP()).IsLoopback()
-		if _, err := os.Stat("/.dockerenv"); err == nil && c.ClientIP() == "172.17.0.1" && c.RemoteIP() == "127.0.0.1" {
-			isLocal = true
-		}
 		if isLocal {
 			return
 		}

--- a/tequilapi/middlewares/http_middlewares.go
+++ b/tequilapi/middlewares/http_middlewares.go
@@ -20,6 +20,7 @@ package middlewares
 import (
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -69,8 +70,12 @@ func NewLocalhostOnlyFilter() func(*gin.Context) {
 	return func(c *gin.Context) {
 
 		// ClientIP() parses the headers defined in Engine.RemoteIPHeaders if there is
-		clientIP := c.ClientIP()
-		if net.ParseIP(clientIP).IsLoopback() {
+		// so it handles clients behind proxy
+		isLocal := net.ParseIP(c.ClientIP()).IsLoopback()
+		if _, err := os.Stat("/.dockerenv"); err == nil && c.ClientIP() == "172.17.0.1" && c.RemoteIP() == "127.0.0.1" {
+			isLocal = true
+		}
+		if isLocal {
 			return
 		}
 


### PR DESCRIPTION
 Regarding the case when node is run on docker. When a request comes from 172.17.0.1 it could be sent not neccessarily from host, there are many possibilities.
