### PR TITLE
Don't use tc shaper on Linux if userspace mode is active

### DIFF
--- a/core/shaper/shaper_linux.go
+++ b/core/shaper/shaper_linux.go
@@ -31,7 +31,22 @@ type linuxShaper struct {
 	listenTopic string
 }
 
-func create(listener eventListener) *linuxShaper {
+type linuxShaperNoop struct{}
+
+func (s *linuxShaperNoop) Start(interfaceName string) error {
+	return nil
+}
+
+func (s *linuxShaperNoop) Clear(interfaceName string) {
+	return
+}
+
+func create(listener eventListener) Shaper {
+	// return a noop filter if userspace flag is set
+	if config.GetBool(config.FlagUserspace) {
+		return &linuxShaperNoop{}
+	}
+
 	ws := wondershaper.New()
 	ws.Stdout = log.Logger
 	ws.Stderr = log.Logger


### PR DESCRIPTION
Userspace mode implies running node w/o sudo,
but use of tc shaper is useless for this mode and relies on sudo prompt

Symptom: no traffic is flowing