### PR TITLE
Add "apt-get update" to CI workflows

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -112,6 +112,7 @@ jobs:
 
       - name: Setup FPM
         run: |
+          sudo apt-get update
           sudo apt-get install ruby-dev build-essential
           sudo gem i fpm -f
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Setup build environment
         run: |
+          sudo apt-get update
           sudo apt-get install devscripts build-essential lintian dput dh-make python3-paramiko
           echo -e "${{ secrets.GPG_SIGNING_KEY }}" | gpg --import
           # workaround for expired key until it gets updated
@@ -123,6 +124,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Setup build environment
         run: |
+          sudo apt-get update
           sudo apt-get install devscripts build-essential lintian dput dh-make python3-paramiko
           echo -e "${{ secrets.GPG_SIGNING_KEY }}" | gpg --import
           # workaround for expired key until it gets updated

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -17,7 +17,9 @@ jobs:
           go-version: '1.21.x'
 
       - name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
 
       - name: Unit tests and linters
         run: |


### PR DESCRIPTION
To avoid outdated packages installation attempts (like [here](https://github.com/mysteriumnetwork/node/actions/runs/8262570013/job/22607723527#step:7:409)), run `apt-get update` before each `apt-get install` command. 
