### PR TITLE
Fix data race b/c of lacking lock protection for "data" slice

### DIFF
--- a/ci/test/test.go
+++ b/ci/test/test.go
@@ -30,7 +30,10 @@ func TestWithCoverage() error {
 		return err
 	}
 	args := append([]string{"test", "-race", "-timeout", "5m", "-cover", "-coverprofile", "coverage.txt", "-covermode", "atomic"}, packages...)
-	return sh.RunV("go", args...)
+
+	env := make(map[string]string)
+	env["GORACE"] = "halt_on_error=1"
+	return sh.RunWith(env, "go", args...)
 }
 
 // Test runs unit tests
@@ -39,8 +42,11 @@ func Test() error {
 	if err != nil {
 		return err
 	}
-	args := append([]string{"test", "-race", "-count=1", "-timeout", "5m"}, packages...)
-	return sh.RunV("go", args...)
+	args := append([]string{"test", "-race", "-timeout", "5m"}, packages...)
+
+	env := make(map[string]string)
+	env["GORACE"] = "halt_on_error=1"
+	return sh.RunWith(env, "go", args...)
 }
 
 func unitTestPackages() ([]string, error) {

--- a/session/pingpong/consumer_totals_storage.go
+++ b/session/pingpong/consumer_totals_storage.go
@@ -94,6 +94,9 @@ func (cts *ConsumerTotalsStorage) Store(chainID int64, id identity.Identity, her
 // Get fetches the amount as promised for the given channel.
 func (cts *ConsumerTotalsStorage) Get(chainID int64, id identity.Identity, hermesID common.Address) (*big.Int, error) {
 	key := cts.makeKey(chainID, id, hermesID)
+	cts.createLock.Lock()
+	defer cts.createLock.Unlock()
+
 	element, ok := cts.data[key]
 	if !ok {
 		return nil, ErrNotFound


### PR DESCRIPTION
Resolve: https://github.com/mysteriumnetwork/node/issues/5999#issuecomment-2003111649
To reproduce run  `go run mage.go test`

The test which reproduces the race: TestConsumerBalanceTracker_RecoverGrandTotalPromisedSettledIsBiggerThanPromissedNotOffChain 