### PR TITLE
GH Actions CI s3 "make bucket" operation fix

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
 
       - name: Prepare environment 
         run: |
@@ -64,6 +68,16 @@ jobs:
           name: env.sh
           path: env.sh
 
+      - name: Create bucket
+        if: |
+          github.ref == 'refs/heads/master' ||
+          github.ref_type == 'tag'
+        env:
+          AWS_EC2_METADATA_DISABLED: true
+        run: |
+          source env.sh
+          go run mage.go -v MakeBucket
+
   build-packages:
     runs-on: ubuntu-latest
     needs: [setup-env]
@@ -93,16 +107,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: env.sh
-
-      - name: Create bucket
-        if: |
-          github.ref == 'refs/heads/master' ||
-          github.ref_type == 'tag'
-        env:
-          AWS_EC2_METADATA_DISABLED: true
-        run: |
-          source env.sh
-          go run mage.go -v MakeBucket
 
       - name: Setup FPM
         run: |


### PR DESCRIPTION
Multiple execution of the s3' `mb` operation causes an error, therefore, bucket creation is moved to one common "environment setup" step.