### PR TITLE
Ci migration to Github Actions, part 3

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -53,6 +53,7 @@ jobs:
           cat <<EOT >> env.sh
           export RELEASE_BUILD=$RELEASE_BUILD;
           export RC_BUILD=$RC_BUILD;
+          export PR_BUILD=$PR_BUILD;
           export SNAPSHOT_BUILD=$SNAPSHOT_BUILD;
           export BUILD_NUMBER=$BUILD_NUMBER;
           export BUILD_VERSION=$BUILD_VERSION;
@@ -68,7 +69,7 @@ jobs:
     needs: [setup-env]
 
     strategy:
-      max-parallel: 4
+      max-parallel: 6
       matrix:
         platform:
           - PackageLinuxRaspberryImage

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -3,44 +3,106 @@ name: Build packages
 on:
   workflow_call:
   push:
-    branches: [master]
+    branches: [master, ci-migration]
     tags:
 
-# Mage's `GenerateEnvFile` talks to GH API to setup tags, versions, etc.
 env:
   GITHUB_OWNER: mysteriumnetwork
   GITHUB_REPO: node
   GITHUB_SNAPSHOT_REPO: node-builds
   GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
+  setup-env:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Prepare environment 
+        run: |
+          RELEASE_BUILD=false
+          if [[ "${GITHUB_REF}" == /refs/tags/* ]]; then RELEASE_BUILD=true; fi
+          
+          RC_BUILD=false
+          if [[ "${GITHUB_REF}" == /refs/tags/*-rc ]]; then RC_BUILD=true; fi
+
+          SNAPSHOT_BUILD=false
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then SNAPSHOT_BUILD=true; fi
+
+          PR_BUILD=false
+          if [[ "${SNAPSHOT_BUILD}" == "false" && "${RELEASE_BUILD}" == "false" ]]; then PR_BUILD=true; fi
+
+          BUILD_NUMBER="${{ github.run_id }}"-ghactions
+
+          if [[ "${RELEASE_BUILD}" == "true" ]]; then 
+            BUILD_VERSION="${GITHUB_REF#/refs/tags/}";
+          elif [[ "${SNAPSHOT_BUILD}" == "true" ]]; then
+            BUILD_VERSION="$(git describe --abbrev=0 --tags)"-1snapshot-"$(date '+%Y%m%dT%H%M')"-"$(echo ${GITHUB_SHA} | cut -c1-8)"; 
+          elif [[ "${PR_BUILD}" == "true" ]]; then 
+            BRANCH="${GITHUB_HEAD_REF////-}"
+            if [[ "${BRANCH}" == "" ]]; then BRANCH="${GITHUB_REF_NAME}"; fi
+            BUILD_VERSION="$(git describe --abbrev=0 --tags)"-1branch-"${BRANCH}";
+          fi
+
+          cat <<EOT >> env.sh
+          export RELEASE_BUILD=$RELEASE_BUILD;
+          export RC_BUILD=$RC_BUILD;
+          export SNAPSHOT_BUILD=$SNAPSHOT_BUILD;
+          export BUILD_NUMBER=$BUILD_NUMBER;
+          export BUILD_VERSION=$BUILD_VERSION;
+          EOT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: env.sh
+          path: env.sh
+
   build-packages:
     runs-on: ubuntu-latest
+    needs: [setup-env]
 
     strategy:
       max-parallel: 4
       matrix:
         platform:
-          - PackageLinuxRaspberryImage
+          # - PackageLinuxRaspberryImage
           - PackageLinuxAmd64
-          - PackageLinuxArm
-          - PackageLinuxDebianAmd64
-          - PackageLinuxDebianArm64
-          - PackageLinuxDebianArm
-          - PackageMacOSAmd64
-          - PackageMacOSArm64
-          - PackageWindowsAmd64
-          - PackageAndroid
-          - PackageAndroidProvider
+          # - PackageLinuxArm
+          # - PackageLinuxDebianAmd64
+          # - PackageLinuxDebianArm64
+          # - PackageLinuxDebianArm
+          # - PackageMacOSAmd64
+          # - PackageMacOSArm64
+          # - PackageWindowsAmd64
+          # - PackageAndroid
+          # - PackageAndroidProvider
 
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'
-      - name: Generate Env
-        run: go run mage.go -v GenerateEnvFile
+      - uses: actions/download-artifact@v4
+        with:
+          name: env.sh
+
+      - name: Create bucket
+        if: |
+          contains(github.ref, 'refs/tags') ||
+          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/ci-migration'
+        env:
+          AWS_EC2_METADATA_DISABLED: true
+        run: |
+          source env.sh
+          go run mage.go -v MakeBucket
 
       - name: Setup FPM
         run: |
@@ -48,28 +110,24 @@ jobs:
           sudo gem i fpm -f
       
       - name: Build package
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          source build/env.sh
-          # Following line ensures that s3 bucket name won't overlap with the old CI's target
-          # Should be removed when the old CI is disabled
-          export BUILD_NUMBER=$BUILD_NUMBER"-ghactions" 
-          go run mage.go -v ${{ matrix.platform }}
+          source env.sh
+          unset CI # workaround for "PackageAndroid" target
+          sudo -E go run mage.go -v ${{ matrix.platform }}
 
   build-swagger:
     runs-on: ubuntu-latest
-    needs: [build-packages]
+    needs: [setup-env, build-packages]
 
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'
-      - name: Generate Env
-        run: go run mage.go -v GenerateEnvFile
+      - uses: actions/download-artifact@v4
+        with:
+          name: env.sh
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -83,8 +141,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          source build/env.sh
-          # Following line ensures that s3 bucket name won't overlap with the old CI's target
-          # Should be removed when the old CI is disabled
-          export BUILD_NUMBER=$BUILD_NUMBER"-ghactions" 
+          source env.sh
           go run mage.go -v PackageDockerSwaggerRedoc

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -3,7 +3,7 @@ name: Build packages
 on:
   workflow_call:
   push:
-    branches: [master, ci-migration]
+    branches: [master]
     tags:
 
 env:
@@ -71,17 +71,17 @@ jobs:
       max-parallel: 4
       matrix:
         platform:
-          # - PackageLinuxRaspberryImage
+          - PackageLinuxRaspberryImage
           - PackageLinuxAmd64
-          # - PackageLinuxArm
-          # - PackageLinuxDebianAmd64
-          # - PackageLinuxDebianArm64
-          # - PackageLinuxDebianArm
-          # - PackageMacOSAmd64
-          # - PackageMacOSArm64
-          # - PackageWindowsAmd64
-          # - PackageAndroid
-          # - PackageAndroidProvider
+          - PackageLinuxArm
+          - PackageLinuxDebianAmd64
+          - PackageLinuxDebianArm64
+          - PackageLinuxDebianArm
+          - PackageMacOSAmd64
+          - PackageMacOSArm64
+          - PackageWindowsAmd64
+          - PackageAndroid
+          - PackageAndroidProvider
 
     steps:
       - uses: actions/checkout@v4
@@ -95,9 +95,8 @@ jobs:
 
       - name: Create bucket
         if: |
-          contains(github.ref, 'refs/tags') ||
           github.ref == 'refs/heads/master' ||
-          github.ref == 'refs/heads/ci-migration'
+          github.ref_type == 'tag'
         env:
           AWS_EC2_METADATA_DISABLED: true
         run: |
@@ -137,9 +136,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build docker
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           source env.sh
           go run mage.go -v PackageDockerSwaggerRedoc
+
+  release:
+    needs: [build-packages, build-swagger]
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    if: |
+      github.ref == 'refs/heads/master' ||
+      github.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+on:
+  workflow_call:
+  # push:
+    # tags:
+
+jobs:
+  release-snapshot:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 3
+      matrix:
+        platform:
+          - ReleaseGithubSnapshot
+          # master only
+          # - ReleaseGithubNightly
+          - ReleaseDockerSnapshot
+          - ReleaseDebianPPASnapshot
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+      - uses: actions/download-artifact@v4
+        with:
+          name: env.sh
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release snapshot
+        run: |
+          source env.sh
+          go run mage.go -v ${{ matrix.platform }}
+
+      - name: Release Go report
+        if: github.ref == 'refs/heads/master'
+        run: bin/release_goreport
+
+  release-tag:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 4
+      matrix:
+        platform:
+          - ReleaseGithubTag
+          - ReleaseDockerTag
+          - ReleaseDebianPPAPreRelease
+          - ReleaseAndroidSDK
+          - ReleaseAndroidProviderSDK
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+      - uses: actions/download-artifact@v4
+        with:
+          name: env.sh
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release tag
+        run: |
+          source build/env.sh
+          go run mage.go -v ${{ matrix.platform }}
+
+  post-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+      - uses: actions/download-artifact@v4
+        with:
+          name: env.sh
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove bucket
+        run: go run mage.go -v RemoveBucket
+      - name: Notify UptimeRobot
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [ "$NIGHTLY_BUILD" = "1" -o "$NIGHTLY_BUILD" = "T" -o "$NIGHTLY_BUILD" = "true" -o "$NIGHTLY_BUILD" = "True" -o "$NIGHTLY_BUILD" = "TRUE" ]; then
+            curl -so /dev/null -I "$NIGHTLY_UPTIMEROBOT"
+          fi
+      - name: PR Avado
+        run: go run mage.go -v CreateAvadoPR
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,26 @@
 name: Release
 on:
   workflow_call:
-  # push:
-    # tags:
+
+env:
+  GITHUB_OWNER: mysteriumnetwork
+  GITHUB_REPO: node
+  GITHUB_SNAPSHOT_REPO: node-builds
+  GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
   release-snapshot:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
 
     strategy:
       max-parallel: 3
       matrix:
         platform:
           - ReleaseGithubSnapshot
-          # master only
+          # Nightly build
           # - ReleaseGithubNightly
           - ReleaseDockerSnapshot
           - ReleaseDebianPPASnapshot
@@ -32,7 +39,7 @@ jobs:
       - name: Release snapshot
         run: |
           source env.sh
-          go run mage.go -v ${{ matrix.platform }}
+          sudo -E go run mage.go -v ${{ matrix.platform }}
 
       - name: Release Go report
         if: github.ref == 'refs/heads/master'
@@ -40,6 +47,7 @@ jobs:
 
   release-tag:
     runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
 
     strategy:
       max-parallel: 4
@@ -65,10 +73,13 @@ jobs:
       - name: Release tag
         run: |
           source build/env.sh
-          go run mage.go -v ${{ matrix.platform }}
+          sudo -E go run mage.go -v ${{ matrix.platform }}
 
   post-release:
     runs-on: ubuntu-latest
+    needs: [release-snapshot, release-tag]
+    if: always() && contains(join(needs.*.result, ','), 'success')
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -81,13 +92,19 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove bucket
-        run: go run mage.go -v RemoveBucket
-      - name: Notify UptimeRobot
-        if: github.ref == 'refs/heads/master'
+        env:
+          AWS_EC2_METADATA_DISABLED: true
         run: |
-          if [ "$NIGHTLY_BUILD" = "1" -o "$NIGHTLY_BUILD" = "T" -o "$NIGHTLY_BUILD" = "true" -o "$NIGHTLY_BUILD" = "True" -o "$NIGHTLY_BUILD" = "TRUE" ]; then
-            curl -so /dev/null -I "$NIGHTLY_UPTIMEROBOT"
-          fi
-      - name: PR Avado
-        run: go run mage.go -v CreateAvadoPR
+          source env.sh
+          go run mage.go -v RemoveBucket
+      # - name: Notify UptimeRobot
+      #   if: github.ref == 'refs/heads/master'
+      #   run: |
+      #     if [ "$NIGHTLY_BUILD" = "1" -o "$NIGHTLY_BUILD" = "T" -o "$NIGHTLY_BUILD" = "true" -o "$NIGHTLY_BUILD" = "True" -o "$NIGHTLY_BUILD" = "TRUE" ]; then
+      #       curl -so /dev/null -I "$NIGHTLY_UPTIMEROBOT"
+      #     fi
+      # - name: PR Avado
+      #   run: |
+      #     source env.sh
+      #     go run mage.go -v CreateAvadoPR
 

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -1,6 +1,7 @@
 name: Tests
-on: 
-  pull_request:
+on:
+  workflow_call:
+  # pull_request:
 
 env:
   GOFLAGS: "-count=1"
@@ -12,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'
 
@@ -38,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'
 

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -1,7 +1,6 @@
 name: Tests
 on:
-  workflow_call:
-  # pull_request:
+  pull_request:
 
 env:
   GOFLAGS: "-count=1"

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -31,9 +31,8 @@ jobs:
           file: ./coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  e2e-tests:
+  e2e-basic:
     runs-on: ubuntu-latest
-    needs: unit-tests
 
     steps:
       - uses: actions/checkout@v4
@@ -51,10 +50,26 @@ jobs:
       - name: E2E basic test
         run: go run mage.go -v TestE2EBasic
 
+  e2e-nat:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+           username: ${{ secrets.DOCKERHUB_USERNAME }}
+           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: E2E NAT test
         run: go run mage.go -v TestE2ENAT
 
   verify-build:
-    needs: [unit-tests, e2e-tests]
+    needs: [unit-tests, e2e-basic, e2e-nat]
     uses: ./.github/workflows/build-packages.yml
     secrets: inherit


### PR DESCRIPTION
**Ci migration to Github Actions, part 3**

- Environment generation moved from `go run -v mage.go GenerateEnvFile` command to [setup-env](https://github.com/mysteriumnetwork/node/pull/5978/files#diff-5a99242c5cfc10a7d738e67d46f4ebd0e7cefa3ca65ce566a775006654e1105bR18-R64) workflow step for better readability,
- Release workflow added - snapshot and tag release workflows copy the steps of the current release process.
- The number of parallel jobs and workflows increased to speed up the pipeline execution  