### PR TITLE
Remove "ghactions" prefix from the build number

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -59,7 +59,7 @@ jobs:
           export PR_BUILD=$PR_BUILD;
           export SNAPSHOT_BUILD=$SNAPSHOT_BUILD;
           export BUILD_VERSION=$BUILD_VERSION;
-          export BUILD_NUMBER="${{ github.run_id }}"-ghactions;
+          export BUILD_NUMBER="${{ github.run_id }}";
           export BUILD_COMMIT="$(echo ${GITHUB_SHA} | cut -c1-8)";
           export BUILD_BRANCH="${GITHUB_REF_NAME}";
           EOT


### PR DESCRIPTION
According to the Debian naming policies, if `debian/changelog` file claims the revision that has a `-something` prefix in it, the build must include the original upstream project archive. So, `-ghactions` prefix that was used to distinguish new and old artifacts on S3 caused the .deb package release to fail.