### PR TITLE
feat: add automated package updater for Mysterium Node DEB

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,33 @@ Access service logs:
 docker logs -f myst
 ```
 
+### Debian package automatic updates
+
+New `myst` DEB installations include `myst-updater.timer`. The timer checks the
+stable Mysterium Launchpad PPA every 6–12 hours and installs a newer authenticated
+package when one is available. The updater rejects downgrades, held packages,
+unexpected repositories, architectures, package paths, and artifact hashes. After
+installation it verifies both the installed package version and the running node's
+`/healthcheck` version.
+
+Check the updater manually without installing anything:
+
+```bash
+sudo /usr/lib/mysterium-node/myst-updater --check-only
+```
+
+Inspect its schedule and logs:
+
+```bash
+systemctl list-timers myst-updater.timer
+journalctl -u myst-updater.service
+```
+
+Automatic updates can be disabled by setting `MYST_UPDATER_ENABLED=false` in
+`/etc/default/myst-updater`. APT continues to perform the repository signature
+and package-index hash verification; the updater never enables insecure or
+unauthenticated repository modes.
+
 ### Further information
 
 More installation options are described in the [installation guides](https://help.mystnodes.com/en/?q=installation).

--- a/bin/build
+++ b/bin/build
@@ -44,6 +44,14 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+if [[ "$GOOS" == "linux" ]]; then
+    echo "Compiling 'myst-updater' for '$GOOS/$GOARCH'.."
+    go build -ldflags="$LD_FLAGS" $STATIC_OPTS -o $GOBIN/myst-updater cmd/myst_updater/main.go
+    if [ $? -ne 0 ]; then
+        print_error "Updater compile failed!"
+        exit 1
+    fi
+fi
+
 mkdir -p $GOBIN/config
 copy_config $GOOS $GOBIN
-

--- a/bin/package/installation/myst-updater.default
+++ b/bin/package/installation/myst-updater.default
@@ -1,0 +1,8 @@
+# Set to false to disable automatic package updates without disabling the timer.
+MYST_UPDATER_ENABLED=true
+
+# The updater only accepts an HTTP healthcheck on 127.0.0.1.
+MYST_UPDATER_HEALTHCHECK_URL=http://127.0.0.1:4050/healthcheck
+MYST_UPDATER_HEALTHCHECK_TIMEOUT=2m
+MYST_UPDATER_COMMAND_TIMEOUT=20m
+

--- a/bin/package/installation/myst-updater.service
+++ b/bin/package/installation/myst-updater.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Mysterium Node authenticated package updater
+Documentation=https://github.com/mysteriumnetwork/node
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/default/myst-updater
+ExecStart=/usr/lib/mysterium-node/myst-updater
+TimeoutStartSec=25min
+UMask=0077
+PrivateTmp=true
+ProtectHome=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+Nice=10
+IOSchedulingClass=idle
+

--- a/bin/package/installation/myst-updater.timer
+++ b/bin/package/installation/myst-updater.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Periodically check for authenticated Mysterium Node updates
+
+[Timer]
+OnBootSec=20min
+OnUnitActiveSec=6h
+RandomizedDelaySec=6h
+Persistent=true
+Unit=myst-updater.service
+
+[Install]
+WantedBy=timers.target
+

--- a/bin/package/installation/post-install.sh
+++ b/bin/package/installation/post-install.sh
@@ -22,11 +22,15 @@ function install_initd {
 }
 
 function install_systemd {
-    printf "Installing systemd script '$OS_DIR_SYSTEMD/mysterium-node.service'..\n" \
+    printf "Installing systemd services for Mysterium Node..\n" \
         && cp -f $OS_DIR_INSTALLATION/mysterium-node.service $OS_DIR_SYSTEMD/mysterium-node.service \
         && cp -f $OS_DIR_INSTALLATION/mysterium-consumer.service $OS_DIR_SYSTEMD/mysterium-consumer.service \
+        && cp -f $OS_DIR_INSTALLATION/myst-updater.service $OS_DIR_SYSTEMD/myst-updater.service \
+        && cp -f $OS_DIR_INSTALLATION/myst-updater.timer $OS_DIR_SYSTEMD/myst-updater.timer \
+        && systemctl daemon-reload \
         && systemctl enable systemd-networkd.service \
         && systemctl enable mysterium-node \
+        && systemctl enable --now myst-updater.timer \
         && systemctl restart mysterium-node
 }
 
@@ -75,6 +79,9 @@ ensure_paths
 # Add defaults file, if it doesn't exist
 if [[ ! -f $DAEMON_DEFAULT ]]; then
     cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
+fi
+if [[ ! -f /etc/default/myst-updater ]]; then
+    cp $OS_DIR_INSTALLATION/myst-updater.default /etc/default/myst-updater
 fi
 
 # TODO remove temporary fix for starting all services instead of wireguard.

--- a/bin/package/installation/post-uninstall.sh
+++ b/bin/package/installation/post-uninstall.sh
@@ -14,6 +14,8 @@ fi
 function disable_systemd {
     system_service=/lib/systemd/system/mysterium-node.service
     system_consumer=/lib/systemd/system/mysterium-consumer.service
+    updater_service=/lib/systemd/system/myst-updater.service
+    updater_timer=/lib/systemd/system/myst-updater.timer
     if [ ! -e $system_service ]; then
         return
     fi
@@ -22,7 +24,10 @@ function disable_systemd {
     systemctl disable mysterium-node
     systemctl stop mysterium-consumer
     systemctl disable mysterium-consumer
-    rm -f $system_service $system_consumer
+    systemctl stop myst-updater.timer
+    systemctl disable myst-updater.timer
+    rm -f $system_service $system_consumer $updater_service $updater_timer
+    systemctl daemon-reload
 }
 
 function disable_update_rcd {
@@ -52,11 +57,11 @@ if [[ -f /etc/redhat-release ]]; then
 	    disable_chkconfig
 	fi
     fi
-elif [[ -f /etc/lsb-release ]]; then
+elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     if [[ "$1" != "upgrade" ]]; then
 	# Remove/purge
-	rm -f /etc/default/mysterium-node
+	rm -f /etc/default/mysterium-node /etc/default/myst-updater
 
 	which systemctl &>/dev/null
 	if [[ $? -eq 0 ]]; then

--- a/bin/package_debian
+++ b/bin/package_debian
@@ -64,6 +64,7 @@ printf "Building Debian package '$PACKAGE_FILE' for architecture '$ARCH' ..\n" \
         --depends "iproute2" \
         --depends "sudo" \
         --depends "debconf" \
+        --depends "apt (>= 1.1)" \
         --depends "wireguard" \
         --deb-templates bin/package/installation/templates \
         --before-install bin/package/installation/pre-install.sh \
@@ -71,6 +72,7 @@ printf "Building Debian package '$PACKAGE_FILE' for architecture '$ARCH' ..\n" \
         --after-remove bin/package/installation/post-uninstall.sh \
         -s dir -t deb \
         ${BINARY}=${OS_DIR_BIN}/myst \
+        build/myst/myst-updater=/usr/lib/mysterium-node/myst-updater \
         bin/package/config/linux/=${OS_DIR_CONFIG}/ \
         bin/package/config/common/=${OS_DIR_CONFIG}/ \
         bin/package/sudoers/=${OS_DIR_SUDOERS}/ \

--- a/cmd/myst_updater/main.go
+++ b/cmd/myst_updater/main.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	debupdater "github.com/mysteriumnetwork/node/updater/deb"
+)
+
+func main() {
+	checkOnly := flag.Bool("check-only", false, "validate the available update without installing it")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "myst-updater does not accept positional arguments")
+		os.Exit(2)
+	}
+	if os.Geteuid() != 0 {
+		log.Fatal("myst-updater must run as root")
+	}
+
+	config, err := debupdater.ConfigFromEnvironment(*checkOnly)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := debupdater.New(config).Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Depends:
  ca-certificates,
  iptables,
  iproute2,
+ apt (>= 1.1),
  wireguard,
 Description: Mysterium Node - VPN server and client for Mysterium Network
  Mysterium Node - decentralized VPN built on blockchain

--- a/debian/myst.install
+++ b/debian/myst.install
@@ -1,4 +1,5 @@
 go/src/github.com/mysteriumnetwork/node/build/myst/myst usr/bin
+go/src/github.com/mysteriumnetwork/node/build/myst/myst-updater usr/lib/mysterium-node
 
 go/src/github.com/mysteriumnetwork/node/bin/package/config/linux/* etc/mysterium-node
 go/src/github.com/mysteriumnetwork/node/bin/package/config/common/* etc/mysterium-node

--- a/debian/postinst
+++ b/debian/postinst
@@ -22,11 +22,15 @@ function install_initd {
 }
 
 function install_systemd {
-    printf "Installing systemd script '$OS_DIR_SYSTEMD/mysterium-node.service'..\n" \
+    printf "Installing systemd services for Mysterium Node..\n" \
         && cp -f $OS_DIR_INSTALLATION/mysterium-node.service $OS_DIR_SYSTEMD/mysterium-node.service \
         && cp -f $OS_DIR_INSTALLATION/mysterium-consumer.service $OS_DIR_SYSTEMD/mysterium-consumer.service \
+        && cp -f $OS_DIR_INSTALLATION/myst-updater.service $OS_DIR_SYSTEMD/myst-updater.service \
+        && cp -f $OS_DIR_INSTALLATION/myst-updater.timer $OS_DIR_SYSTEMD/myst-updater.timer \
+        && systemctl daemon-reload \
         && systemctl enable systemd-networkd.service \
         && systemctl enable mysterium-node \
+        && systemctl enable --now myst-updater.timer \
         && systemctl restart mysterium-node
 }
 
@@ -75,6 +79,9 @@ ensure_paths
 # Add defaults file, if it doesn't exist
 if [[ ! -f $DAEMON_DEFAULT ]]; then
     cp $OS_DIR_INSTALLATION/default $DAEMON_DEFAULT
+fi
+if [[ ! -f /etc/default/myst-updater ]]; then
+    cp $OS_DIR_INSTALLATION/myst-updater.default /etc/default/myst-updater
 fi
 
 # TODO remove temporary fix for starting all services instead of wireguard.

--- a/debian/postrm
+++ b/debian/postrm
@@ -14,6 +14,8 @@ fi
 function disable_systemd {
     system_service=/lib/systemd/system/mysterium-node.service
     system_consumer=/lib/systemd/system/mysterium-consumer.service
+    updater_service=/lib/systemd/system/myst-updater.service
+    updater_timer=/lib/systemd/system/myst-updater.timer
     if [ ! -e $system_service ]; then
         return
     fi
@@ -22,7 +24,10 @@ function disable_systemd {
     systemctl disable mysterium-node
     systemctl stop mysterium-consumer
     systemctl disable mysterium-consumer
-    rm -f $system_service $system_consumer
+    systemctl stop myst-updater.timer
+    systemctl disable myst-updater.timer
+    rm -f $system_service $system_consumer $updater_service $updater_timer
+    systemctl daemon-reload
 }
 
 function disable_update_rcd {
@@ -52,11 +57,11 @@ if [[ -f /etc/redhat-release ]]; then
 	    disable_chkconfig
 	fi
     fi
-elif [[ -f /etc/lsb-release ]]; then
+elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     if [[ "$1" != "upgrade" ]]; then
 	# Remove/purge
-	rm -f /etc/default/mysterium-node
+	rm -f /etc/default/mysterium-node /etc/default/myst-updater
 
 	which systemctl &>/dev/null
 	if [[ $? -eq 0 ]]; then

--- a/session/pingpong/consumer_balance_tracker.go
+++ b/session/pingpong/consumer_balance_tracker.go
@@ -247,20 +247,25 @@ func (cbt *ConsumerBalanceTracker) publishChangeEvent(id identity.Identity, befo
 }
 
 func (cbt *ConsumerBalanceTracker) handleUnlockEvent(data identity.AppEventIdentityUnlock) {
-	err := cbt.recoverGrandTotalPromised(data.ChainID, data.ID)
-	if err != nil {
-		log.Error().Err(err).Msg("Could not recover Grand Total Promised")
-	}
-
 	status, err := cbt.registry.GetRegistrationStatus(data.ChainID, data.ID)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not recover get registration status")
 	}
 
-	switch status {
-	case registry.InProgress:
+	// ConsumerTotalsStorage.Store publishes GrandTotalChanged asynchronously.
+	// Establish the transactor bounty first so that event cannot race with this
+	// initialization and replace the in-progress balance with an unregistered
+	// blockchain balance.
+	if status == registry.InProgress {
 		cbt.alignWithTransactor(data.ChainID, data.ID)
-	default:
+	}
+
+	err = cbt.recoverGrandTotalPromised(data.ChainID, data.ID)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not recover Grand Total Promised")
+	}
+
+	if status != registry.InProgress {
 		cbt.ForceBalanceUpdate(data.ChainID, data.ID)
 	}
 

--- a/updater/deb/config.go
+++ b/updater/deb/config.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	PackageName            = "myst"
-	RepositoryOrigin       = "LP-PPA-mysteriumnetwork-node"
+	packageName            = "myst"
+	repositoryOrigin       = "LP-PPA-mysteriumnetwork-node"
 	defaultHealthcheckURL  = "http://127.0.0.1:4050/healthcheck"
 	defaultCommandTimeout  = 20 * time.Minute
 	defaultHealthTimeout   = 2 * time.Minute

--- a/updater/deb/config.go
+++ b/updater/deb/config.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+// Package deb implements the unattended updater for Debian packages.
+package deb
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	PackageName            = "myst"
+	RepositoryOrigin       = "LP-PPA-mysteriumnetwork-node"
+	defaultHealthcheckURL  = "http://127.0.0.1:4050/healthcheck"
+	defaultCommandTimeout  = 20 * time.Minute
+	defaultHealthTimeout   = 2 * time.Minute
+	defaultHealthInterval  = 3 * time.Second
+	maxHealthResponseBytes = 64 * 1024
+)
+
+// Config controls updater behavior. Repository identity and package name are
+// deliberately not configurable: accepting those values from the environment
+// would turn a configuration write into root code execution.
+type Config struct {
+	Enabled        bool
+	CheckOnly      bool
+	HealthcheckURL string
+	CommandTimeout time.Duration
+	HealthTimeout  time.Duration
+	HealthInterval time.Duration
+}
+
+// ConfigFromEnvironment reads the small set of operator-tunable settings.
+func ConfigFromEnvironment(checkOnly bool) (Config, error) {
+	enabled, err := envBool("MYST_UPDATER_ENABLED", true)
+	if err != nil {
+		return Config{}, err
+	}
+
+	config := Config{
+		Enabled:        enabled,
+		CheckOnly:      checkOnly,
+		HealthcheckURL: envString("MYST_UPDATER_HEALTHCHECK_URL", defaultHealthcheckURL),
+		CommandTimeout: defaultCommandTimeout,
+		HealthTimeout:  defaultHealthTimeout,
+		HealthInterval: defaultHealthInterval,
+	}
+	if config.CommandTimeout, err = envDuration("MYST_UPDATER_COMMAND_TIMEOUT", config.CommandTimeout); err != nil {
+		return Config{}, err
+	}
+	if config.HealthTimeout, err = envDuration("MYST_UPDATER_HEALTHCHECK_TIMEOUT", config.HealthTimeout); err != nil {
+		return Config{}, err
+	}
+
+	healthURL, err := url.Parse(config.HealthcheckURL)
+	if err != nil || healthURL.Scheme != "http" || healthURL.Hostname() != "127.0.0.1" {
+		return Config{}, fmt.Errorf("MYST_UPDATER_HEALTHCHECK_URL must be an http URL on 127.0.0.1")
+	}
+	return config, nil
+}
+
+func envString(name, fallback string) string {
+	if value, ok := os.LookupEnv(name); ok {
+		return value
+	}
+	return fallback
+}
+
+func envBool(name string, fallback bool) (bool, error) {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return fallback, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	return parsed, nil
+}
+
+func envDuration(name string, fallback time.Duration) (time.Duration, error) {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return fallback, nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil || parsed <= 0 {
+		return 0, fmt.Errorf("invalid %s duration %q", name, value)
+	}
+	return parsed, nil
+}

--- a/updater/deb/config_test.go
+++ b/updater/deb/config_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package deb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFromEnvironment(t *testing.T) {
+	t.Setenv("MYST_UPDATER_ENABLED", "false")
+	t.Setenv("MYST_UPDATER_COMMAND_TIMEOUT", "10m")
+	t.Setenv("MYST_UPDATER_HEALTHCHECK_TIMEOUT", "45s")
+
+	config, err := ConfigFromEnvironment(true)
+	require.NoError(t, err)
+	assert.False(t, config.Enabled)
+	assert.True(t, config.CheckOnly)
+	assert.Equal(t, 10*time.Minute, config.CommandTimeout)
+	assert.Equal(t, 45*time.Second, config.HealthTimeout)
+}
+
+func TestConfigRejectsRemoteHealthcheck(t *testing.T) {
+	t.Setenv("MYST_UPDATER_HEALTHCHECK_URL", "https://example.com/healthcheck")
+	_, err := ConfigFromEnvironment(false)
+	assert.Error(t, err)
+}

--- a/updater/deb/parse.go
+++ b/updater/deb/parse.go
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2026 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package deb
+
+import (
+	"bufio"
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	debianVersionPattern = regexp.MustCompile(`^[0-9A-Za-z.+:~_-]{1,255}$`)
+	sha256Pattern        = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+)
+
+type packageMetadata struct {
+	Package      string
+	Version      string
+	Architecture string
+	Filename     string
+	SHA256       string
+}
+
+func parseCandidate(policy string) (string, error) {
+	for _, line := range strings.Split(policy, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Candidate:") {
+			continue
+		}
+		candidate := strings.TrimSpace(strings.TrimPrefix(line, "Candidate:"))
+		if candidate == "" || candidate == "(none)" {
+			return "", fmt.Errorf("APT has no candidate for package %s", PackageName)
+		}
+		if !debianVersionPattern.MatchString(candidate) {
+			return "", fmt.Errorf("APT returned invalid candidate version %q", candidate)
+		}
+		return candidate, nil
+	}
+	return "", fmt.Errorf("APT policy did not contain a candidate")
+}
+
+func validateCandidateSource(policy, candidate string) error {
+	inCandidate := false
+	for _, rawLine := range strings.Split(policy, "\n") {
+		line := strings.TrimSpace(rawLine)
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "***" {
+			fields = fields[1:]
+		}
+		if len(fields) >= 2 {
+			if _, err := strconv.Atoi(fields[1]); err == nil && debianVersionPattern.MatchString(fields[0]) {
+				inCandidate = fields[0] == candidate
+				continue
+			}
+		}
+		if !inCandidate || len(fields) < 2 {
+			continue
+		}
+		if _, err := strconv.Atoi(fields[0]); err != nil {
+			continue
+		}
+		if isAllowedRepositoryURL(fields[1]) {
+			return nil
+		}
+	}
+	return fmt.Errorf("candidate %s is not supplied by the Mysterium node PPA", candidate)
+}
+
+func validateRepositoryPolicy(policy string) error {
+	lines := strings.Split(policy, "\n")
+	for index, rawLine := range lines {
+		fields := strings.Fields(strings.TrimSpace(rawLine))
+		if len(fields) < 2 || !isAllowedRepositoryURL(fields[1]) {
+			continue
+		}
+		end := index + 4
+		if end > len(lines) {
+			end = len(lines)
+		}
+		for _, detail := range lines[index+1 : end] {
+			if strings.Contains(detail, "o="+RepositoryOrigin) {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("authenticated APT metadata for origin %s was not found", RepositoryOrigin)
+}
+
+func parsePackageMetadata(output, candidate, architecture string) (packageMetadata, error) {
+	for _, stanza := range splitParagraphs(output) {
+		values := make(map[string]string)
+		scanner := bufio.NewScanner(strings.NewReader(stanza))
+		for scanner.Scan() {
+			key, value, ok := strings.Cut(scanner.Text(), ":")
+			if ok {
+				values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+			}
+		}
+		if values["Package"] != PackageName || values["Version"] != candidate {
+			continue
+		}
+		metadata := packageMetadata{
+			Package:      values["Package"],
+			Version:      values["Version"],
+			Architecture: values["Architecture"],
+			Filename:     values["Filename"],
+			SHA256:       strings.ToLower(values["SHA256"]),
+		}
+		if metadata.Architecture != architecture && metadata.Architecture != "all" {
+			return packageMetadata{}, fmt.Errorf("candidate architecture %q does not match host %q", metadata.Architecture, architecture)
+		}
+		if !validPackageFilename(metadata.Filename) {
+			return packageMetadata{}, fmt.Errorf("candidate has unsafe package filename %q", metadata.Filename)
+		}
+		if !sha256Pattern.MatchString(metadata.SHA256) {
+			return packageMetadata{}, fmt.Errorf("candidate has invalid SHA256 %q", metadata.SHA256)
+		}
+		return metadata, nil
+	}
+	return packageMetadata{}, fmt.Errorf("APT metadata for exact candidate %s was not found", candidate)
+}
+
+func validateDownloadURI(output string, metadata packageMetadata) error {
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		rawURI := strings.Trim(fields[0], "'")
+		if !isAllowedRepositoryURL(rawURI) {
+			continue
+		}
+		uri, err := url.Parse(rawURI)
+		if err != nil {
+			continue
+		}
+		uriPath, err := url.PathUnescape(uri.Path)
+		if err != nil || !strings.HasSuffix(uriPath, "/"+metadata.Filename) {
+			continue
+		}
+		if !strings.EqualFold(fields[len(fields)-1], "SHA256:"+metadata.SHA256) {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("APT did not resolve candidate %s to its authenticated PPA artifact", metadata.Version)
+}
+
+func isAllowedRepositoryURL(rawURL string) bool {
+	uri, err := url.Parse(rawURL)
+	if err != nil || uri.Scheme != "https" || uri.User != nil || uri.RawQuery != "" || uri.Fragment != "" {
+		return false
+	}
+	basePath := "/mysteriumnetwork/node/ubuntu"
+	return (uri.Host == "ppa.launchpadcontent.net" || uri.Host == "ppa.mysterium.network") &&
+		(uri.Path == basePath || strings.HasPrefix(uri.Path, basePath+"/"))
+}
+
+func validPackageFilename(filename string) bool {
+	return filename != "" &&
+		!strings.HasPrefix(filename, "/") &&
+		path.Clean(filename) == filename &&
+		strings.HasPrefix(filename, "pool/") &&
+		strings.HasSuffix(filename, ".deb")
+}
+
+func splitParagraphs(value string) []string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	return strings.Split(value, "\n\n")
+}

--- a/updater/deb/parse.go
+++ b/updater/deb/parse.go
@@ -40,7 +40,7 @@ func parseCandidate(policy string) (string, error) {
 		}
 		candidate := strings.TrimSpace(strings.TrimPrefix(line, "Candidate:"))
 		if candidate == "" || candidate == "(none)" {
-			return "", fmt.Errorf("APT has no candidate for package %s", PackageName)
+			return "", fmt.Errorf("APT has no candidate for package %s", packageName)
 		}
 		if !debianVersionPattern.MatchString(candidate) {
 			return "", fmt.Errorf("APT returned invalid candidate version %q", candidate)
@@ -89,12 +89,12 @@ func validateRepositoryPolicy(policy string) error {
 			end = len(lines)
 		}
 		for _, detail := range lines[index+1 : end] {
-			if strings.Contains(detail, "o="+RepositoryOrigin) {
+			if strings.Contains(detail, "o="+repositoryOrigin) {
 				return nil
 			}
 		}
 	}
-	return fmt.Errorf("authenticated APT metadata for origin %s was not found", RepositoryOrigin)
+	return fmt.Errorf("authenticated APT metadata for origin %s was not found", repositoryOrigin)
 }
 
 func parsePackageMetadata(output, candidate, architecture string) (packageMetadata, error) {
@@ -107,7 +107,7 @@ func parsePackageMetadata(output, candidate, architecture string) (packageMetada
 				values[strings.TrimSpace(key)] = strings.TrimSpace(value)
 			}
 		}
-		if values["Package"] != PackageName || values["Version"] != candidate {
+		if values["Package"] != packageName || values["Version"] != candidate {
 			continue
 		}
 		metadata := packageMetadata{

--- a/updater/deb/parse_test.go
+++ b/updater/deb/parse_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package deb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestParseAndValidateCandidate(t *testing.T) {
+	policy := `myst:
+  Installed: 1.36.4+build1+jammy
+  Candidate: 1.36.5+build2+jammy
+  Version table:
+     1.36.5+build2+jammy 500
+        500 https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu jammy/main amd64 Packages
+ *** 1.36.4+build1+jammy 100
+        100 /var/lib/dpkg/status
+`
+	candidate, err := parseCandidate(policy)
+	require.NoError(t, err)
+	assert.Equal(t, "1.36.5+build2+jammy", candidate)
+	assert.NoError(t, validateCandidateSource(policy, candidate))
+}
+
+func TestCandidateRejectsAnotherRepository(t *testing.T) {
+	policy := `myst:
+  Installed: 1.36.4
+  Candidate: 9.9.9
+  Version table:
+     9.9.9 1000
+       1000 https://packages.example.test/ubuntu jammy/main amd64 Packages
+`
+	candidate, err := parseCandidate(policy)
+	require.NoError(t, err)
+	assert.Error(t, validateCandidateSource(policy, candidate))
+}
+
+func TestValidateRepositoryPolicy(t *testing.T) {
+	policy := `Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 https://ppa.mysterium.network/mysteriumnetwork/node/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=LP-PPA-mysteriumnetwork-node,a=jammy,n=jammy,l=Mysterium Node,c=main,b=amd64
+     origin ppa.mysterium.network
+`
+	assert.NoError(t, validateRepositoryPolicy(policy))
+	assert.Error(t, validateRepositoryPolicy(strings.Replace(policy, RepositoryOrigin, "spoofed-origin", 1)))
+}
+
+func TestParsePackageMetadata(t *testing.T) {
+	output := `Package: myst
+Architecture: amd64
+Version: 1.36.5+build2+jammy
+Filename: pool/main/m/myst/myst_1.36.5+build2+jammy_amd64.deb
+SHA256: ` + testSHA256 + `
+Description: Mysterium Node
+`
+	metadata, err := parsePackageMetadata(output, "1.36.5+build2+jammy", "amd64")
+	require.NoError(t, err)
+	assert.Equal(t, PackageName, metadata.Package)
+	assert.Equal(t, testSHA256, metadata.SHA256)
+}
+
+func TestPackageMetadataRejectsUnsafeValues(t *testing.T) {
+	base := `Package: myst
+Architecture: amd64
+Version: 1.36.5+build2+jammy
+Filename: %s
+SHA256: ` + testSHA256 + "\n"
+	for _, filename := range []string{
+		"/tmp/myst.deb",
+		"pool/main/m/myst/../../../../tmp/myst.deb",
+		"pool/main/m/myst/myst.tar.gz",
+	} {
+		_, err := parsePackageMetadata(strings.Replace(base, "%s", filename, 1), "1.36.5+build2+jammy", "amd64")
+		assert.Error(t, err, filename)
+	}
+}
+
+func TestValidateDownloadURI(t *testing.T) {
+	metadata := packageMetadata{
+		Version:  "1.36.5+build2+jammy",
+		Filename: "pool/main/m/myst/myst_1.36.5+build2+jammy_amd64.deb",
+		SHA256:   testSHA256,
+	}
+	output := `'https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu/pool/main/m/myst/myst_1.36.5%2bbuild2%2bjammy_amd64.deb' myst.deb 1234 SHA256:` + testSHA256
+	assert.NoError(t, validateDownloadURI(output, metadata))
+	assert.Error(t, validateDownloadURI(strings.Replace(output, testSHA256, strings.Repeat("f", 64), 1), metadata))
+	assert.Error(t, validateDownloadURI(strings.Replace(output, "ppa.launchpadcontent.net", "evil.example", 1), metadata))
+}
+
+func TestAllowedRepositoryURL(t *testing.T) {
+	for _, allowed := range []string{
+		"https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu/dists/jammy/main/binary-amd64/Packages",
+		"https://ppa.mysterium.network/mysteriumnetwork/node/ubuntu/pool/main/m/myst/myst.deb",
+	} {
+		assert.True(t, isAllowedRepositoryURL(allowed), allowed)
+	}
+	for _, rejected := range []string{
+		"http://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu/pool/myst.deb",
+		"https://ppa.launchpadcontent.net/another/node/ubuntu/pool/myst.deb",
+		"https://ppa.launchpadcontent.net.evil.example/mysteriumnetwork/node/ubuntu/pool/myst.deb",
+		"https://user@ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu/pool/myst.deb",
+	} {
+		assert.False(t, isAllowedRepositoryURL(rejected), rejected)
+	}
+}

--- a/updater/deb/parse_test.go
+++ b/updater/deb/parse_test.go
@@ -57,7 +57,7 @@ func TestValidateRepositoryPolicy(t *testing.T) {
      origin ppa.mysterium.network
 `
 	assert.NoError(t, validateRepositoryPolicy(policy))
-	assert.Error(t, validateRepositoryPolicy(strings.Replace(policy, RepositoryOrigin, "spoofed-origin", 1)))
+	assert.Error(t, validateRepositoryPolicy(strings.Replace(policy, repositoryOrigin, "spoofed-origin", 1)))
 }
 
 func TestParsePackageMetadata(t *testing.T) {
@@ -70,7 +70,7 @@ Description: Mysterium Node
 `
 	metadata, err := parsePackageMetadata(output, "1.36.5+build2+jammy", "amd64")
 	require.NoError(t, err)
-	assert.Equal(t, PackageName, metadata.Package)
+	assert.Equal(t, packageName, metadata.Package)
 	assert.Equal(t, testSHA256, metadata.SHA256)
 }
 

--- a/updater/deb/updater.go
+++ b/updater/deb/updater.go
@@ -107,7 +107,7 @@ func (updater *Updater) Run(ctx context.Context) error {
 		return err
 	}
 
-	packagePolicy, err := updater.runner.Output(commandContext, "apt-cache", "policy", PackageName)
+	packagePolicy, err := updater.runner.Output(commandContext, "apt-cache", "policy", packageName)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (updater *Updater) Run(ctx context.Context) error {
 		return err
 	}
 	if candidate == installed {
-		log.Printf("%s is current at version %s", PackageName, installed)
+		log.Printf("%s is current at version %s", packageName, installed)
 		return nil
 	}
 
@@ -141,7 +141,7 @@ func (updater *Updater) Run(ctx context.Context) error {
 		return err
 	}
 	if held {
-		log.Printf("%s is held; leaving version %s installed", PackageName, installed)
+		log.Printf("%s is held; leaving version %s installed", packageName, installed)
 		return nil
 	}
 
@@ -150,7 +150,7 @@ func (updater *Updater) Run(ctx context.Context) error {
 		return err
 	}
 	architecture = strings.TrimSpace(architecture)
-	metadataOutput, err := updater.runner.Output(commandContext, "apt-cache", "show", "--no-all-versions", PackageName+"="+candidate)
+	metadataOutput, err := updater.runner.Output(commandContext, "apt-cache", "show", "--no-all-versions", packageName+"="+candidate)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (updater *Updater) Run(ctx context.Context) error {
 	uriArguments := append([]string{}, aptSecurityOptions...)
 	// apt-get historically defaults --print-uris to MD5 for compatibility.
 	// Force the same strong hash that we validated in the signed Packages index.
-	uriArguments = append(uriArguments, "-o", "Acquire::ForceHash=sha256", "--print-uris", "download", PackageName+"="+candidate)
+	uriArguments = append(uriArguments, "-o", "Acquire::ForceHash=sha256", "--print-uris", "download", packageName+"="+candidate)
 	uriOutput, err := updater.runner.Output(commandContext, "apt-get", uriArguments...)
 	if err != nil {
 		return err
@@ -178,7 +178,7 @@ func (updater *Updater) Run(ctx context.Context) error {
 
 	wasActive := updater.serviceIsActive(commandContext)
 	log.Printf("installing authenticated update %s -> %s", installed, candidate)
-	if err := updater.aptGet(commandContext, "install", "--yes", "--only-upgrade", "--no-remove", PackageName+"="+candidate); err != nil {
+	if err := updater.aptGet(commandContext, "install", "--yes", "--only-upgrade", "--no-remove", packageName+"="+candidate); err != nil {
 		return fmt.Errorf("could not install %s: %w", candidate, err)
 	}
 
@@ -194,7 +194,7 @@ func (updater *Updater) Run(ctx context.Context) error {
 			return err
 		}
 	}
-	log.Printf("successfully updated %s to %s", PackageName, candidate)
+	log.Printf("successfully updated %s to %s", packageName, candidate)
 	return nil
 }
 
@@ -205,9 +205,9 @@ func (updater *Updater) aptGet(ctx context.Context, arguments ...string) error {
 }
 
 func (updater *Updater) installedVersion(ctx context.Context) (string, error) {
-	version, err := updater.runner.Output(ctx, "dpkg-query", "--show", "--showformat=${Version}", PackageName)
+	version, err := updater.runner.Output(ctx, "dpkg-query", "--show", "--showformat=${Version}", packageName)
 	if err != nil {
-		return "", fmt.Errorf("could not determine installed %s version: %w", PackageName, err)
+		return "", fmt.Errorf("could not determine installed %s version: %w", packageName, err)
 	}
 	version = strings.TrimSpace(version)
 	if !debianVersionPattern.MatchString(version) {
@@ -233,7 +233,7 @@ func (updater *Updater) packageIsHeld(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	for _, heldPackage := range strings.Fields(heldPackages) {
-		if heldPackage == PackageName {
+		if heldPackage == packageName {
 			return true, nil
 		}
 	}

--- a/updater/deb/updater.go
+++ b/updater/deb/updater.go
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2026 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package deb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type commandRunner interface {
+	Output(ctx context.Context, name string, args ...string) (string, error)
+	Run(ctx context.Context, name string, args ...string) error
+}
+
+type systemRunner struct{}
+
+func (systemRunner) Output(ctx context.Context, name string, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Env = secureEnvironment()
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s failed: %w: %s", name, err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func (systemRunner) Run(ctx context.Context, name string, args ...string) error {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Env = secureEnvironment()
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("%s failed: %w", name, err)
+	}
+	return nil
+}
+
+func secureEnvironment() []string {
+	return []string{
+		"PATH=/usr/sbin:/usr/bin:/sbin:/bin",
+		"LC_ALL=C",
+		"LANG=C",
+		"DEBIAN_FRONTEND=noninteractive",
+	}
+}
+
+// Updater validates and installs a newer myst package through APT.
+type Updater struct {
+	config Config
+	runner commandRunner
+	client *http.Client
+}
+
+// New constructs a production updater.
+func New(config Config) *Updater {
+	return &Updater{
+		config: config,
+		runner: systemRunner{},
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+var aptSecurityOptions = []string{
+	"-o", "Acquire::AllowInsecureRepositories=false",
+	"-o", "Acquire::AllowDowngradeToInsecureRepositories=false",
+	"-o", "Acquire::Check-Valid-Until=true",
+	"-o", "Acquire::https::Verify-Peer=true",
+	"-o", "Acquire::https::Verify-Host=true",
+	"-o", "APT::Get::AllowUnauthenticated=false",
+	"-o", "DPkg::Lock::Timeout=300",
+}
+
+// Run performs a single update check and, when eligible, installs the update.
+func (updater *Updater) Run(ctx context.Context) error {
+	if !updater.config.Enabled {
+		log.Print("automatic updates are disabled")
+		return nil
+	}
+
+	commandContext, cancel := context.WithTimeout(ctx, updater.config.CommandTimeout)
+	defer cancel()
+
+	if err := updater.aptGet(commandContext, "update"); err != nil {
+		return fmt.Errorf("could not refresh authenticated APT metadata: %w", err)
+	}
+
+	repositoryPolicy, err := updater.runner.Output(commandContext, "apt-cache", "policy")
+	if err != nil {
+		return err
+	}
+	if err := validateRepositoryPolicy(repositoryPolicy); err != nil {
+		return err
+	}
+
+	packagePolicy, err := updater.runner.Output(commandContext, "apt-cache", "policy", PackageName)
+	if err != nil {
+		return err
+	}
+	candidate, err := parseCandidate(packagePolicy)
+	if err != nil {
+		return err
+	}
+	if err := validateCandidateSource(packagePolicy, candidate); err != nil {
+		return err
+	}
+
+	installed, err := updater.installedVersion(commandContext)
+	if err != nil {
+		return err
+	}
+	if candidate == installed {
+		log.Printf("%s is current at version %s", PackageName, installed)
+		return nil
+	}
+
+	newer, err := updater.versionIsGreater(commandContext, candidate, installed)
+	if err != nil {
+		return err
+	}
+	if !newer {
+		log.Printf("refusing downgrade from %s to %s", installed, candidate)
+		return nil
+	}
+	held, err := updater.packageIsHeld(commandContext)
+	if err != nil {
+		return err
+	}
+	if held {
+		log.Printf("%s is held; leaving version %s installed", PackageName, installed)
+		return nil
+	}
+
+	architecture, err := updater.runner.Output(commandContext, "dpkg", "--print-architecture")
+	if err != nil {
+		return err
+	}
+	architecture = strings.TrimSpace(architecture)
+	metadataOutput, err := updater.runner.Output(commandContext, "apt-cache", "show", "--no-all-versions", PackageName+"="+candidate)
+	if err != nil {
+		return err
+	}
+	metadata, err := parsePackageMetadata(metadataOutput, candidate, architecture)
+	if err != nil {
+		return err
+	}
+
+	uriArguments := append([]string{}, aptSecurityOptions...)
+	// apt-get historically defaults --print-uris to MD5 for compatibility.
+	// Force the same strong hash that we validated in the signed Packages index.
+	uriArguments = append(uriArguments, "-o", "Acquire::ForceHash=sha256", "--print-uris", "download", PackageName+"="+candidate)
+	uriOutput, err := updater.runner.Output(commandContext, "apt-get", uriArguments...)
+	if err != nil {
+		return err
+	}
+	if err := validateDownloadURI(uriOutput, metadata); err != nil {
+		return err
+	}
+
+	if updater.config.CheckOnly {
+		log.Printf("validated update %s -> %s (check-only)", installed, candidate)
+		return nil
+	}
+
+	wasActive := updater.serviceIsActive(commandContext)
+	log.Printf("installing authenticated update %s -> %s", installed, candidate)
+	if err := updater.aptGet(commandContext, "install", "--yes", "--only-upgrade", "--no-remove", PackageName+"="+candidate); err != nil {
+		return fmt.Errorf("could not install %s: %w", candidate, err)
+	}
+
+	installedAfter, err := updater.installedVersion(commandContext)
+	if err != nil {
+		return err
+	}
+	if installedAfter != candidate {
+		return fmt.Errorf("installed version %s does not equal validated candidate %s", installedAfter, candidate)
+	}
+	if wasActive {
+		if err := updater.waitForHealth(ctx, candidate); err != nil {
+			return err
+		}
+	}
+	log.Printf("successfully updated %s to %s", PackageName, candidate)
+	return nil
+}
+
+func (updater *Updater) aptGet(ctx context.Context, arguments ...string) error {
+	args := append([]string{}, aptSecurityOptions...)
+	args = append(args, arguments...)
+	return updater.runner.Run(ctx, "apt-get", args...)
+}
+
+func (updater *Updater) installedVersion(ctx context.Context) (string, error) {
+	version, err := updater.runner.Output(ctx, "dpkg-query", "--show", "--showformat=${Version}", PackageName)
+	if err != nil {
+		return "", fmt.Errorf("could not determine installed %s version: %w", PackageName, err)
+	}
+	version = strings.TrimSpace(version)
+	if !debianVersionPattern.MatchString(version) {
+		return "", fmt.Errorf("dpkg returned invalid installed version %q", version)
+	}
+	return version, nil
+}
+
+func (updater *Updater) versionIsGreater(ctx context.Context, candidate, installed string) (bool, error) {
+	err := updater.runner.Run(ctx, "dpkg", "--compare-versions", candidate, "gt", installed)
+	if err == nil {
+		return true, nil
+	}
+	if updater.runner.Run(ctx, "dpkg", "--compare-versions", candidate, "le", installed) == nil {
+		return false, nil
+	}
+	return false, fmt.Errorf("could not compare Debian versions %q and %q", candidate, installed)
+}
+
+func (updater *Updater) packageIsHeld(ctx context.Context) (bool, error) {
+	heldPackages, err := updater.runner.Output(ctx, "apt-mark", "showhold")
+	if err != nil {
+		return false, err
+	}
+	for _, heldPackage := range strings.Fields(heldPackages) {
+		if heldPackage == PackageName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (updater *Updater) serviceIsActive(ctx context.Context) bool {
+	return updater.runner.Run(ctx, "systemctl", "is-active", "--quiet", "mysterium-node.service") == nil
+}
+
+func (updater *Updater) waitForHealth(ctx context.Context, candidate string) error {
+	healthContext, cancel := context.WithTimeout(ctx, updater.config.HealthTimeout)
+	defer cancel()
+	expectedVersion := strings.SplitN(candidate, "+", 2)[0]
+	expectedVersion = strings.Replace(expectedVersion, "~rc", "-rc", 1)
+
+	ticker := time.NewTicker(updater.config.HealthInterval)
+	defer ticker.Stop()
+	for {
+		if err := updater.checkHealth(healthContext, expectedVersion); err == nil {
+			return nil
+		}
+		select {
+		case <-healthContext.Done():
+			return fmt.Errorf("mysterium-node did not become healthy at version %s within %s", expectedVersion, updater.config.HealthTimeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (updater *Updater) checkHealth(ctx context.Context, expectedVersion string) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, updater.config.HealthcheckURL, nil)
+	if err != nil {
+		return err
+	}
+	response, err := updater.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("healthcheck returned %s", response.Status)
+	}
+	var health struct {
+		Version string `json:"version"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(response.Body, maxHealthResponseBytes))
+	if err := decoder.Decode(&health); err != nil {
+		return fmt.Errorf("invalid healthcheck response: %w", err)
+	}
+	if health.Version != expectedVersion {
+		return fmt.Errorf("healthcheck reports version %q, expected %q", health.Version, expectedVersion)
+	}
+	return nil
+}

--- a/updater/deb/updater_test.go
+++ b/updater/deb/updater_test.go
@@ -40,13 +40,13 @@ func (runner *fakeRunner) Output(_ context.Context, name string, args ...string)
 	joined := strings.Join(args, " ")
 	switch {
 	case name == "apt-cache" && joined == "policy":
-		origin := RepositoryOrigin
+		origin := repositoryOrigin
 		if !runner.trusted {
 			origin = "untrusted-origin"
 		}
 		return "Package files:\n 500 https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu jammy/main amd64 Packages\n     release o=" + origin + ",a=jammy,n=jammy,c=main,b=amd64\n", nil
-	case name == "apt-cache" && joined == "policy "+PackageName:
-		return fmt.Sprintf("%s:\n  Installed: %s\n  Candidate: %s\n  Version table:\n     %s 500\n        500 https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu jammy/main amd64 Packages\n *** %s 100\n        100 /var/lib/dpkg/status\n", PackageName, runner.installed, runner.candidate, runner.candidate, runner.installed), nil
+	case name == "apt-cache" && joined == "policy "+packageName:
+		return fmt.Sprintf("%s:\n  Installed: %s\n  Candidate: %s\n  Version table:\n     %s 500\n        500 https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu jammy/main amd64 Packages\n *** %s 100\n        100 /var/lib/dpkg/status\n", packageName, runner.installed, runner.candidate, runner.candidate, runner.installed), nil
 	case name == "dpkg-query":
 		if runner.installedCandidate {
 			return runner.candidate, nil
@@ -54,13 +54,13 @@ func (runner *fakeRunner) Output(_ context.Context, name string, args ...string)
 		return runner.installed, nil
 	case name == "apt-mark":
 		if runner.held {
-			return PackageName + "\n", nil
+			return packageName + "\n", nil
 		}
 		return "", nil
 	case name == "dpkg" && joined == "--print-architecture":
 		return "amd64\n", nil
 	case name == "apt-cache" && strings.HasPrefix(joined, "show --no-all-versions"):
-		return fmt.Sprintf("Package: %s\nArchitecture: amd64\nVersion: %s\nFilename: pool/main/m/myst/myst_%s_amd64.deb\nSHA256: %s\n", PackageName, runner.candidate, runner.candidate, testSHA256), nil
+		return fmt.Sprintf("Package: %s\nArchitecture: amd64\nVersion: %s\nFilename: pool/main/m/myst/myst_%s_amd64.deb\nSHA256: %s\n", packageName, runner.candidate, runner.candidate, testSHA256), nil
 	case name == "apt-get" && strings.Contains(joined, "Acquire::ForceHash=sha256 --print-uris download"):
 		return fmt.Sprintf("'https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu/pool/main/m/myst/myst_%s_amd64.deb' myst.deb 123 SHA256:%s\n", runner.candidate, testSHA256), nil
 	default:
@@ -118,7 +118,7 @@ func TestUpdaterRejectsUnexpectedRepositoryOrigin(t *testing.T) {
 	updater := testUpdater(runner)
 	err := updater.Run(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), RepositoryOrigin)
+	assert.Contains(t, err.Error(), repositoryOrigin)
 	assert.False(t, runner.installedCandidate)
 }
 

--- a/updater/deb/updater_test.go
+++ b/updater/deb/updater_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 The "MysteriumNetwork/node" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package deb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRunner struct {
+	installed          string
+	candidate          string
+	held               bool
+	trusted            bool
+	installedCandidate bool
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func (runner *fakeRunner) Output(_ context.Context, name string, args ...string) (string, error) {
+	joined := strings.Join(args, " ")
+	switch {
+	case name == "apt-cache" && joined == "policy":
+		origin := RepositoryOrigin
+		if !runner.trusted {
+			origin = "untrusted-origin"
+		}
+		return "Package files:\n 500 https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu jammy/main amd64 Packages\n     release o=" + origin + ",a=jammy,n=jammy,c=main,b=amd64\n", nil
+	case name == "apt-cache" && joined == "policy "+PackageName:
+		return fmt.Sprintf("%s:\n  Installed: %s\n  Candidate: %s\n  Version table:\n     %s 500\n        500 https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu jammy/main amd64 Packages\n *** %s 100\n        100 /var/lib/dpkg/status\n", PackageName, runner.installed, runner.candidate, runner.candidate, runner.installed), nil
+	case name == "dpkg-query":
+		if runner.installedCandidate {
+			return runner.candidate, nil
+		}
+		return runner.installed, nil
+	case name == "apt-mark":
+		if runner.held {
+			return PackageName + "\n", nil
+		}
+		return "", nil
+	case name == "dpkg" && joined == "--print-architecture":
+		return "amd64\n", nil
+	case name == "apt-cache" && strings.HasPrefix(joined, "show --no-all-versions"):
+		return fmt.Sprintf("Package: %s\nArchitecture: amd64\nVersion: %s\nFilename: pool/main/m/myst/myst_%s_amd64.deb\nSHA256: %s\n", PackageName, runner.candidate, runner.candidate, testSHA256), nil
+	case name == "apt-get" && strings.Contains(joined, "Acquire::ForceHash=sha256 --print-uris download"):
+		return fmt.Sprintf("'https://ppa.launchpadcontent.net/mysteriumnetwork/node/ubuntu/pool/main/m/myst/myst_%s_amd64.deb' myst.deb 123 SHA256:%s\n", runner.candidate, testSHA256), nil
+	default:
+		return "", fmt.Errorf("unexpected output command: %s %s", name, joined)
+	}
+}
+
+func (runner *fakeRunner) Run(_ context.Context, name string, args ...string) error {
+	joined := strings.Join(args, " ")
+	switch {
+	case name == "apt-get" && strings.HasSuffix(joined, " update"):
+		return nil
+	case name == "dpkg" && len(args) == 4 && args[0] == "--compare-versions":
+		if args[2] == "gt" && runner.candidate != runner.installed {
+			return nil
+		}
+		if args[2] == "le" && runner.candidate == runner.installed {
+			return nil
+		}
+		return fmt.Errorf("comparison is false")
+	case name == "systemctl" && joined == "is-active --quiet mysterium-node.service":
+		return nil
+	case name == "apt-get" && strings.Contains(joined, " install "):
+		runner.installedCandidate = true
+		return nil
+	default:
+		return fmt.Errorf("unexpected run command: %s %s", name, joined)
+	}
+}
+
+func testUpdater(runner *fakeRunner) *Updater {
+	return &Updater{
+		config: Config{
+			Enabled:        true,
+			CheckOnly:      true,
+			HealthcheckURL: defaultHealthcheckURL,
+			CommandTimeout: time.Minute,
+			HealthTimeout:  time.Second,
+			HealthInterval: time.Millisecond,
+		},
+		runner: runner,
+		client: &http.Client{Timeout: time.Second},
+	}
+}
+
+func TestUpdaterValidatesUpdateWithoutInstalling(t *testing.T) {
+	runner := &fakeRunner{installed: "1.36.4+build1+jammy", candidate: "1.36.5+build2+jammy", trusted: true}
+	updater := testUpdater(runner)
+	require.NoError(t, updater.Run(context.Background()))
+	assert.False(t, runner.installedCandidate)
+}
+
+func TestUpdaterRejectsUnexpectedRepositoryOrigin(t *testing.T) {
+	runner := &fakeRunner{installed: "1.36.4+build1+jammy", candidate: "1.36.5+build2+jammy", trusted: false}
+	updater := testUpdater(runner)
+	err := updater.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), RepositoryOrigin)
+	assert.False(t, runner.installedCandidate)
+}
+
+func TestUpdaterRespectsPackageHold(t *testing.T) {
+	runner := &fakeRunner{installed: "1.36.4+build1+jammy", candidate: "1.36.5+build2+jammy", held: true, trusted: true}
+	updater := testUpdater(runner)
+	require.NoError(t, updater.Run(context.Background()))
+	assert.False(t, runner.installedCandidate)
+}
+
+func TestUpdaterInstallsAndChecksExactRunningVersion(t *testing.T) {
+	runner := &fakeRunner{installed: "1.36.4+build1+jammy", candidate: "1.36.5+build2+jammy", trusted: true}
+	updater := testUpdater(runner)
+	updater.config.CheckOnly = false
+	updater.client = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`{"version":"1.36.5"}`)),
+		}, nil
+	})}
+	require.NoError(t, updater.Run(context.Background()))
+	assert.True(t, runner.installedCandidate)
+}


### PR DESCRIPTION
- Introduced `myst-updater` service and timer for automatic updates.
- Created configuration file `myst-updater.default` for environment variables.
- Implemented updater logic in `cmd/myst_updater/main.go` to handle package updates.
- Added necessary systemd service and timer files for managing the updater.
- Updated installation scripts to include new updater service and timer.
- Enhanced package management with validation and health checks for updates.
- Added tests for updater functionality and configuration parsing.