### PR TITLE
Don't use the "tun" interface prefix for resolvconf call

### DIFF
--- a/bin/package/config/linux/update-resolv-conf
+++ b/bin/package/config/linux/update-resolv-conf
@@ -54,9 +54,9 @@ case "$script_type" in
     for NS in $NMSRVRS ; do
             R="${R}nameserver $NS\n"
     done
-    echo -e -n "$R" | sudo $RESOLVCONFBIN -a "tun.${dev}"
+    echo -e -n "$R" | sudo $RESOLVCONFBIN -a "${dev}"
     ;;
   down)
-    sudo $RESOLVCONFBIN -d "tun.${dev}"
+    sudo $RESOLVCONFBIN -d "${dev}"
     ;;
 esac


### PR DESCRIPTION
The symptoms:
MystDark / node consumer dont work on Linux.
MystDark operates the node using --usermode flag.

But on establishing connection node (usermode) calls myst_superviser to do wg-up, which results into command:
> script_type=up dev=myst0 foreign_option_1="dhcp-option DNS 10.182.3.1" /home/user/src/node/build/myst/config/update-resolv-conf

and it fails with
> Failed to resolve interface "tun.myst0": No such device

The problem might not have been noticed if testing was carried out in VM / headless Linux, as it lacks resolvconf. 
The problem only appears when OS has resolvconf.