### PR TITLE
Disable s3 region lookup and ignore deletion error on Actions CI

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -13,6 +13,7 @@ env:
   GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_EC2_METADATA_DISABLED: true # disable AWS region lookup
 
 jobs:
   setup-env:
@@ -72,8 +73,6 @@ jobs:
         if: |
           github.ref == 'refs/heads/master' ||
           github.ref_type == 'tag'
-        env:
-          AWS_EC2_METADATA_DISABLED: true
         run: |
           source env.sh
           go run mage.go -v MakeBucket
@@ -108,8 +107,9 @@ jobs:
         with:
           name: env.sh
 
-      - name: Setup FPM
+      - name: Setup Debber and FPM
         run: |
+          go install github.com/debber/debber-v0.3/cmd/debber@latest
           sudo apt-get install ruby-dev build-essential
           sudo gem i fpm -f
       
@@ -152,3 +152,25 @@ jobs:
     if: |
       github.ref == 'refs/heads/master' ||
       github.ref_type == 'tag'
+
+  cleanup-env:
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: |
+      always() &&
+      (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+      - uses: actions/download-artifact@v4
+        with:
+          name: env.sh
+
+      - name: Remove bucket
+        run: |
+          source env.sh
+          go run mage.go -v RemoveBucket || true # ignore if bucket was not available

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
   GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_EC2_METADATA_DISABLED: true
 
 jobs:
   release-snapshot:
@@ -91,20 +92,14 @@ jobs:
           name: env.sh
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Remove bucket
-        env:
-          AWS_EC2_METADATA_DISABLED: true
+      - name: Notify UptimeRobot
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [ "$NIGHTLY_BUILD" = "1" -o "$NIGHTLY_BUILD" = "T" -o "$NIGHTLY_BUILD" = "true" -o "$NIGHTLY_BUILD" = "True" -o "$NIGHTLY_BUILD" = "TRUE" ]; then
+            curl -so /dev/null -I "$NIGHTLY_UPTIMEROBOT"
+          fi
+      - name: PR Avado
         run: |
           source env.sh
-          go run mage.go -v RemoveBucket
-      # - name: Notify UptimeRobot
-      #   if: github.ref == 'refs/heads/master'
-      #   run: |
-      #     if [ "$NIGHTLY_BUILD" = "1" -o "$NIGHTLY_BUILD" = "T" -o "$NIGHTLY_BUILD" = "true" -o "$NIGHTLY_BUILD" = "True" -o "$NIGHTLY_BUILD" = "TRUE" ]; then
-      #       curl -so /dev/null -I "$NIGHTLY_UPTIMEROBOT"
-      #     fi
-      # - name: PR Avado
-      #   run: |
-      #     source env.sh
-      #     go run mage.go -v CreateAvadoPR
+          go run mage.go -v CreateAvadoPR
 


### PR DESCRIPTION
This PR fixes errors discovered during test deployment:
- AWS CLI fails to sync bucket contents because of the region lookup operation - disable lookup via additional env variable,
- S3 bucket deletion does not run if previous steps fail - added post-run cleanup operation that should run always.  