### PR TITLE
Fix location cache gets never updated sometimes

### DIFF
--- a/core/location/cache.go
+++ b/core/location/cache.go
@@ -56,7 +56,7 @@ func NewCache(resolver Resolver, pub publisher, expiry time.Duration) *Cache {
 }
 
 func (c *Cache) needsRefresh() bool {
-	return c.lastFetched.IsZero() || c.lastFetched.After(time.Now().Add(-c.expiry))
+	return c.lastFetched.IsZero() || c.lastFetched.Before(time.Now().Add(-c.expiry))
 }
 
 func (c *Cache) fetchAndSave() (locationstate.Location, error) {
@@ -72,6 +72,7 @@ func (c *Cache) fetchAndSave() (locationstate.Location, error) {
 		c.location = loc
 		c.lastFetched = time.Now()
 	}
+
 	return loc, err
 }
 
@@ -90,6 +91,7 @@ func (c *Cache) DetectLocation() (locationstate.Location, error) {
 	if !c.needsRefresh() {
 		return c.location, nil
 	}
+
 	return c.fetchAndSave()
 }
 

--- a/core/location/cache_test.go
+++ b/core/location/cache_test.go
@@ -46,7 +46,7 @@ func TestCache_needsRefresh(t *testing.T) {
 			name: "returns true if expired",
 			want: true,
 			fields: fields{
-				lastFetched: time.Now().Add(time.Second * -59),
+				lastFetched: time.Now().Add(time.Second * -69),
 				expiry:      time.Minute * 1,
 			},
 		},
@@ -54,7 +54,7 @@ func TestCache_needsRefresh(t *testing.T) {
 			name: "returns false if updated recently",
 			want: false,
 			fields: fields{
-				lastFetched: time.Now().Add(time.Second * -61),
+				lastFetched: time.Now().Add(time.Second * -50),
 				expiry:      time.Minute * 1,
 			},
 		},


### PR DESCRIPTION
The needsRefresh method in the location cache has been refactored to correctly check if the cache needs to be refreshed. The previous implementation used the After method, but it has been changed to use the Before method to ensure accurate comparison with the expiry time. This change improves the reliability of the cache refresh mechanism.