### PR TITLE
Data race #4

### DIFF
--- a/tequilapi/endpoints/service.go
+++ b/tequilapi/endpoints/service.go
@@ -352,6 +352,12 @@ func (se *ServiceEndpoint) toServiceOptions(serviceType string, value *json.RawM
 }
 
 func (se *ServiceEndpoint) toServiceInfoResponse(id service.ID, instance *service.Instance) (contract.ServiceInfoDTO, error) {
+
+	// Warning.
+	// Use only safely obtained copy of instance.Proposal field, otherwise concurrent
+	// access to that field from Instance.proposalWithCurrentLocation
+	// can trigger a data race
+
 	priced, err := se.proposalRepository.EnrichProposalWithPrice(instance.CopyProposal())
 	if err != nil {
 		return contract.ServiceInfoDTO{}, err


### PR DESCRIPTION
Resolves: https://github.com/mysteriumnetwork/node/issues/6060

Note: 
>  github.com/mysteriumnetwork/node/core/service.(*Instance).proposalWithCurrentLocation()
>  github.com/mysteriumnetwork/node/tequilapi/endpoints.(*ServiceEndpoint).toServiceInfoResponse()

The 2 methods, which trigger a race are not public and are in different packages, that's why making a unit-test is not possible.
