### PR TITLE
Add release permission to CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Release
 on:
   workflow_call:
 
+permissions:
+  contents: write
+
 env:
   GITHUB_OWNER: mysteriumnetwork
   GITHUB_REPO: node
@@ -46,7 +49,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Install Deb build scripts
-        run: sudo apt-get install devscripts build-essential lintian dput
+        run: sudo apt-get install devscripts build-essential lintian dput dh-make
 
       - name: Release snapshot
         run: |
@@ -90,7 +93,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Install Deb build scripts
-        run: sudo apt-get install devscripts build-essential lintian dput
+        run: sudo apt-get install devscripts build-essential lintian dput dh-make
 
       - name: Release tag
         run: |


### PR DESCRIPTION
Github Snapshot release job failed because of lacking permission. Expand token with `contents: write` right to allow CI to create releases.