### PR TITLE
fix: WireGuard log level respects --log-level flag

### DIFF
--- a/logconfig/wglevel.go
+++ b/logconfig/wglevel.go
@@ -1,0 +1,17 @@
+package logconfig
+
+import "github.com/rs/zerolog"
+
+// WireGuardLogLevel maps the node's configured zerolog level to a WireGuard
+// device log level (0=silent, 1=error, 2=verbose).
+// This ensures WireGuard logging respects the --log-level flag.
+func WireGuardLogLevel() int {
+	switch CurrentLogOptions.LogLevel {
+	case zerolog.TraceLevel, zerolog.DebugLevel:
+		return 2 // device.LogLevelVerbose
+	case zerolog.InfoLevel, zerolog.WarnLevel:
+		return 1 // device.LogLevelError
+	default:
+		return 0 // device.LogLevelSilent
+	}
+}

--- a/mobile/mysterium/wireguard_connection_setup.go
+++ b/mobile/mysterium/wireguard_connection_setup.go
@@ -34,6 +34,7 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/mysteriumnetwork/node/core/connection"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/core/connection/connectionstate"
 	"github.com/mysteriumnetwork/node/core/ip"
 	"github.com/mysteriumnetwork/node/p2p"
@@ -209,7 +210,7 @@ func (w *wireguardDeviceImpl) Start(privateKey string, config wireguard.ServiceC
 		}
 	}()
 
-	w.device = device.NewDevice(tunDevice, conn.NewStdNetBind(), device.NewLogger(device.LogLevelVerbose, "[userspace-wg]"))
+	w.device = device.NewDevice(tunDevice, conn.NewStdNetBind(), device.NewLogger(logconfig.WireGuardLogLevel(), "[userspace-wg]"))
 
 	err = w.applyConfig(w.device, privateKey, config)
 	if err != nil {

--- a/services/wireguard/endpoint/netstack-provider/client.go
+++ b/services/wireguard/endpoint/netstack-provider/client.go
@@ -29,6 +29,7 @@ import (
 	"golang.zx2c4.com/wireguard/device"
 
 	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
 )
 
@@ -53,7 +54,7 @@ func (c *client) ConfigureDevice(cfg wgcfg.DeviceConfig) error {
 		return fmt.Errorf("failed to create netstack device %s: %w", cfg.IfaceName, err)
 	}
 
-	logger := device.NewLogger(device.LogLevelVerbose, fmt.Sprintf("(%s) ", cfg.IfaceName))
+	logger := device.NewLogger(logconfig.WireGuardLogLevel(), fmt.Sprintf("(%s) ", cfg.IfaceName))
 	wgDevice := device.NewDevice(tunnel, conn.NewDefaultBind(), logger)
 
 	log.Info().Msg("Applying interface configuration")

--- a/services/wireguard/endpoint/proxyclient/client.go
+++ b/services/wireguard/endpoint/proxyclient/client.go
@@ -32,6 +32,7 @@ import (
 	"golang.zx2c4.com/wireguard/device"
 
 	"github.com/mysteriumnetwork/node/config"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack"
 	"github.com/mysteriumnetwork/node/services/wireguard/endpoint/userspace"
 	"github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
@@ -70,7 +71,7 @@ func (c *client) ConfigureDevice(cfg wgcfg.DeviceConfig) error {
 		return fmt.Errorf("failed to create netstack device %s: %w", cfg.IfaceName, err)
 	}
 
-	logger := device.NewLogger(device.LogLevelVerbose, fmt.Sprintf("(%s) ", cfg.IfaceName))
+	logger := device.NewLogger(logconfig.WireGuardLogLevel(), fmt.Sprintf("(%s) ", cfg.IfaceName))
 	wgDevice := device.NewDevice(tunnel, conn.NewDefaultBind(), logger)
 
 	log.Info().Msg("Applying interface configuration")

--- a/services/wireguard/endpoint/userspace/client.go
+++ b/services/wireguard/endpoint/userspace/client.go
@@ -28,6 +28,7 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/mysteriumnetwork/node/services/wireguard/connection/dns"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
 	"github.com/mysteriumnetwork/node/utils/actionstack"
 	"github.com/mysteriumnetwork/node/utils/netutil"
@@ -52,7 +53,7 @@ func (c *client) ConfigureDevice(config wgcfg.DeviceConfig) (err error) {
 		return errors.Wrap(err, "failed to create TUN device")
 	}
 
-	devAPI := device.NewDevice(c.tun, conn.NewDefaultBind(), device.NewLogger(device.LogLevelVerbose, "[userspace-wg]"))
+	devAPI := device.NewDevice(c.tun, conn.NewDefaultBind(), device.NewLogger(logconfig.WireGuardLogLevel(), "[userspace-wg]"))
 	c.devAPI = devAPI
 	rollback.Push(func() {
 		devAPI.Close()

--- a/supervisor/daemon/wireguard/wginterface/interface.go
+++ b/supervisor/daemon/wireguard/wginterface/interface.go
@@ -28,6 +28,7 @@ import (
 	"golang.zx2c4.com/wireguard/device"
 
 	"github.com/mysteriumnetwork/node/services/wireguard/connection/dns"
+	"github.com/mysteriumnetwork/node/logconfig"
 	"github.com/mysteriumnetwork/node/services/wireguard/wgcfg"
 	"github.com/mysteriumnetwork/node/utils/netutil"
 )
@@ -47,7 +48,7 @@ func New(cfg wgcfg.DeviceConfig, uid string) (*WgInterface, error) {
 		return nil, fmt.Errorf("failed to create TUN device %s: %w", cfg.IfaceName, err)
 	}
 
-	logger := device.NewLogger(device.LogLevelVerbose, fmt.Sprintf("(%s) ", interfaceName))
+	logger := device.NewLogger(logconfig.WireGuardLogLevel(), fmt.Sprintf("(%s) ", interfaceName))
 	logger.Verbosef("Starting wireguard-go")
 
 	logger.Verbosef("Starting device")


### PR DESCRIPTION
WireGuard device logger was hardcoded to LogLevelVerbose, producing excessive DEBUG output (peer handshakes, keepalives) regardless of the node's --log-level setting.

Added logconfig.WireGuardLogLevel() that maps zerolog levels:
  trace/debug → LogLevelVerbose (handshakes, keepalives)
  info/warn   → LogLevelError (errors only)
  error+      → LogLevelSilent

All 5 device creation sites now call logconfig.WireGuardLogLevel() instead of hardcoding a level.