### PR TITLE
NodeUI + MMN API URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/mysteriumnetwork/EventBus v0.0.0-20220415063055-d22cb121672c
 	github.com/mysteriumnetwork/feedback v1.3.2
 	github.com/mysteriumnetwork/go-ci v0.0.0-20220711082519-1245471bae0d
-	github.com/mysteriumnetwork/go-dvpn-web/v2 v2.16.3
+	github.com/mysteriumnetwork/go-dvpn-web/v2 v2.16.5
 	github.com/mysteriumnetwork/go-openvpn v0.0.23
 	github.com/mysteriumnetwork/go-rest v0.3.1
 	github.com/mysteriumnetwork/go-wondershaper v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1212,8 +1212,8 @@ github.com/mysteriumnetwork/feedback v1.3.2/go.mod h1:g8PD0Gl5UVIFt3N159ohJUmBnG
 github.com/mysteriumnetwork/go-ci v0.0.0-20200121125840-b99aac3d815c/go.mod h1:GlJmsQDFyRmV9psEs/Mt/humLALu8xmZ7blXQ6Rc9Rs=
 github.com/mysteriumnetwork/go-ci v0.0.0-20220711082519-1245471bae0d h1:IejX10D2zdFwidh09Gy7L37BHfvc2ckgLrHXadLvzTA=
 github.com/mysteriumnetwork/go-ci v0.0.0-20220711082519-1245471bae0d/go.mod h1:FdrIqN3Z27igwo8A4aKZcmds7q894iGcdUIPz0+vOXY=
-github.com/mysteriumnetwork/go-dvpn-web/v2 v2.16.3 h1:FIwxQwbwyQ90+W93CpQWOYulwVvexJsgIaM+KoDzk1E=
-github.com/mysteriumnetwork/go-dvpn-web/v2 v2.16.3/go.mod h1:rFTH4Hfx0pdZUTrJtzy3Yaz0mHTaur7+TezbvWA/8C8=
+github.com/mysteriumnetwork/go-dvpn-web/v2 v2.16.5 h1:ZJemfWiAvSUkLsAIGsQ6/6ejPcUQJkDgR9Dap9MamVw=
+github.com/mysteriumnetwork/go-dvpn-web/v2 v2.16.5/go.mod h1:rFTH4Hfx0pdZUTrJtzy3Yaz0mHTaur7+TezbvWA/8C8=
 github.com/mysteriumnetwork/go-openvpn v0.0.23 h1:6BKoTwU9CpJL/Na9M9a0uaelAaVIo/XZPDpElfzFjxM=
 github.com/mysteriumnetwork/go-openvpn v0.0.23/go.mod h1:YDjnxC/3sGNecq/f6GM0BGz7nnGPTPIGtQjHaoLf8UE=
 github.com/mysteriumnetwork/go-rest v0.3.1 h1:zWyeW08ZVm9pWfjBrnq6SYZxoqc8kqzkr3eAbgZqr50=

--- a/metadata/network.go
+++ b/metadata/network.go
@@ -95,7 +95,7 @@ var MainnetDefinition = NetworkDefinition{
 		},
 	},
 	MMNAddress:      "https://my.mystnodes.com",
-	MMNAPIAddress:   "https://my.mystnodes.com/api/v1",
+	MMNAPIAddress:   "https://api.mystnodes.com/api/v1",
 	PilvytisAddress: "https://pilvytis.mysterium.network",
 	ObserverAddress: "https://observer.mysterium.network",
 	DNSMap: map[string][]string{
@@ -160,7 +160,7 @@ var TestnetDefinition = NetworkDefinition{
 		},
 	},
 	MMNAddress:      "https://my.mystnodes.com",
-	MMNAPIAddress:   "https://my.mystnodes.com/api/v1",
+	MMNAPIAddress:   "https://api.mystnodes.com/api/v1",
 	PilvytisAddress: "https://pilvytis-testnet.mysterium.network",
 	ObserverAddress: "https://observer-testnet.mysterium.network",
 	DNSMap: map[string][]string{


### PR DESCRIPTION
- Bump NodeUI
  - Monitoring status indicator fix
  - Fix spinner indicator for ClickBoarding
- Change API URL to api.mystnodes.com (dedicated API subdomain) instead of using client app NGinx proxy