### PR TITLE
Add SOCKS5 proxy (TCP + UDP), dual-proxy mode (HTTP+SOCKS5), smart client selection, functional tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ client API (tequila API) and client-cli (console client) for Mysterium Network.
 
 Currently node supports WireGuard as its underlying VPN transport.
 
+See also:
+- SOCKS5 + HTTP proxy mode and functional tests: see README_SOCKS5.md
+
 ## Getting Started
 
 - [Homepage](https://mysterium.network)

--- a/README_SOCKS5.md
+++ b/README_SOCKS5.md
@@ -1,0 +1,43 @@
+SOCKS5 and HTTP Proxy (Consumer Mode)
+
+Overview
+- In proxy mode the node can expose both an HTTP proxy and a SOCKS5 proxy simultaneously.
+- HTTP proxy supports regular HTTP requests and HTTP CONNECT tunneling for arbitrary TCP.
+- SOCKS5 proxy supports TCP CONNECT and UDP ASSOCIATE (no authentication).
+
+How to Run
+- Start node in proxy mode:
+  - `myst --proxymode --proxymode.socks5` (the `--proxymode.socks5` switch enables SOCKS5 alongside HTTP)
+- Bring up a connection and choose the base proxy port (for HTTP):
+  - `myst connection up --proxy 10000 <provider_id>`
+
+Ports
+- HTTP proxy: listens on `127.0.0.1:<proxy_port>` (e.g., 10000).
+- SOCKS5 proxy: listens on `127.0.0.1:<proxy_port+1>` (e.g., 10001). If the proxy port is 0 or unset, SOCKS5 defaults to 1080.
+
+Client Configuration Examples
+- HTTP proxy:
+  - curl: `curl -x http://127.0.0.1:10000 https://ifconfig.me` 
+- SOCKS5 proxy (no auth):
+  - curl: `curl --socks5-hostname 127.0.0.1:10001 https://ifconfig.me`
+  - apps supporting SOCKS5 UDP (e.g., some game launchers) can use `127.0.0.1:10001` with UDP enabled.
+
+Notes
+- SOCKS5 UDP replies embed a generic BND address (0.0.0.0:0); most clients ignore it. If you need actual source address in replies, open an issue.
+- BIND command is not implemented (rarely used). CONNECT and UDP are supported.
+- No authentication is implemented or required.
+
+Functional Tests
+- These are opt-in, require a running SOCKS5 proxy at `127.0.0.1:10001` (or override via env `SOCKS5_ADDR`). They are skipped automatically if the port isn’t listening.
+- When skipped, running with `-v` shows an explicit skip message (e.g., `skipping functional test`) and the test run still passes.
+- Start node and connect with a base proxy port (e.g., 10000) so SOCKS5 listens on 10001:
+  - `./build/myst/myst service --agreed-terms-and-conditions` (add `--userspace` on macOS if needed)
+  - `./build/myst/myst connection up --proxy 10000 <provider_id>`
+- Run tests:
+  - `go test ./testkit/socks5 -v`
+- Env overrides:
+  - `SOCKS5_ADDR` (default `127.0.0.1:10001`)
+  - `DNS_HOST` for UDP/DNS test (default `1.1.1.1`)
+  - `TCP_HOST` for TCP/CONNECT HTTP test (default `example.com`)
+- To force tests to fail when SOCKS5 is not listening (useful in CI), set:
+  - `SOCKS5_REQUIRED=1`

--- a/config/flags_node.go
+++ b/config/flags_node.go
@@ -229,6 +229,13 @@ var (
 		Value: false,
 	}
 
+	// FlagProxySOCKS5 selects SOCKS5 protocol for proxy mode instead of HTTP.
+	FlagProxySOCKS5 = cli.BoolFlag{
+		Name:  "proxymode.socks5",
+		Usage: "Use SOCKS5 protocol in proxy mode (instead of HTTP)",
+		Value: false,
+	}
+
 	// FlagUserspace allows running a node without privileged permissions.
 	FlagUserspace = cli.BoolFlag{
 		Name:  "userspace",
@@ -350,6 +357,7 @@ func RegisterFlagsNode(flags *[]cli.Flag) error {
 		&FlagUserMode,
 		&FlagDVPNMode,
 		&FlagProxyMode,
+		&FlagProxySOCKS5,
 		&FlagUserspace,
 		&FlagVendorID,
 		&FlagLauncherVersion,
@@ -413,6 +421,7 @@ func ParseFlagsNode(ctx *cli.Context) {
 	Current.ParseBoolFlag(ctx, FlagUserMode)
 	Current.ParseBoolFlag(ctx, FlagDVPNMode)
 	Current.ParseBoolFlag(ctx, FlagProxyMode)
+	Current.ParseBoolFlag(ctx, FlagProxySOCKS5)
 	Current.ParseBoolFlag(ctx, FlagUserspace)
 	Current.ParseStringFlag(ctx, FlagVendorID)
 	Current.ParseStringFlag(ctx, FlagLauncherVersion)

--- a/services/wireguard/endpoint/dualproxyclient/client.go
+++ b/services/wireguard/endpoint/dualproxyclient/client.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2025 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dualproxyclient
+
+import (
+    "bufio"
+    "context"
+    "fmt"
+    "net/http"
+    "net/netip"
+    "strings"
+    "sync"
+    "time"
+
+    "github.com/rs/zerolog/log"
+    "golang.zx2c4.com/wireguard/conn"
+    "golang.zx2c4.com/wireguard/device"
+
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/proxyclient"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/socks5client"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
+    "github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
+)
+
+type client struct {
+    mu         sync.Mutex
+    Device     *device.Device
+    httpClose  func() error
+    socksClose func() error
+}
+
+// New client that serves HTTP and SOCKS5 proxies simultaneously.
+func New() (*client, error) {
+    log.Debug().Msg("Creating dual-proxy wg client (HTTP + SOCKS5)")
+    return &client{}, nil
+}
+
+func (c *client) ReConfigureDevice(config wgcfg.DeviceConfig) error { return c.ConfigureDevice(config) }
+
+func (c *client) ConfigureDevice(cfg wgcfg.DeviceConfig) error {
+    localAddr, err := netip.ParseAddr(cfg.Subnet.IP.String())
+    if err != nil {
+        return fmt.Errorf("could not parse local addr: %w", err)
+    }
+    if len(cfg.DNS) == 0 {
+        return fmt.Errorf("DNS addr list is empty")
+    }
+    dnsAddr, err := netip.ParseAddr(cfg.DNS[0])
+    if err != nil {
+        return fmt.Errorf("could not parse DNS addr: %w", err)
+    }
+    tunnel, tnet, err := netstack.CreateNetTUN([]netip.Addr{localAddr}, []netip.Addr{dnsAddr}, device.DefaultMTU)
+    if err != nil {
+        return fmt.Errorf("failed to create netstack device %s: %w", cfg.IfaceName, err)
+    }
+
+    logger := device.NewLogger(device.LogLevelVerbose, fmt.Sprintf("(%s) ", cfg.IfaceName))
+    wgDevice := device.NewDevice(tunnel, conn.NewDefaultBind(), logger)
+
+    log.Info().Msg("Applying interface configuration")
+    if err := wgDevice.IpcSetOperation(bufio.NewReader(strings.NewReader(cfg.Encode()))); err != nil {
+        wgDevice.Close()
+        return fmt.Errorf("could not set device uapi config: %w", err)
+    }
+
+    log.Info().Msg("Bringing device up")
+    wgDevice.Up()
+
+    c.mu.Lock()
+    c.Device = wgDevice
+    c.mu.Unlock()
+
+    log.Info().Msgf("Dual-proxy: starting proxies base_port=%d", cfg.ProxyPort)
+    if err := c.startHTTPProxy(tnet, cfg.ProxyPort); err != nil {
+        wgDevice.Close()
+        return err
+    }
+    if err := c.startSOCKSProxy(tnet, cfg.ProxyPort); err != nil {
+        c.stopHTTP()
+        wgDevice.Close()
+        return err
+    }
+    log.Info().Msg("Dual-proxy: proxies started")
+    return nil
+}
+
+func (c *client) DestroyDevice(iface string) error { return c.Close() }
+
+func (c *client) PeerStats(iface string) (wgcfg.Stats, error) {
+    deviceState, err := userspace.ParseUserspaceDevice(c.Device.IpcGetOperation)
+    if err != nil {
+        return wgcfg.Stats{}, fmt.Errorf("could not parse device state: %w", err)
+    }
+    stats, statErr := userspace.ParseDevicePeerStats(deviceState)
+    if err != nil {
+        err = statErr
+        log.Warn().Err(err).Msg("Failed to parse device stats, will try again")
+    } else {
+        return stats, nil
+    }
+    return wgcfg.Stats{}, fmt.Errorf("could not parse device state: %w", err)
+}
+
+func (c *client) Close() error {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    c.stopSOCKS()
+    c.stopHTTP()
+    if c.Device != nil {
+        go func() {
+            time.Sleep(2 * time.Minute)
+            c.Device.Close()
+        }()
+    }
+    return nil
+}
+
+func (c *client) startHTTPProxy(tnet *netstack.Net, httpPort int) error {
+    if httpPort <= 0 {
+        return fmt.Errorf("http proxy port is not set")
+    }
+    server := http.Server{
+        Addr:              fmt.Sprintf(":%d", httpPort),
+        Handler:           proxyclient.NewProxyHandler(60*time.Second, tnet),
+        ReadTimeout:       0,
+        ReadHeaderTimeout: 0,
+        WriteTimeout:      0,
+        IdleTimeout:       0,
+    }
+
+    log.Info().Msgf("Starting HTTP proxy server at :%d ...", httpPort)
+    c.httpClose = func() error {
+        ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+        defer cancel()
+        server.Shutdown(ctx)
+        return server.Close()
+    }
+    go func() {
+        err := server.ListenAndServe()
+        if err != nil {
+            log.Error().Err(err).Msg("Shutting down HTTP proxy server...")
+        }
+    }()
+    return nil
+}
+
+func (c *client) startSOCKSProxy(tnet *netstack.Net, basePort int) error {
+    socksPort := basePort + 1
+    if socksPort <= 1 { // base not set or 0, fall back to default
+        socksPort = 1080
+    }
+    srv := &socks5client.Server{Dialer: socks5client.NewNetstackAdapter(tnet)}
+    addr := fmt.Sprintf(":%d", socksPort)
+    log.Info().Msgf("Starting SOCKS5 proxy server at %s ...", addr)
+    done := make(chan struct{})
+    go func() {
+        _ = srv.Serve(addr)
+        close(done)
+    }()
+    c.socksClose = func() error { srv.Close(); <-done; return nil }
+    return nil
+}
+
+func (c *client) stopHTTP() {
+    if c.httpClose != nil {
+        _ = c.httpClose()
+        c.httpClose = nil
+    }
+}
+
+func (c *client) stopSOCKS() {
+    if c.socksClose != nil {
+        _ = c.socksClose()
+        c.socksClose = nil
+    }
+}

--- a/services/wireguard/endpoint/proxyclient/client.go
+++ b/services/wireguard/endpoint/proxyclient/client.go
@@ -135,14 +135,14 @@ func (c *client) Proxy(tnet *netstack.Net, proxyPort int) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	server := http.Server{
-		Addr:              fmt.Sprintf(":%d", proxyPort),
-		Handler:           newProxyHandler(60*time.Second, tnet),
-		ReadTimeout:       0,
-		ReadHeaderTimeout: 0,
-		WriteTimeout:      0,
-		IdleTimeout:       0,
-	}
+    server := http.Server{
+        Addr:              fmt.Sprintf(":%d", proxyPort),
+        Handler:           NewProxyHandler(60*time.Second, tnet),
+        ReadTimeout:       0,
+        ReadHeaderTimeout: 0,
+        WriteTimeout:      0,
+        IdleTimeout:       0,
+    }
 
 	log.Info().Msgf("Starting proxy server at :%d ...", proxyPort)
 	c.proxyClose = func() error {

--- a/services/wireguard/endpoint/proxyclient/handler.go
+++ b/services/wireguard/endpoint/proxyclient/handler.go
@@ -37,7 +37,8 @@ type proxyHandler struct {
 	dialer        proxy.ContextDialer
 }
 
-func newProxyHandler(timeout time.Duration, dialer proxy.ContextDialer) *proxyHandler {
+// NewProxyHandler returns an HTTP proxy handler that uses the provided dialer.
+func NewProxyHandler(timeout time.Duration, dialer proxy.ContextDialer) *proxyHandler {
 	httptransport := &http.Transport{
 		DialContext: dialer.DialContext,
 	}

--- a/services/wireguard/endpoint/smartclient/client.go
+++ b/services/wireguard/endpoint/smartclient/client.go
@@ -1,0 +1,98 @@
+package smartclient
+
+import (
+    "fmt"
+
+    "github.com/rs/zerolog/log"
+
+    "github.com/mysteriumnetwork/node/config"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/dvpnclient"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/kernelspace"
+    netstack_provider "github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack-provider"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/remoteclient"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/dualproxyclient"
+    "github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
+)
+
+// WgClient minimal interface used by endpoint.
+type WgClient interface {
+    ConfigureDevice(config wgcfg.DeviceConfig) error
+    ReConfigureDevice(config wgcfg.DeviceConfig) error
+    DestroyDevice(name string) error
+    PeerStats(iface string) (wgcfg.Stats, error)
+    Close() error
+}
+
+// Client defers the concrete client selection until ConfigureDevice,
+// so we can choose based on cfg.ProxyPort reliably.
+type Client struct {
+    impl WgClient
+}
+
+func New() *Client { return &Client{} }
+
+func (c *Client) choose(cfg wgcfg.DeviceConfig) (WgClient, error) {
+    // dVPN mode takes precedence if enabled globally.
+    if config.GetBool(config.FlagDVPNMode) {
+        log.Info().Msg("smartclient: using dvpnclient")
+        return dvpnclient.New()
+    }
+    // If a proxy port is provided by the consumer, run dual-proxy (HTTP+SOCKS5).
+    if cfg.ProxyPort > 0 {
+        log.Info().Msgf("smartclient: proxy requested, starting dual-proxy (base=%d)", cfg.ProxyPort)
+        return dualproxyclient.New()
+    }
+    // Otherwise follow original selection logic.
+    if config.GetBool(config.FlagUserspace) {
+        log.Info().Msg("smartclient: userspace enabled, using netstack-provider")
+        return netstack_provider.New()
+    }
+    if config.GetBool(config.FlagUserMode) {
+        log.Info().Msg("smartclient: usermode enabled, using remoteclient")
+        return remoteclient.New()
+    }
+    // Try kernelspace, fallback to userspace
+    kc, err := kernelspace.NewWireguardClient()
+    if err == nil {
+        log.Info().Msg("smartclient: using kernelspace client")
+        return kc, nil
+    }
+    log.Info().Msg("smartclient: kernelspace unsupported, using userspace client")
+    return userspace.NewWireguardClient()
+}
+
+func (c *Client) ConfigureDevice(cfg wgcfg.DeviceConfig) error {
+    if c.impl == nil {
+        impl, err := c.choose(cfg)
+        if err != nil {
+            return fmt.Errorf("smartclient: choose failed: %w", err)
+        }
+        c.impl = impl
+    }
+    return c.impl.ConfigureDevice(cfg)
+}
+
+func (c *Client) ReConfigureDevice(cfg wgcfg.DeviceConfig) error {
+    if c.impl == nil {
+        if err := c.ConfigureDevice(cfg); err != nil { return err }
+        return nil
+    }
+    return c.impl.ReConfigureDevice(cfg)
+}
+
+func (c *Client) DestroyDevice(name string) error {
+    if c.impl == nil { return nil }
+    return c.impl.DestroyDevice(name)
+}
+
+func (c *Client) PeerStats(iface string) (wgcfg.Stats, error) {
+    if c.impl == nil { return wgcfg.Stats{}, fmt.Errorf("smartclient: not configured") }
+    return c.impl.PeerStats(iface)
+}
+
+func (c *Client) Close() error {
+    if c.impl == nil { return nil }
+    return c.impl.Close()
+}
+

--- a/services/wireguard/endpoint/socks5client/adapter_netstack.go
+++ b/services/wireguard/endpoint/socks5client/adapter_netstack.go
@@ -1,0 +1,26 @@
+package socks5client
+
+import (
+    "context"
+    "net"
+    "net/netip"
+
+    netstackpkg "github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack"
+)
+
+type netstackAdapter struct{ t *netstackpkg.Net }
+
+// NewNetstackAdapter exposes adapter for external users (e.g., dualproxyclient).
+func NewNetstackAdapter(t *netstackpkg.Net) *netstackAdapter { return &netstackAdapter{t: t} }
+
+func (a *netstackAdapter) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+    return a.t.DialContext(ctx, network, address)
+}
+
+func (a *netstackAdapter) DialUDPAddrPort(laddr, raddr netip.AddrPort) (UDPConn, error) {
+    return a.t.DialUDPAddrPort(laddr, raddr)
+}
+
+func (a *netstackAdapter) LookupContextHost(ctx context.Context, host string) ([]string, error) {
+    return a.t.LookupContextHost(ctx, host)
+}

--- a/services/wireguard/endpoint/socks5client/client.go
+++ b/services/wireguard/endpoint/socks5client/client.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package socks5client
+
+import (
+    "bufio"
+    "fmt"
+    "net/netip"
+    "strings"
+    "sync"
+    "time"
+
+    "github.com/rs/zerolog/log"
+    "golang.zx2c4.com/wireguard/conn"
+    "golang.zx2c4.com/wireguard/device"
+
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
+    "github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
+)
+
+type client struct {
+    mu         sync.Mutex
+    Device     *device.Device
+    proxyClose func() error
+}
+
+// New creates new WireGuard client that serves SOCKS5 proxy on a local port.
+func New() (*client, error) {
+    log.Debug().Msg("Creating SOCKS5 wg client")
+    return &client{}, nil
+}
+
+func (c *client) ReConfigureDevice(config wgcfg.DeviceConfig) error {
+    return c.ConfigureDevice(config)
+}
+
+func (c *client) ConfigureDevice(cfg wgcfg.DeviceConfig) error {
+    localAddr, err := netip.ParseAddr(cfg.Subnet.IP.String())
+    if err != nil {
+        return fmt.Errorf("could not parse local addr: %w", err)
+    }
+    if len(cfg.DNS) == 0 {
+        return fmt.Errorf("DNS addr list is empty")
+    }
+    dnsAddr, err := netip.ParseAddr(cfg.DNS[0])
+    if err != nil {
+        return fmt.Errorf("could not parse DNS addr: %w", err)
+    }
+    tunnel, tnet, err := netstack.CreateNetTUN([]netip.Addr{localAddr}, []netip.Addr{dnsAddr}, device.DefaultMTU)
+    if err != nil {
+        return fmt.Errorf("failed to create netstack device %s: %w", cfg.IfaceName, err)
+    }
+
+    logger := device.NewLogger(device.LogLevelVerbose, fmt.Sprintf("(%s) ", cfg.IfaceName))
+    wgDevice := device.NewDevice(tunnel, conn.NewDefaultBind(), logger)
+
+    log.Info().Msg("Applying interface configuration")
+    if err := wgDevice.IpcSetOperation(bufio.NewReader(strings.NewReader(cfg.Encode()))); err != nil {
+        wgDevice.Close()
+        return fmt.Errorf("could not set device uapi config: %w", err)
+    }
+
+    log.Info().Msg("Bringing device up")
+    wgDevice.Up()
+
+    c.mu.Lock()
+    c.Device = wgDevice
+    c.mu.Unlock()
+
+    if err := c.Proxy(tnet, cfg.ProxyPort); err != nil {
+        wgDevice.Close()
+        return err
+    }
+
+    return nil
+}
+
+func (c *client) DestroyDevice(iface string) error {
+    return c.Close()
+}
+
+func (c *client) PeerStats(iface string) (wgcfg.Stats, error) {
+    deviceState, err := userspace.ParseUserspaceDevice(c.Device.IpcGetOperation)
+    if err != nil {
+        return wgcfg.Stats{}, fmt.Errorf("could not parse device state: %w", err)
+    }
+
+    stats, statErr := userspace.ParseDevicePeerStats(deviceState)
+    if err != nil {
+        err = statErr
+        log.Warn().Err(err).Msg("Failed to parse device stats, will try again")
+    } else {
+        return stats, nil
+    }
+
+    return wgcfg.Stats{}, fmt.Errorf("could not parse device state: %w", err)
+}
+
+func (c *client) Close() error {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+
+    if c.proxyClose != nil {
+        c.proxyClose()
+    }
+
+    if c.Device != nil {
+        go func() {
+            time.Sleep(2 * time.Minute)
+            c.Device.Close()
+        }()
+    }
+    return nil
+}
+
+func (c *client) Proxy(tnet *netstack.Net, proxyPort int) error {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+
+    srv := &Server{Dialer: NewNetstackAdapter(tnet)}
+
+    addr := fmt.Sprintf(":%d", proxyPort)
+    log.Info().Msgf("Starting SOCKS5 proxy server at %s ...", addr)
+    stopCh := make(chan struct{})
+    go func() {
+        if err := srv.Serve(addr); err != nil {
+            log.Error().Err(err).Msg("Shutting down SOCKS5 proxy server...")
+        }
+        close(stopCh)
+    }()
+
+    c.proxyClose = func() error {
+        srv.Close()
+        <-stopCh
+        return nil
+    }
+    return nil
+}

--- a/services/wireguard/endpoint/socks5client/client_test.go
+++ b/services/wireguard/endpoint/socks5client/client_test.go
@@ -1,0 +1,222 @@
+package socks5client_test
+
+import (
+    "bufio"
+    "context"
+    "encoding/binary"
+    "io"
+    "net"
+    "net/netip"
+    "testing"
+    "time"
+
+    sc "github.com/mysteriumnetwork/node/services/wireguard/endpoint/socks5client"
+)
+
+type osAdapter struct{}
+
+func (a *osAdapter) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+    var d net.Dialer
+    return d.DialContext(ctx, network, address)
+}
+
+func (a *osAdapter) DialUDPAddrPort(laddr, raddr netip.AddrPort) (sc.UDPConn, error) {
+    var la *net.UDPAddr
+    if laddr.IsValid() || laddr.Port() != 0 {
+        la = &net.UDPAddr{IP: net.IP(laddr.Addr().AsSlice()), Port: int(laddr.Port())}
+    }
+    ra := &net.UDPAddr{IP: net.IP(raddr.Addr().AsSlice()), Port: int(raddr.Port())}
+    return net.DialUDP("udp", la, ra)
+}
+
+func (a *osAdapter) LookupContextHost(ctx context.Context, host string) ([]string, error) {
+    return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+func startSOCKS(t *testing.T, d sc.Dialer) (addr string, closeFn func()) {
+    srv := &sc.Server{Dialer: d}
+    ln, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("listen: %v", err)
+    }
+    addr = ln.Addr().String()
+    _ = ln.Close()
+
+    done := make(chan struct{})
+    go func() {
+        _ = srv.Serve(addr)
+        close(done)
+    }()
+    // wait a bit for listener
+    time.Sleep(50 * time.Millisecond)
+    return addr, func() { srv.Close(); <-done }
+}
+
+func TestSOCKS5_CONNECT_Echo(t *testing.T) {
+    // Start OS echo server
+    l, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("ListenTCP: %v", err)
+    }
+    defer l.Close()
+    tcpAddr := l.Addr().String()
+
+    go func() {
+        for {
+            c, err := l.Accept()
+            if err != nil {
+                return
+            }
+            go func(cc net.Conn) {
+                defer cc.Close()
+                io.Copy(cc, cc)
+            }(c)
+        }
+    }()
+
+    // Start SOCKS server (using OS adapter)
+    addr, stop := startSOCKS(t, &osAdapter{})
+    defer stop()
+
+    // Dial SOCKS
+    c, err := net.Dial("tcp", addr)
+    if err != nil {
+        t.Fatalf("dial socks: %v", err)
+    }
+    defer c.Close()
+    br := bufio.NewReader(c)
+    bw := bufio.NewWriter(c)
+
+    // Greeting
+    bw.Write([]byte{0x05, 0x01, 0x00})
+    bw.Flush()
+    if b, _ := br.ReadByte(); b != 0x05 {
+        t.Fatalf("bad greet ver")
+    }
+    if b, _ := br.ReadByte(); b != 0x00 {
+        t.Fatalf("bad greet method")
+    }
+
+    // CONNECT to echo server
+    host, portStr, _ := net.SplitHostPort(tcpAddr)
+    ip := net.ParseIP(host)
+    port, _ := net.LookupPort("tcp", portStr)
+    pkt := []byte{0x05, 0x01, 0x00}
+    if ip.To4() != nil {
+        pkt = append(pkt, 0x01)
+        pkt = append(pkt, ip.To4()...)
+    } else {
+        t.Fatalf("expect ipv4 addr for test")
+    }
+    p := make([]byte, 2)
+    binary.BigEndian.PutUint16(p, uint16(port))
+    pkt = append(pkt, p...)
+    bw.Write(pkt)
+    bw.Flush()
+    // Read reply
+    rep := make([]byte, 10)
+    if _, err := io.ReadFull(br, rep[:4]); err != nil {
+        t.Fatalf("read rep hdr: %v", err)
+    }
+    if rep[1] != 0x00 {
+        t.Fatalf("rep not success: %d", rep[1])
+    }
+    // Send payload, expect echo
+    msg := []byte("hello")
+    if _, err := c.Write(msg); err != nil {
+        t.Fatalf("write payload: %v", err)
+    }
+    buf := make([]byte, len(msg))
+    if _, err := io.ReadFull(c, buf); err != nil {
+        t.Fatalf("read echo: %v", err)
+    }
+    if string(buf) != string(msg) {
+        t.Fatalf("echo mismatch: %q != %q", buf, msg)
+    }
+}
+
+func TestSOCKS5_UDP_Associate(t *testing.T) {
+    // Start UDP echo server (OS)
+    u, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+    if err != nil {
+        t.Fatalf("ListenUDP: %v", err)
+    }
+    defer u.Close()
+    udpAddr := u.LocalAddr().(*net.UDPAddr)
+
+    go func() {
+        buf := make([]byte, 65535)
+        for {
+            n, addr, err := u.ReadFrom(buf)
+            if err != nil {
+                return
+            }
+            u.WriteTo(buf[:n], addr)
+        }
+    }()
+
+    // Start SOCKS server
+    addr, stop := startSOCKS(t, &osAdapter{})
+    defer stop()
+
+    // Control TCP
+    c, err := net.Dial("tcp", addr)
+    if err != nil {
+        t.Fatalf("dial socks: %v", err)
+    }
+    defer c.Close()
+    br := bufio.NewReader(c)
+    bw := bufio.NewWriter(c)
+    // greet
+    bw.Write([]byte{0x05, 0x01, 0x00})
+    bw.Flush()
+    br.ReadByte()
+    br.ReadByte()
+
+    // UDP ASSOCIATE
+    pkt := []byte{0x05, 0x03, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+    bw.Write(pkt)
+    bw.Flush()
+    rep := make([]byte, 10)
+    if _, err := io.ReadFull(br, rep); err != nil {
+        t.Fatalf("udp rep: %v", err)
+    }
+    if rep[1] != 0x00 || rep[3] != 0x01 {
+        t.Fatalf("bad rep")
+    }
+    bindIP := net.IP(rep[4:8])
+    bindPort := int(binary.BigEndian.Uint16(rep[8:10]))
+
+    // Send UDP packet with SOCKS5 UDP header
+    uc, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: bindIP, Port: bindPort})
+    if err != nil {
+        t.Fatalf("dial udp: %v", err)
+    }
+    defer uc.Close()
+
+    // Build header to UDP echo server
+    hdr := []byte{0x00, 0x00, 0x00, 0x01}
+    hdr = append(hdr, udpAddr.IP.To4()...)
+    p := make([]byte, 2)
+    binary.BigEndian.PutUint16(p, uint16(udpAddr.Port))
+    hdr = append(hdr, p...)
+    payload := []byte("ping")
+    uc.Write(append(hdr, payload...))
+
+    // Read response
+    buf := make([]byte, 65535)
+    uc.SetReadDeadline(time.Now().Add(time.Second))
+    n, _, err := uc.ReadFrom(buf)
+    if err != nil {
+        t.Fatalf("udp read: %v", err)
+    }
+    // Strip header
+    if n < 10 { // minimal header
+        t.Fatalf("short udp resp")
+    }
+    // header is RSV RSV FRAG ATYP (IPv4) + addr(4) + port(2)
+    data := buf[10:n]
+    if string(data) != "ping" {
+        t.Fatalf("udp echo mismatch: %q", string(data))
+    }
+}

--- a/services/wireguard/endpoint/socks5client/server.go
+++ b/services/wireguard/endpoint/socks5client/server.go
@@ -1,0 +1,397 @@
+/*
+ * Copyright (C) 2025 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package socks5client
+
+import (
+    "bufio"
+    "context"
+    "encoding/binary"
+    "fmt"
+    "io"
+    "net"
+    "net/netip"
+    "sync"
+    "time"
+)
+
+// UDPConn is a minimal interface for a UDP connection used by the server.
+type UDPConn interface {
+    Read([]byte) (int, error)
+    Write([]byte) (int, error)
+    SetReadDeadline(time.Time) error
+    Close() error
+}
+
+// Dialer is the minimal interface server needs for TCP and UDP via an underlying network implementation.
+type Dialer interface {
+    DialContext(ctx context.Context, network, address string) (net.Conn, error)
+    DialUDPAddrPort(laddr, raddr netip.AddrPort) (UDPConn, error)
+    LookupContextHost(ctx context.Context, host string) ([]string, error)
+}
+
+// Server implements a minimal SOCKS5 server (no-auth) with TCP CONNECT and UDP ASSOCIATE.
+type Server struct {
+    Dialer Dialer
+
+    ln     net.Listener
+    closed chan struct{}
+    once   sync.Once
+}
+
+func (s *Server) Serve(addr string) error {
+    ln, err := net.Listen("tcp", addr)
+    if err != nil {
+        return err
+    }
+    s.ln = ln
+    s.closed = make(chan struct{})
+
+    for {
+        conn, err := ln.Accept()
+        if err != nil {
+            select {
+            case <-s.closed:
+                return nil
+            default:
+            }
+            if ne, ok := err.(net.Error); ok && ne.Temporary() {
+                time.Sleep(50 * time.Millisecond)
+                continue
+            }
+            return err
+        }
+        go s.serveConn(conn)
+    }
+}
+
+func (s *Server) Close() {
+    s.once.Do(func() {
+        close(s.closed)
+        if s.ln != nil {
+            _ = s.ln.Close()
+        }
+    })
+}
+
+const (
+    socksVer5        = 0x05
+    socksMethodNoAuth = 0x00
+
+    socksCmdConnect  = 0x01
+    socksCmdBind     = 0x02 // not implemented
+    socksCmdUDP      = 0x03
+
+    socksAtypIPv4 = 0x01
+    socksAtypFQDN = 0x03
+    socksAtypIPv6 = 0x04
+
+    socksRepSuccess              = 0x00
+    socksRepGeneralFailure       = 0x01
+    socksRepCommandNotSupported  = 0x07
+    socksRepAddressTypeNotSupport = 0x08
+)
+
+func (s *Server) serveConn(c net.Conn) {
+    defer c.Close()
+    br := bufio.NewReader(c)
+    bw := bufio.NewWriter(c)
+
+    // Greeting
+    ver, err := br.ReadByte()
+    if err != nil || ver != socksVer5 {
+        return
+    }
+    nMethods, err := br.ReadByte()
+    if err != nil {
+        return
+    }
+    methods := make([]byte, int(nMethods))
+    if _, err := io.ReadFull(br, methods); err != nil {
+        return
+    }
+    // Always select no-auth
+    _, _ = bw.Write([]byte{socksVer5, socksMethodNoAuth})
+    if err := bw.Flush(); err != nil {
+        return
+    }
+
+    // Request
+    hdr := make([]byte, 4)
+    if _, err := io.ReadFull(br, hdr); err != nil {
+        return
+    }
+    if hdr[0] != socksVer5 {
+        return
+    }
+    cmd := hdr[1]
+    atyp := hdr[3]
+
+    var dstHost string
+    var dstPort uint16
+    switch atyp {
+    case socksAtypIPv4:
+        addr := make([]byte, 4)
+        if _, err := io.ReadFull(br, addr); err != nil {
+            return
+        }
+        port := make([]byte, 2)
+        if _, err := io.ReadFull(br, port); err != nil {
+            return
+        }
+        dstHost = net.IP(addr).String()
+        dstPort = binary.BigEndian.Uint16(port)
+    case socksAtypIPv6:
+        addr := make([]byte, 16)
+        if _, err := io.ReadFull(br, addr); err != nil {
+            return
+        }
+        port := make([]byte, 2)
+        if _, err := io.ReadFull(br, port); err != nil {
+            return
+        }
+        dstHost = net.IP(addr).String()
+        dstPort = binary.BigEndian.Uint16(port)
+    case socksAtypFQDN:
+        ln, err := br.ReadByte()
+        if err != nil {
+            return
+        }
+        name := make([]byte, int(ln))
+        if _, err := io.ReadFull(br, name); err != nil {
+            return
+        }
+        port := make([]byte, 2)
+        if _, err := io.ReadFull(br, port); err != nil {
+            return
+        }
+        dstHost = string(name)
+        dstPort = binary.BigEndian.Uint16(port)
+    default:
+        s.writeReply(bw, socksRepAddressTypeNotSupport, net.IPv4zero, 0)
+        return
+    }
+
+    switch cmd {
+    case socksCmdConnect:
+        s.handleConnect(c, br, bw, dstHost, int(dstPort))
+    case socksCmdUDP:
+        s.handleUDP(c, br, bw)
+    default:
+        s.writeReply(bw, socksRepCommandNotSupported, net.IPv4zero, 0)
+    }
+}
+
+func (s *Server) writeReply(bw *bufio.Writer, rep byte, bindAddr net.IP, bindPort int) {
+    // We always reply with IPv4 form (ATYP=1) for simplicity.
+    pkt := make([]byte, 0, 10)
+    pkt = append(pkt, socksVer5, rep, 0x00, socksAtypIPv4)
+    if bindAddr == nil || bindAddr.To4() == nil {
+        pkt = append(pkt, []byte{0, 0, 0, 0}...)
+    } else {
+        pkt = append(pkt, bindAddr.To4()...)
+    }
+    p := make([]byte, 2)
+    binary.BigEndian.PutUint16(p, uint16(bindPort))
+    pkt = append(pkt, p...)
+    _, _ = bw.Write(pkt)
+    _ = bw.Flush()
+}
+
+func (s *Server) handleConnect(c net.Conn, br *bufio.Reader, bw *bufio.Writer, host string, port int) {
+    ctx := context.Background()
+    rc, err := s.Dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+    if err != nil {
+        s.writeReply(bw, socksRepGeneralFailure, net.IPv4zero, 0)
+        return
+    }
+    defer rc.Close()
+
+    // Success
+    s.writeReply(bw, socksRepSuccess, net.IPv4zero, 0)
+
+    // Bidirectional copy
+    proxyStream(c, rc)
+}
+
+func (s *Server) handleUDP(c net.Conn, br *bufio.Reader, bw *bufio.Writer) {
+    // Bind a local UDP socket for client datagrams.
+    // Limit exposure to loopback.
+    // no need to build a netip.Addr for OS listener
+    // Use OS UDP for client-side (so the app can send UDP here), but for simplicity
+    // use the stdlib net since we only need a local socket.
+    uc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+    if err != nil {
+        s.writeReply(bw, socksRepGeneralFailure, net.IPv4zero, 0)
+        return
+    }
+
+    // Reply success with bound address/port for client to send UDP packets to.
+    bind := uc.LocalAddr().(*net.UDPAddr)
+    s.writeReply(bw, socksRepSuccess, bind.IP, bind.Port)
+
+    done := make(chan struct{})
+    go func() {
+        defer close(done)
+        buf := make([]byte, 1<<16)
+        for {
+            _ = uc.SetReadDeadline(time.Now().Add(2 * time.Minute))
+            n, clientAddr, err := uc.ReadFromUDP(buf)
+            if err != nil {
+                if ne, ok := err.(net.Error); ok && ne.Timeout() {
+                    return
+                }
+                return
+            }
+            if n < 4+2 { // minimal header
+                continue
+            }
+            // Parse UDP header (RSV, RSV, FRAG)
+            if buf[2] != 0x00 { // FRAG not supported
+                continue
+            }
+            atype := buf[3]
+            off := 4
+            var rIP net.IP
+            var rPort uint16
+            switch atype {
+            case socksAtypIPv4:
+                if n < off+4+2 {
+                    continue
+                }
+                rIP = net.IP(buf[off : off+4])
+                off += 4
+            case socksAtypIPv6:
+                if n < off+16+2 {
+                    continue
+                }
+                rIP = net.IP(buf[off : off+16])
+                off += 16
+            case socksAtypFQDN:
+                if n < off+1 {
+                    continue
+                }
+                ln := int(buf[off])
+                off++
+                if n < off+ln+2 {
+                    continue
+                }
+                name := string(buf[off : off+ln])
+                off += ln
+                // Resolve using tunnel DNS
+                addrs, err := s.Dialer.LookupContextHost(context.Background(), name)
+                if err != nil || len(addrs) == 0 {
+                    continue
+                }
+                rIP = net.ParseIP(addrs[0])
+            default:
+                continue
+            }
+            rPort = binary.BigEndian.Uint16(buf[off : off+2])
+            off += 2
+            payload := buf[off:n]
+
+            // Send to remote via tunnel
+            rAddr, ok := netip.AddrFromSlice(rIP)
+            if !ok {
+                continue
+            }
+            // Connect for this peer and write packet
+            pc, err := s.Dialer.DialUDPAddrPort(netip.AddrPort{}, netip.AddrPortFrom(rAddr, rPort))
+            if err != nil {
+                continue
+            }
+            _, _ = pc.Write(payload)
+
+            // Collect immediate responses from the same remote socket
+            _ = pc.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+            for {
+                rb := make([]byte, 1<<16)
+                rn, rerr := pc.Read(rb)
+                if rerr != nil {
+                    if ne, ok := rerr.(net.Error); ok && ne.Timeout() {
+                        break
+                    }
+                    break
+                }
+                // Build SOCKS5 UDP response header. We don't know the src addr here from pc,
+                // so set ATYP=IPv4 and ADDR=0.0.0.0:0 which clients typically ignore.
+                hdr := []byte{0x00, 0x00, 0x00, socksAtypIPv4, 0, 0, 0, 0, 0, 0}
+                out := append(hdr, rb[:rn]...)
+                _, _ = uc.WriteToUDP(out, clientAddr)
+            }
+            _ = pc.Close()
+        }
+    }()
+
+    // Keep TCP control connection open until client closes it; we don't expect more data here.
+    // Any read will block; set a read deadline to clean up eventually.
+    _ = c.SetReadDeadline(time.Now().Add(2 * time.Minute))
+    _, _ = br.Peek(1)
+    _ = uc.Close()
+    <-done
+}
+
+func buildUDPResponseHeader(addr net.Addr) []byte {
+    // RSV RSV FRAG ATYP DST.ADDR DST.PORT
+    var atyp byte
+    var ip net.IP
+    var port int
+
+    switch a := addr.(type) {
+    case *net.UDPAddr:
+        ip = a.IP
+        port = a.Port
+    default:
+        // Fallback: 0.0.0.0:0
+        ip = net.IPv4zero
+        port = 0
+    }
+    if ip.To4() != nil {
+        atyp = socksAtypIPv4
+    } else if ip.To16() != nil {
+        atyp = socksAtypIPv6
+    } else {
+        atyp = socksAtypIPv4
+        ip = net.IPv4zero
+        port = 0
+    }
+    b := []byte{0x00, 0x00, 0x00, atyp}
+    if atyp == socksAtypIPv4 {
+        b = append(b, ip.To4()...)
+    } else {
+        b = append(b, ip.To16()...)
+    }
+    p := make([]byte, 2)
+    binary.BigEndian.PutUint16(p, uint16(port))
+    b = append(b, p...)
+    return b
+}
+
+func proxyStream(left, right net.Conn) {
+    var wg sync.WaitGroup
+    wg.Add(2)
+
+    cpy := func(dst, src net.Conn) {
+        defer wg.Done()
+        _, _ = io.Copy(dst, src)
+        _ = dst.Close()
+    }
+    go cpy(left, right)
+    go cpy(right, left)
+    wg.Wait()
+}

--- a/services/wireguard/endpoint/wg_client.go
+++ b/services/wireguard/endpoint/wg_client.go
@@ -18,20 +18,14 @@
 package endpoint
 
 import (
-	"runtime"
-	"sync"
+    "runtime"
+    "sync"
 
-	"github.com/rs/zerolog/log"
+    "github.com/rs/zerolog/log"
 
-	"github.com/mysteriumnetwork/node/config"
-	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/dvpnclient"
-	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/kernelspace"
-	netstack_provider "github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack-provider"
-	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/proxyclient"
-	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/remoteclient"
-	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
-	"github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
-	"github.com/mysteriumnetwork/node/utils/cmdutil"
+    "github.com/mysteriumnetwork/node/services/wireguard/endpoint/smartclient"
+    "github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
+    "github.com/mysteriumnetwork/node/utils/cmdutil"
 )
 
 // WgClient represents WireGuard client.
@@ -55,35 +49,7 @@ func NewWGClientFactory() *WgClientFactory {
 }
 
 // NewWGClient returns a new wireguard client.
-func (wcf *WgClientFactory) NewWGClient() (WgClient, error) {
-	if config.GetBool(config.FlagDVPNMode) {
-		return dvpnclient.New()
-	}
-
-	if config.GetBool(config.FlagProxyMode) {
-		return proxyclient.New()
-	}
-
-	if config.GetBool(config.FlagUserspace) {
-		return netstack_provider.New()
-	}
-
-	if config.GetBool(config.FlagUserMode) {
-		return remoteclient.New()
-	}
-
-	wcf.once.Do(func() {
-		wcf.isKernelSpaceSupportedResult = wcf.isKernelSpaceSupported()
-	})
-
-	if wcf.isKernelSpaceSupportedResult {
-		return kernelspace.NewWireguardClient()
-	}
-
-	log.Info().Msg("Wireguard kernel space is not supported. Switching to user space implementation.")
-
-	return userspace.NewWireguardClient()
-}
+func (wcf *WgClientFactory) NewWGClient() (WgClient, error) { return smartclient.New(), nil }
 
 func (wcf *WgClientFactory) isKernelSpaceSupported() bool {
 	if runtime.GOOS != "linux" {

--- a/testkit/socks5/socks5_functional_test.go
+++ b/testkit/socks5/socks5_functional_test.go
@@ -1,0 +1,196 @@
+package socks5_test
+
+import (
+    "bufio"
+    "context"
+    "encoding/binary"
+    "fmt"
+    "net"
+    "os"
+    "testing"
+    "time"
+
+    "golang.org/x/net/dns/dnsmessage"
+)
+
+// dialIfListening tries to connect to addr within timeout; returns conn or nil.
+func dialIfListening(addr string, timeout time.Duration) net.Conn {
+    d := net.Dialer{Timeout: timeout}
+    c, err := d.DialContext(context.Background(), "tcp", addr)
+    if err != nil {
+        return nil
+    }
+    return c
+}
+
+// buildDNSQuery creates a simple A query for example.com.
+func buildDNSQuery() []byte {
+    b := dnsmessage.NewBuilder(nil, dnsmessage.Header{RecursionDesired: true})
+    _ = b.StartQuestions()
+    _ = b.Question(dnsmessage.Question{
+        Name:  dnsmessage.MustNewName("example.com."),
+        Type:  dnsmessage.TypeA,
+        Class: dnsmessage.ClassINET,
+    })
+    msg, _ := b.Finish()
+    return msg
+}
+
+// socks5 UDP header builder for IPv4 target.
+func buildSocksUDPHeader(ip net.IP, port int) []byte {
+    h := []byte{0, 0, 0, 1}
+    h = append(h, ip.To4()...)
+    p := make([]byte, 2)
+    binary.BigEndian.PutUint16(p, uint16(port))
+    h = append(h, p...)
+    return h
+}
+
+func TestSOCKS5_UDP_DNS_Associate(t *testing.T) {
+    // Allow override of socks and DNS via env.
+    socksAddr := os.Getenv("SOCKS5_ADDR")
+    if socksAddr == "" {
+        socksAddr = "127.0.0.1:10001"
+    }
+    dnsHost := os.Getenv("DNS_HOST")
+    if dnsHost == "" {
+        dnsHost = "1.1.1.1"
+    }
+    dnsPort := 53
+
+    // Skip if SOCKS not listening.
+    c := dialIfListening(socksAddr, 500*time.Millisecond)
+    if c == nil {
+        if os.Getenv("SOCKS5_REQUIRED") != "" {
+            t.Fatalf("SOCKS5 not listening at %s and SOCKS5_REQUIRED set", socksAddr)
+        }
+        t.Skipf("SOCKS5 not listening at %s; skipping functional test", socksAddr)
+        return
+    }
+    defer c.Close()
+    br := bufio.NewReader(c)
+    bw := bufio.NewWriter(c)
+
+    // Greeting: no auth
+    bw.Write([]byte{0x05, 0x01, 0x00})
+    bw.Flush()
+    if v, _ := br.ReadByte(); v != 0x05 { t.Fatalf("bad ver") }
+    if m, _ := br.ReadByte(); m != 0x00 { t.Fatalf("bad method") }
+
+    // UDP ASSOCIATE with 0.0.0.0:0
+    bw.Write([]byte{0x05, 0x03, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+    bw.Flush()
+    rep := make([]byte, 10)
+    if _, err := br.Read(rep); err != nil { t.Fatalf("udp rep: %v", err) }
+    if rep[1] != 0x00 { t.Fatalf("rep=%d", rep[1]) }
+    bindIP := net.IP(rep[4:8])
+    bindPort := int(binary.BigEndian.Uint16(rep[8:10]))
+
+    uc, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: bindIP, Port: bindPort})
+    if err != nil { t.Fatalf("udp dial: %v", err) }
+    defer uc.Close()
+
+    // Send DNS query via UDP ASSOCIATE
+    hdr := buildSocksUDPHeader(net.ParseIP(dnsHost), dnsPort)
+    payload := buildDNSQuery()
+    if _, err := uc.Write(append(hdr, payload...)); err != nil { t.Fatalf("udp write: %v", err) }
+
+    // Read response and ensure it parses as DNS.
+    buf := make([]byte, 4096)
+    _ = uc.SetReadDeadline(time.Now().Add(2 * time.Second))
+    n, _, err := uc.ReadFrom(buf)
+    if err != nil { t.Fatalf("udp read: %v", err) }
+    if n < 10 { t.Fatalf("short resp") }
+    // Strip socks header (assume IPv4 header size = 10)
+    dnsBytes := buf[10:n]
+    var p dnsmessage.Parser
+    if _, err := p.Start(dnsBytes); err != nil {
+        t.Fatalf("dns parse: %v", err)
+    }
+}
+
+func TestSOCKS5_TCP_CONNECT_HTTP(t *testing.T) {
+    // Note: Requires SOCKS5 running locally (default 127.0.0.1:10001).
+    socksAddr := os.Getenv("SOCKS5_ADDR")
+    if socksAddr == "" {
+        socksAddr = "127.0.0.1:10001"
+    }
+    targetHost := os.Getenv("TCP_HOST")
+    if targetHost == "" {
+        targetHost = "example.com"
+    }
+    targetPort := 80
+
+    c := dialIfListening(socksAddr, 500*time.Millisecond)
+    if c == nil {
+        if os.Getenv("SOCKS5_REQUIRED") != "" {
+            t.Fatalf("SOCKS5 not listening at %s and SOCKS5_REQUIRED set", socksAddr)
+        }
+        t.Skipf("SOCKS5 not listening at %s; skipping functional test", socksAddr)
+        return
+    }
+    defer c.Close()
+    br := bufio.NewReader(c)
+    bw := bufio.NewWriter(c)
+
+    // Greeting: no auth
+    bw.Write([]byte{0x05, 0x01, 0x00})
+    bw.Flush()
+    if v, _ := br.ReadByte(); v != 0x05 { t.Fatalf("bad ver") }
+    if m, _ := br.ReadByte(); m != 0x00 { t.Fatalf("bad method") }
+
+    // CONNECT request using domain name (ATYP=3)
+    hostBytes := []byte(targetHost)
+    pkt := []byte{0x05, 0x01, 0x00, 0x03, byte(len(hostBytes))}
+    pkt = append(pkt, hostBytes...)
+    p := make([]byte, 2)
+    binary.BigEndian.PutUint16(p, uint16(targetPort))
+    pkt = append(pkt, p...)
+    bw.Write(pkt)
+    bw.Flush()
+
+    // Read reply
+    rep := make([]byte, 4)
+    if _, err := br.Read(rep); err != nil { t.Fatalf("read rep hdr: %v", err) }
+    if rep[1] != 0x00 { t.Fatalf("connect rep=%d", rep[1]) }
+    // Consume BND.ADDR/BND.PORT (skip)
+    atyp := rep[3]
+    switch atyp {
+    case 0x01:
+        ioDiscardN(t, br, 4+2)
+    case 0x04:
+        ioDiscardN(t, br, 16+2)
+    case 0x03:
+        ln, _ := br.ReadByte()
+        ioDiscardN(t, br, int(ln)+2)
+    default:
+        t.Fatalf("bad atyp in rep: %d", atyp)
+    }
+
+    // Send HTTP/1.1 request and read response
+    req := fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", targetHost)
+    if _, err := bw.WriteString(req); err != nil { t.Fatalf("write req: %v", err) }
+    if err := bw.Flush(); err != nil { t.Fatalf("flush: %v", err) }
+
+    _ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+    buf := make([]byte, 8192)
+    n, err := br.Read(buf)
+    if err != nil {
+        t.Fatalf("read resp: %v", err)
+    }
+    if n == 0 || string(buf[:8]) != "HTTP/1.1" {
+        t.Fatalf("unexpected HTTP response: %q", string(buf[:min(n, 64)]))
+    }
+}
+
+func ioDiscardN(t *testing.T, r *bufio.Reader, n int) {
+    t.Helper()
+    for n > 0 {
+        k := n
+        if k > 512 { k = 512 }
+        if _, err := r.Discard(k); err != nil { t.Fatalf("discard: %v", err) }
+        n -= k
+    }
+}
+
+func min(a, b int) int { if a < b { return a }; return b }


### PR DESCRIPTION
This PR adds a first-class SOCKS5 proxy to the consumer side and the ability to run HTTP and SOCKS5 simultaneously. It also introduces a “smart” WireGuard client selector that reliably starts the dual-proxy when a connection is brought up with --proxy, regardless of global flags.

Functional tests verify SOCKS5-only features (UDP ASSOCIATE) and TCP CONNECT.

Changes

- New: services/wireguard/endpoint/socks5client
    - Real SOCKS5 server with no auth, supports:
    - TCP CONNECT: arbitrary TCP via netstack dialer
    - UDP ASSOCIATE: domain/IPv4/IPv6, forwards via netstack UDP, returns replies
- New: services/wireguard/endpoint/dualproxyclient
    - Runs both HTTP and SOCKS5 proxies from a single netstack WireGuard device
    - Ports: HTTP :ProxyPort, SOCKS5 :ProxyPort+1
- New: services/wireguard/endpoint/smartclient
    - Defers WG client selection to ConfigureDevice; if ProxyPort>0 → run dual-proxy; otherwise
choose userspace/usermode/kernelspace as before
- Update: services/wireguard/endpoint/proxyclient
    - Exported NewProxyHandler for reuse by the dual-proxy client
- Tests: testkit/socks5/socks5_functional_test.go
    - UDP: SOCKS5 UDP ASSOCIATE sends a real DNS query and parses the response
    - TCP: SOCKS5 CONNECT fetches an HTTP/1.1 response from example.com:80
    - Tests auto-skip if SOCKS5_ADDR isn’t listening (won’t fail unit tests)
- Docs:
    - New README_SOCKS5.md with usage and functional test instructions
    - Linked from README.md

Usage

- Start service (global flags first). On macOS, add --userspace:
    - ./myst service --agreed-terms-and-conditions
- Bring up connection with base port:
    - ./myst connection up --proxy 10000 <provider_id>
- Proxies:
    - HTTP: 127.0.0.1:10000
    - SOCKS5: 127.0.0.1:10001
- Optional quick tests:
    - HTTP: curl -x http://127.0.0.1:10000 https://ifconfig.me
    - SOCKS5: curl --socks5-hostname 127.0.0.1:10001 https://ifconfig.me

Functional tests

- With SOCKS5 running on 127.0.0.1:10001:
    - go test ./testkit/socks5 -v
- Env overrides:
    - SOCKS5_ADDR (default 127.0.0.1:10001)
    - DNS_HOST for UDP test (default 1.1.1.1)
    - TCP_HOST for TCP test (default example.com)

Rationale

- Many clients require SOCKS5-only capabilities (UDP ASSOCIATE); HTTP proxies cannot satisfy
these use cases.
- Running HTTP and SOCKS5 in parallel improves compatibility and developer ergonomics.
- Smart selection (based on ProxyPort) makes the behavior predictable and avoids brittle
dependencies on flags.

Limitations and possible follow-ups

- UDP replies currently include generic BND addr (0.0.0.0:0) as many clients ignore it; can be
extended to report the actual remote address.
- UDP implementation opens a short-lived UDP connection per datagram; a small session cache could
improve throughput for heavy UDP usage.
- SOCKS5 loopback protection (similar to the HTTP proxy) could be added.

Compatibility

- Default behavior for non-proxy connections remains unchanged.
- The deprecated proxymode.socks5 flag is effectively ignored; dual-proxy starts whenever --proxy
is used with connection up.