### PR TITLE
Extend GPG key validity period

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
 
       - name: Release snapshot
         run: |
+          # workaround for expired key until it gets updated
+          gpg --quick-set-expire F0AB06E81EEBCED6F69460F12B13D750E4ECCA9D 2025-02-05
+
           source env.sh
           sudo -E go run mage.go -v ${{ matrix.platform }}
 
@@ -99,6 +102,9 @@ jobs:
 
       - name: Release tag
         run: |
+          # workaround for expired key until it gets updated
+          gpg --quick-set-expire F0AB06E81EEBCED6F69460F12B13D750E4ECCA9D 2025-02-05
+
           source build/env.sh
           sudo -E go run mage.go -v ${{ matrix.platform }}
 


### PR DESCRIPTION
Deb package signing key has recently expired so we have to use `--quick-set-expire` as a workaround until we replace the key 