### PR TITLE
fix: add 16KB page size alignment for Android AAR builds

### DIFF
--- a/bin/package_android
+++ b/bin/package_android
@@ -26,7 +26,7 @@ docker run --rm \
     -e FLAG_V=false \
     -e FLAG_X=false \
     -e FLAG_RACE=false \
-    -e FLAG_LDFLAGS="-w -s $(get_linker_ldflags) -checklinkname=0" \
+    -e FLAG_LDFLAGS="-w -s $(get_linker_ldflags) -checklinkname=0 -extldflags=-Wl,-z,max-page-size=16384" \
     -e FLAG_BUILDMODE=default \
     -e FLAG_TAGS="android" \
     -e TARGETS=android/. \

--- a/bin/package_android_provider
+++ b/bin/package_android_provider
@@ -26,7 +26,7 @@ docker run --rm \
     -e FLAG_V=false \
     -e FLAG_X=false \
     -e FLAG_RACE=false \
-    -e FLAG_LDFLAGS="-w -s $(get_linker_ldflags) -checklinkname=0" \
+    -e FLAG_LDFLAGS="-w -s $(get_linker_ldflags) -checklinkname=0 -extldflags=-Wl,-z,max-page-size=16384" \
     -e FLAG_BUILDMODE=default \
     -e FLAG_TAGS="android mobile_provider" \
     -e TARGETS=android_provider/. \


### PR DESCRIPTION
Google Play requires apps targeting Android 15+ to support 16KB memory page sizes by Nov 2025. Add -extldflags=-Wl,-z,max-page-size=16384 to Go linker flags for both consumer and provider Android builds.