### PR TITLE
add additionals steps for pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,77 @@ jobs:
           user-email: core-services@mysterium.network
           commit-message: Create release version ${{ env.RELEASE_VERSION }}
           target-branch: master
-        
+
+      - name: Send pull-request
+        env:
+          GH_TOKEN: ${{ secrets.REPO_TOKEN }}
+        run: |
+          LATEST_TAG=$(git describe --tags --always --abbrev=0)
+          REPOSITORY="mysteriumTeam/mysterium-mobile-provider"
+          FOLDER="bin/$REPOSITORY"
+          BRANCH_NAME="release-$LATEST_TAG"
+
+          # Clone the remote repository and change working directory to the
+          # folder it was cloned to.
+          git clone \
+            --depth=1 \
+            --branch=bitrise \
+            https://mpolubotko:${{ secrets.REPO_TOKEN }}@github.com/$REPOSITORY \
+            $FOLDER
+
+          cd $FOLDER
+
+          # Setup the committers identity.
+          git config user.email "core-services@mysterium.network"
+          git config user.name "MysteriumTeam"
+
+          # Create a new feature branch for the changes.
+          git checkout -b $BRANCH_NAME
+
+          # Update the script files to the latest version.
+          cp -R ../../../mobile-app/android android
+
+          # Commit the changes and push the feature branch to origin
+          git add .
+          git commit -m "update files for new release version $LATEST_TAG"
+          git push origin $BRANCH_NAME
+
+          # Store the PAT in a file that can be accessed by the
+          # GitHub CLI.
+          echo "${{ secrets.REPO_TOKEN }}" > token.txt
+
+          # Authorize GitHub CLI for the current repository and
+          # create a pull-request containing the updates.
+          PR_URL=$(gh pr create \
+            --body "" \
+            --title "Release $LATEST_TAG" \
+            --head "$BRANCH_NAME" \
+            --base "master" \
+            | sed -n 's#https://github\.com/[^/]\+/[^/]\+/\pull/\([0-9]\+\).*#\1#p')
+          echo "PR_NUMBER=$PR_URL" >> $GITHUB_ENV
+
+      - name: Approve Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+          REPO_OWNER: "MysteriumTeam"
+          REPO_NAME: "mysterium-mobile-provider"
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: | 
+          response=$(curl -s -o /dev/null -w "%{http_code}" -L -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/merge \
+            -d '{"commit_title":"Release v${{ env.RELEASE_VERSION }}","commit_message":"${{ env.RELEASE_VERSION }}"}')
+          
+          # Check HTTP response
+          if [ "$response" == "204" ] || [ "$response" == "200" ] || [ "$response" == "201" ]; then
+            echo "PR was approved successfully"
+          else
+            echo "Couldn't approved PR, HTTP-status: $response"
+            exit 1  
+          fi
+      
       - name: "Call Bitrise API"
         uses: indiesdev/curl@v1.1
         with:


### PR DESCRIPTION
I had problems with previous builds. Because of the branch in the mysterium-mobile-provider-protected repository I could not add the changes that we have for the execution of the pipeline. I have now added two additional steps. The first is to create a PR in the mysterium-mobile-provider repository. The second one confirms the PR in the mysterium-mobile-provider repository. I've got the test running locally, but it would be nice if we could have a chance to test this.