### PR TITLE
docker: crosscompile

### DIFF
--- a/bin/docker/alpine/Dockerfile
+++ b/bin/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine AS builder
 
 # Install packages
 RUN apk add --no-cache git bash gcc musl-dev make linux-headers
@@ -13,7 +13,8 @@ WORKDIR /go/src/github.com/mysteriumnetwork/node
 ADD go.mod go.sum ./
 RUN go mod download
 ADD . .
-RUN bin/build
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH BUILD_STATIC=1 bin/build
 
 
 FROM alpine:3.14


### PR DESCRIPTION
Use cross-compilation for docker image in order to reduce CI pipeline time. At this moment docker build is one of longest steps of build. This change should reduce time significantly as we won't need to run golang compiler in QEMU for foreign architectures.