### PR TITLE
Convert bandwidth limits from Kbytes to Kbits

### DIFF
--- a/core/shaper/shaper_linux.go
+++ b/core/shaper/shaper_linux.go
@@ -48,12 +48,12 @@ func (s *linuxShaper) Start(interfaceName string) error {
 		s.ws.Clear(interfaceName)
 
 		if config.GetBool(config.FlagShaperEnabled) {
-			err := s.ws.LimitDownlink(interfaceName, int(config.GetUInt64(config.FlagShaperBandwidth)))
+			err := s.ws.LimitDownlink(interfaceName, int(config.GetUInt64(config.FlagShaperBandwidth))*8)
 			if err != nil {
 				log.Error().Err(err).Msg("Could not limit download speed")
 				return err
 			}
-			err = s.ws.LimitUplink(interfaceName, int(config.GetUInt64(config.FlagShaperBandwidth)))
+			err = s.ws.LimitUplink(interfaceName, int(config.GetUInt64(config.FlagShaperBandwidth))*8)
 			if err != nil {
 				log.Error().Err(err).Msg("Could not limit upload speed")
 				return err


### PR DESCRIPTION
Issue #5902 is caused by the misalignment between the node config and network shaper component - node config uses Kbytes/sec as a network bandwidth unit, while shaper expects Kbits/sec. This fix simply converts values to Kbites before setting the limits.