### PR TITLE
CI migration to Github Actions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,23 +1,8 @@
 name: Test and build
-on:
-  push:
-    branches:
-      - ci-migration
+on: [pull_request]
+
 env:
-  # following envs are added for the back compatibility
-  # we need to check if they are used at all
-  GO_PACKAGE: github.com/mysteriumnetwork/node
   GOFLAGS: "-count=1"
-  GITHUB_OWNER: "mysteriumnetwork"
-  GITHUB_REPO: "node"
-  GITHUB_SNAPSHOT_REPO: "node-builds"
-  GITHUB_API_TOKEN: ""
-  BUILD_BRANCH: ${{ github.ref_name }}
-  BUILD_NUMBER: ${{ github.job_id }}
-  # BUILD_COMMIT: $CI_COMMIT_SHORT_SHA
-  # BUILD_BRANCH_SAFE: $CI_COMMIT_REF_SLUG
-  # BUILD_TAG: $CI_COMMIT_TAG
-  # GIT_CLONE_PATH:
 
 jobs:
   test-and-build:
@@ -33,10 +18,6 @@ jobs:
 
       - name: Install protoc
         run: sudo apt install -y protobuf-compiler
-
-      # - name: Prepare Env
-      #   run: |
-      #     go run mage.go -v GenerateEnvFile
 
       - name: Unit tests and linters
         run: |
@@ -61,10 +42,3 @@ jobs:
 
       - name: E2E NAT test
         run: go run mage.go -v TestE2ENAT
-
-  # create-release:
-  #   name: Create Release
-  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-  #   runs-on: ubuntu-latest
-  #   needs: publish-images
-

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -50,7 +50,16 @@ jobs:
           file: ./coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      # - name: E2E basic test
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+           username: ${{ secrets.DOCKERHUB_USERNAME }}
+           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: E2E basic test
+        run: |
+          go run mage.go -v TestE2EBasic
+
       # - name: E2E NAT test
 
   # create-release:
@@ -59,8 +68,3 @@ jobs:
   #   runs-on: ubuntu-latest
   #   needs: publish-images
 
-    # - name: Login to Docker Hub
-    #   uses: docker/login-action@v3
-    #   with:
-    #      username: ${{ secrets.DOCKERHUB_USERNAME }}
-    #      password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,66 @@
+name: Test and build
+on:
+  push:
+    branches:
+      - ci-migration
+env:
+  # following envs are added for the back compatibility
+  # we need to check if they are used at all
+  GO_PACKAGE: github.com/mysteriumnetwork/node
+  GOFLAGS: "-count=1"
+  GITHUB_OWNER: "mysteriumnetwork"
+  GITHUB_REPO: "node"
+  GITHUB_SNAPSHOT_REPO: "node-builds"
+  GITHUB_API_TOKEN: ""
+  BUILD_BRANCH: ${{ github.ref_name }}
+  BUILD_NUMBER: ${{ github.job_id }}
+  # BUILD_COMMIT: $CI_COMMIT_SHORT_SHA
+  # BUILD_BRANCH_SAFE: $CI_COMMIT_REF_SLUG
+  # BUILD_TAG: $CI_COMMIT_TAG
+  # GIT_CLONE_PATH:
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+
+      - name: Install protoc
+        run: sudo apt install -y protobuf-compiler
+
+      # - name: Prepare Env
+      #   run: |
+      #     go run mage.go -v GenerateEnvFile
+
+      - name: Unit tests and linters
+        run: |
+          go run mage.go -v Generate
+          go run mage.go -v Check
+          go run mage.go -v TestWithCoverage
+
+      - name: Upload codecov report 
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      # - name: E2E basic test
+      # - name: E2E NAT test
+
+  # create-release:
+  #   name: Create Release
+  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+  #   runs-on: ubuntu-latest
+  #   needs: publish-images
+
+    # - name: Login to Docker Hub
+    #   uses: docker/login-action@v3
+    #   with:
+    #      username: ${{ secrets.DOCKERHUB_USERNAME }}
+    #      password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -57,10 +57,10 @@ jobs:
            password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: E2E basic test
-        run: |
-          go run mage.go -v TestE2EBasic
+        run: go run mage.go -v TestE2EBasic
 
-      # - name: E2E NAT test
+      - name: E2E NAT test
+        run: go run mage.go -v TestE2ENAT
 
   # create-release:
   #   name: Create Release

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,4 +1,4 @@
-name: Released
+name: Mobile-release
 
 on:
   release:


### PR DESCRIPTION
This is part 1 of the CI migration to the GitHub Actions. After this PR is merged, we'll have the old CI workflows unchanged, and GitHub Actions that will run in parallel, with gradually increasing responsibilities scope. At this stage, the GitHub Actions workflow includes:
- Unit tests and lints - `mage check`, `mage testwithcoverage`,
- Codecov report,
- E2E basic and NAT scenarios.

Additionally:
- `build/env.sh` file generation dropped until there will be a need for a custom env setup,
- GitHub `production` environment created with vars/secrets from the current CI.

The proposed update triggers workflow run on the `pull_request` events - this will be tuned later on.
Part 2 of the migration process will extend the workflow jobs to the package build operations.

---

The previously existing workflow named `Released` was renamed to `Mobile-release` to better reflect its purpose. It did not pass the execution before, and won't be fixed or touched in the course of these updates.  