### PR TITLE
Fix runner specification in build-packages.yml workflow

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   setup-env:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest-l
 
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
           go run mage.go -v MakeBucket
 
   build-packages:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest-l
     needs: [setup-env]
 
     strategy:
@@ -123,7 +123,7 @@ jobs:
           sudo -E env "PATH=$PATH" bash -lc 'source env.sh && go run mage.go -v ${{ matrix.platform }}'
 
   build-swagger:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest-l
     needs: [setup-env, build-packages]
 
     steps:
@@ -157,7 +157,7 @@ jobs:
       github.ref_type == 'tag'
 
   cleanup-env:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest-l
     needs: [release]
     if: |
       always() &&


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use larger runner machines for all jobs in the `build-packages.yml` workflow. The main change is switching from `ubuntu-latest-m` (medium) to `ubuntu-latest-l` (large) runners, which should provide more resources for CI jobs.

**CI/CD Infrastructure Updates:**

* Updated the `runs-on` parameter from `ubuntu-latest-m` to `ubuntu-latest-l` for the following jobs in `.github/workflows/build-packages.yml`: `setup-env`, `build-packages`, `build-swagger`, and `cleanup-env`. This ensures all jobs run on larger GitHub-hosted runners, likely improving build performance and reliability. [[1]](diffhunk://#diff-5a99242c5cfc10a7d738e67d46f4ebd0e7cefa3ca65ce566a775006654e1105bL23-R23) [[2]](diffhunk://#diff-5a99242c5cfc10a7d738e67d46f4ebd0e7cefa3ca65ce566a775006654e1105bL84-R84) [[3]](diffhunk://#diff-5a99242c5cfc10a7d738e67d46f4ebd0e7cefa3ca65ce566a775006654e1105bL126-R126) [[4]](diffhunk://#diff-5a99242c5cfc10a7d738e67d46f4ebd0e7cefa3ca65ce566a775006654e1105bL160-R160)Corrected the runner specification from 'ubuntu-latest-m' to 'ubuntu-latest-l' across multiple jobs in the workflow file.