### PR TITLE
Add `ConnectParams.ForwardIPSelector` for dvpnmode

### DIFF
--- a/core/connection/connect_options.go
+++ b/core/connection/connect_options.go
@@ -33,6 +33,8 @@ type ConnectParams struct {
 	DisableKillSwitch bool
 	// DNS servers to use
 	DNS DNSOption
+	// selector for `ip rule` command
+	ForwardIPSelector string
 
 	ProxyPort int
 }

--- a/services/wireguard/connection/connection.go
+++ b/services/wireguard/connection/connection.go
@@ -157,8 +157,9 @@ func (c *Connection) start(ctx context.Context, start startConn, options connect
 			AllowedIPs:             []string{"0.0.0.0/0", "::/0"},
 			KeepAlivePeriodSeconds: 18,
 		},
-		ReplacePeers: true,
-		ProxyPort:    options.Params.ProxyPort,
+		ReplacePeers:      true,
+		ForwardIPSelector: options.Params.ForwardIPSelector,
+		ProxyPort:         options.Params.ProxyPort,
 	})
 	if err != nil {
 		return errors.Wrap(err, "could not start new connection")

--- a/services/wireguard/wgcfg/device_config.go
+++ b/services/wireguard/wgcfg/device_config.go
@@ -51,7 +51,8 @@ type DeviceConfig struct {
 	Peer         Peer `json:"peer"`
 	ReplacePeers bool `json:"replace_peers,omitempty"`
 
-	ProxyPort int `json:"proxy_port,omitempty"`
+	ForwardIPSelector string `json:"forward_ip_selector,omitempty"`
+	ProxyPort         int    `json:"proxy_port,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler interface to provide human readable configuration.
@@ -64,15 +65,16 @@ func (dc DeviceConfig) MarshalJSON() ([]byte, error) {
 	}
 
 	type deviceConfig struct {
-		IfaceName    string   `json:"iface_name"`
-		Subnet       string   `json:"subnet"`
-		PrivateKey   string   `json:"private_key"`
-		ListenPort   int      `json:"listen_port"`
-		DNS          []string `json:"dns"`
-		DNSScriptDir string   `json:"dns_script_dir"`
-		Peer         peer     `json:"peer"`
-		ReplacePeers bool     `json:"replace_peers,omitempty"`
-		ProxyPort    int      `json:"proxy_port,omitempty"`
+		IfaceName         string   `json:"iface_name"`
+		Subnet            string   `json:"subnet"`
+		PrivateKey        string   `json:"private_key"`
+		ListenPort        int      `json:"listen_port"`
+		DNS               []string `json:"dns"`
+		DNSScriptDir      string   `json:"dns_script_dir"`
+		Peer              peer     `json:"peer"`
+		ReplacePeers      bool     `json:"replace_peers,omitempty"`
+		ForwardIPSelector string   `json:"forward_ip_selector,omitempty"`
+		ProxyPort         int      `json:"proxy_port,omitempty"`
 	}
 
 	var peerEndpoint string
@@ -108,15 +110,16 @@ func (dc *DeviceConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	type deviceConfig struct {
-		IfaceName    string   `json:"iface_name"`
-		Subnet       string   `json:"subnet"`
-		PrivateKey   string   `json:"private_key"`
-		ListenPort   int      `json:"listen_port"`
-		DNS          []string `json:"dns"`
-		DNSScriptDir string   `json:"dns_script_dir"`
-		Peer         peer     `json:"peer"`
-		ReplacePeers bool     `json:"replace_peers,omitempty"`
-		ProxyPort    int      `json:"proxy_port"`
+		IfaceName         string   `json:"iface_name"`
+		Subnet            string   `json:"subnet"`
+		PrivateKey        string   `json:"private_key"`
+		ListenPort        int      `json:"listen_port"`
+		DNS               []string `json:"dns"`
+		DNSScriptDir      string   `json:"dns_script_dir"`
+		Peer              peer     `json:"peer"`
+		ReplacePeers      bool     `json:"replace_peers,omitempty"`
+		ForwardIPSelector string   `json:"forward_ip_selector"`
+		ProxyPort         int      `json:"proxy_port"`
 	}
 
 	cfg := deviceConfig{}

--- a/tequilapi/contract/connection.go
+++ b/tequilapi/contract/connection.go
@@ -216,6 +216,11 @@ type ConnectOptions struct {
 	// default: auto
 	// example: auto, provider, system, "1.1.1.1,8.8.8.8"
 	DNS connection.DNSOption `json:"dns"`
+	// Selector to use in `ip rule` command to forward traffic
+	// required: false
+	// default: ClientIP
+	// example: "from 192.168.0.10", "iif eth1", "fwmark FWMARK"
+	ForwardIPSelector string `json:"forward_ip_selector"`
 
 	ProxyPort int `json:"proxy_port"`
 }

--- a/tequilapi/docs/swagger.json
+++ b/tequilapi/docs/swagger.json
@@ -3591,6 +3591,10 @@
           "x-go-name": "DisableKillSwitch",
           "example": true
         },
+        "forward_ip_selector": {
+          "type": "string",
+          "x-go-name": "ForwardIPSelector"
+        },
         "proxy_port": {
           "type": "integer",
           "format": "int64",

--- a/tequilapi/endpoints/connection.go
+++ b/tequilapi/endpoints/connection.go
@@ -149,7 +149,7 @@ func (ce *ConnectionEndpoint) Create(c *gin.Context) {
 		return
 	}
 
-	cr, err := toConnectionRequest(c.Request, hermes.Hex())
+	cr, err := toConnectionRequest(c.Request, hermes.Hex(), "from "+c.ClientIP())
 	if err != nil {
 		ce.publisher.Publish(quality.AppTopicConnectionEvents, (&contract.ConnectionCreateRequest{}).Event(quality.StagePraseRequest, err.Error()))
 		c.Error(apierror.ParseFailed())
@@ -360,11 +360,12 @@ func AddRoutesForConnection(
 	}
 }
 
-func toConnectionRequest(req *http.Request, defaultHermes string) (*contract.ConnectionCreateRequest, error) {
+func toConnectionRequest(req *http.Request, defaultHermes string, defaultForwardIPSelector string) (*contract.ConnectionCreateRequest, error) {
 	connectionRequest := contract.ConnectionCreateRequest{
 		ConnectOptions: contract.ConnectOptions{
 			DisableKillSwitch: false,
 			DNS:               connection.DNSOptionAuto,
+			ForwardIPSelector: defaultForwardIPSelector,
 		},
 		HermesID: defaultHermes,
 	}
@@ -384,6 +385,7 @@ func getConnectOptions(cr *contract.ConnectionCreateRequest) connection.ConnectP
 	return connection.ConnectParams{
 		DisableKillSwitch: cr.ConnectOptions.DisableKillSwitch,
 		DNS:               dns,
+		ForwardIPSelector: cr.ConnectOptions.ForwardIPSelector,
 		ProxyPort:         cr.ConnectOptions.ProxyPort,
 	}
 }


### PR DESCRIPTION
Add `ConnectParams.ForwardIPSelector` for dvpnmode.

This allows myst to be used as an L3 proxy (without any external tools).