### PR TITLE
set price for cellular nodes the same as for residential nodes

### DIFF
--- a/session/pingpong/pricing.go
+++ b/session/pingpong/pricing.go
@@ -120,7 +120,7 @@ func (p *Pricer) getPriceForCountry(pricing market.LatestPrices, country string)
 func (p *Pricer) getCurrentByType(pricing market.LatestPrices, nodeType string, country string, serviceType string) *market.Price {
 	base := p.getPriceForCountry(pricing, country)
 	switch strings.ToLower(nodeType) {
-	case "residential":
+	case "residential", "cellular":
 		return p.getCurrentByServiceType(base.Current.Residential, serviceType)
 	default:
 		return p.getCurrentByServiceType(base.Current.Other, serviceType)
@@ -143,7 +143,7 @@ func (p *Pricer) getCurrentByServiceType(pricingByServiceType *market.PriceBySer
 func (p *Pricer) getPreviousByType(pricing market.LatestPrices, nodeType string, country string, serviceType string) *market.Price {
 	base := p.getPriceForCountry(pricing, country)
 	switch strings.ToLower(nodeType) {
-	case "residential":
+	case "residential", "cellular":
 		return p.getCurrentByServiceType(base.Previous.Residential, serviceType)
 	default:
 		return p.getCurrentByServiceType(base.Previous.Other, serviceType)


### PR DESCRIPTION
Currently we have ~200 `android` nodes with node type `residential`. It's about to be changed to `cellular` node type.
Changes in this PR set price for cellular nodes the same as for residential nodes